### PR TITLE
fix: handle silent failures in NBD flush:

### DIFF
--- a/nbd/viperblock.go
+++ b/nbd/viperblock.go
@@ -76,6 +76,7 @@ func (p *ViperBlockPlugin) Config(key string, value string) error {
 		return nil
 	} else if key == "secret_key" {
 		secret_key = value
+		return nil
 	} else if key == "host" {
 		host = value
 		return nil
@@ -300,7 +301,9 @@ func (c *ViperBlockConnection) CanFlush() (bool, error) {
 
 func (c *ViperBlockConnection) Flush(flags uint32) error {
 
-	c.vb.Flush()
+	if err := c.vb.Flush(); err != nil {
+		return nbdkit.PluginError{Errmsg: fmt.Sprintf("Could not flush: %v", err)}
+	}
 
 	var err error
 	if c.vb.UseShardedWAL {

--- a/viperblock/v_utils/v_utils.go
+++ b/viperblock/v_utils/v_utils.go
@@ -2,8 +2,10 @@ package v_utils
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"time"
 
@@ -112,14 +114,16 @@ func ImportDiskImage(s3Config *s3.S3Config, vbConfig *viperblock.VB, filename st
 
 	//var walNum uint64
 
-	// First, fetch the state from the remote backend
-	_ = vb.LoadState()
-	// err = vb.LoadState()
-
-	// if err != nil {
-	// 	// Soft error, since volume may be new
-	// 	//return fmt.Errorf("failed to load state: %v", err)
-	// }
+	// First, fetch the state from the remote backend.
+	// New volumes have no state, so ErrInvalidState (block size is 0) is expected.
+	// Other errors (network, auth, corruption) should fail the import.
+	if err := vb.LoadState(); err != nil {
+		if errors.Is(err, viperblock.ErrInvalidState) {
+			slog.Info("No existing volume state, starting fresh import", "error", err)
+		} else {
+			return fmt.Errorf("failed to load state: %w", err)
+		}
+	}
 
 	err = vb.LoadBlockState()
 

--- a/viperblock/viperblock.go
+++ b/viperblock/viperblock.go
@@ -296,6 +296,7 @@ var ErrRequestTooLarge = errors.New("request too large")
 var ErrRequestOutOfRange = errors.New("request out of range")
 var ErrRequestBlockSize = errors.New("request must be a multiple of block size")
 var ErrRequestBufferEmpty = errors.New("request requires a buffer > 0")
+var ErrInvalidState = errors.New("invalid state: block size or object block size is 0")
 
 // getSystemMemory returns the total system memory in bytes
 func getSystemMemory() uint64 {
@@ -1953,21 +1954,23 @@ func (vb *VB) createChunkFile(currentWALNum uint64, chunkIndex uint64, chunkBuff
 func (vb *VB) SaveHotState(filename string) (err error) {
 
 	vb.Writes.mu.RLock()
+	defer vb.Writes.mu.RUnlock()
 
 	// Write the BlocksToObject to a file as a binary file
 	file, err := os.Create(filename)
 	if err != nil {
 		return err
 	}
-	defer file.Close()
+	defer func() {
+		if cerr := file.Close(); cerr != nil && err == nil {
+			err = fmt.Errorf("failed to close hot state file: %w", cerr)
+		}
+	}()
 
 	// Write the BlocksToObject to the file as JSON
 	if err := json.NewEncoder(file).Encode(vb.Writes.Blocks); err != nil {
-		vb.Writes.mu.RUnlock()
 		return fmt.Errorf("failed to encode blocks to JSON: %w", err)
 	}
-
-	defer vb.Writes.mu.RUnlock()
 
 	return nil
 
@@ -2014,7 +2017,11 @@ func (vb *VB) SaveBlockState() (err error) {
 		return err
 	}
 
-	defer file.Close()
+	defer func() {
+		if cerr := file.Close(); cerr != nil && err == nil {
+			err = fmt.Errorf("failed to close block checkpoint file: %w", cerr)
+		}
+	}()
 
 	// Write the file locally
 	if _, err = file.Write(checkpoint); err != nil {
@@ -2432,9 +2439,8 @@ func (vb *VB) LoadState() error {
 	}
 
 	if stateBackend.BlockSize == 0 && state.BlockSize == 0 {
-		errMsg := "invalid state, block size or object block size is 0. Not syncing config"
-		slog.Error(errMsg)
-		return errors.New(errMsg)
+		slog.Error("invalid state, block size or object block size is 0. Not syncing config")
+		return ErrInvalidState
 	}
 
 	// Step 3. Compare the two states, the state with the highest SeqNum is the correct state.


### PR DESCRIPTION
V-1: NBD Flush() — nbd/viperblock.go                                                          
                                                                                                
  When a VM issues a flush (fsync), the NBD plugin calls c.vb.Flush() which writes dirty blocks 
  from memory to the WAL. Previously the return value was discarded:                            
                                                                                                
  // Before   
  c.vb.Flush()                                                                                  
                                                                                                
  // After                                                                                      
  if err := c.vb.Flush(); err != nil {                                                          
      return nbdkit.PluginError{Errmsg: fmt.Sprintf("Could not flush: %v", err)}
  }                                                                                             
              
  Without this, the VM guest OS gets a success response and believes data is durable. If the WAL
   write failed (disk full, I/O error), that data only existed in process memory — a power loss
  or crash loses it silently. Now the error propagates through NBD back to the guest kernel,    
  which can retry or report the I/O error to userspace.
                                               
  Also added the missing return nil on the secret_key config branch — every other branch had it,
   this one fell through to the trailing return nil by accident.
                                                                                                
  V-2: LoadState() in import utility — v_utils/v_utils.go                                       
                                               
  The import utility creates new volumes from disk images. It calls LoadState() to fetch any    
  existing volume state, but new volumes have no state — so the old code just discarded the
  error:                                                                                        
              
  // Before                                    
  _ = vb.LoadState()                                                                            
                                                                                                
  The problem: this also silently swallows network failures, auth errors, and state corruption. 
  If your S3 backend is down during import, the utility happily proceeds with empty state and   
  overwrites whatever was there.                                                                
                                               
  // After                                                                                      
  if err := vb.LoadState(); err != nil {
      if errors.Is(err, viperblock.ErrInvalidState) {                                           
          slog.Info("No existing volume state, starting fresh import", "error", err)
      } else {                                                                                  
          return fmt.Errorf("failed to load state: %w", err)                                    
      }                                                                                         
  }                                                                                             
                                                                                                
  LoadState() returns ErrInvalidState when both local and backend sources have BlockSize == 0 — 
  which is the "no state exists" case for new volumes. That's expected and logged. Any other
  error (which would come from future changes to LoadState) now fails the import.               
              
  To make this robust, I also defined ErrInvalidState as a sentinel error in viperblock.go and  
  updated LoadState() to return it instead of constructing a new errors.New() each time. This
  lets callers use errors.Is() instead of fragile string matching.                              
              
  V-3: Deferred file close on write paths — viperblock/viperblock.go                            
  
  Two functions (SaveHotState, SaveBlockState) create files, write data, then rely on defer     
  file.Close(). On Linux, Close() on a written file can fail — it's the last chance for the
  kernel to report that buffered writes didn't actually make it to disk (e.g., NFS errors, disk 
  full on delayed allocation). A bare defer file.Close() discards that error.
                                               
  // Before
  defer file.Close()                                                                            
  
  // After                                                                                      
  defer func() {
      if cerr := file.Close(); cerr != nil && err == nil {                                      
          err = fmt.Errorf("failed to close block checkpoint file: %w", cerr)                   
      }                                                                                         
  }()                                                                                           
                                                                                                
  The err == nil guard avoids overwriting a more specific error that already happened (e.g., the
   Write() call failed). The named return err in the function signature is what the closure
  captures.                                                                                     
              
  For SaveHotState specifically, the audit also caught a pre-existing deadlock: defer           
  vb.Writes.mu.RUnlock() was registered after os.Create, so if file creation failed, the read
  lock was never released — freezing all future writes to the volume. Fixed by moving the defer 
  immediately after the lock:
                                               
  // Before
  vb.Writes.mu.RLock()
  // ... os.Create could fail and return without unlocking ...                                  
  defer vb.Writes.mu.RUnlock()  // registered too late                                          
                                                                                                
  // After                                                                                      
  vb.Writes.mu.RLock()                                                                          
  defer vb.Writes.mu.RUnlock()  // always runs 