### PR TITLE
fix: route NBD Zero through WriteAt so sub-4K zero ops succeed

### DIFF
--- a/nbd/viperblock.go
+++ b/nbd/viperblock.go
@@ -270,9 +270,13 @@ func (c *ViperBlockConnection) Zero(count uint32, offset uint64, flags uint32) e
 
 	slog.Info("ZERO:", "len", count, "offset", offset)
 
+	if count == 0 {
+		return nil
+	}
+
 	data := make([]byte, count)
 
-	err := c.vb.Write(offset/uint64(c.vb.BlockSize), data)
+	err := c.vb.WriteAt(offset, data)
 
 	if err != nil {
 		return nbdkit.PluginError{Errmsg: fmt.Sprintf("Could not write zero data: %v", err)}


### PR DESCRIPTION
The NBD Zero handler called the strict vb.Write path, which rejects any request whose length is not a multiple of the 4 KiB block size. Guest kernels (ubuntu) legitimately issue sub-4K WriteZeroes during cloud-init (mkswap, resize2fs metadata, discard-mount TRIM), causing viperblock to return "request must be a multiple of block size" and failing VM boot.

Switch to vb.WriteAt, the same RMW-aware path PWrite already uses for arbitrary-alignment writes (originally added for GRUB's 512-byte bootloader writes). Also short-circuit count==0 since WriteAt rejects empty buffers.