### PR TITLE
feat(viperblock): classify LoadState errors for retry vs fail (siv-25 medium-term)

### DIFF
--- a/viperblock/backends/s3/s3.go
+++ b/viperblock/backends/s3/s3.go
@@ -7,19 +7,40 @@ package s3
 import (
 	"bytes"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/mulgadc/viperblock/types"
 	"golang.org/x/net/http2"
 )
+
+// wrapNotFound returns err wrapped with os.ErrNotExist when the AWS error code
+// indicates the requested object is genuinely absent (NoSuchKey, 404 NotFound,
+// NoSuchBucket). Callers can detect "missing" vs "transient" via
+// errors.Is(err, os.ErrNotExist) without taking an AWS SDK dependency.
+func wrapNotFound(err error) error {
+	if err == nil {
+		return nil
+	}
+	var aerr awserr.Error
+	if errors.As(err, &aerr) {
+		switch aerr.Code() {
+		case s3.ErrCodeNoSuchKey, s3.ErrCodeNoSuchBucket, "NotFound", "NoSuchVersion":
+			return fmt.Errorf("%w: %w", os.ErrNotExist, err)
+		}
+	}
+	return err
+}
 
 // 2. Define config structs
 type S3Config struct {
@@ -179,7 +200,7 @@ func (backend *Backend) Read(fileType types.FileType, objectId uint64, offset ui
 	textResult, err := backend.config.S3Client.GetObject(requestObject)
 
 	if err != nil {
-		return nil, err
+		return nil, wrapNotFound(err)
 	}
 	defer textResult.Body.Close()
 
@@ -257,7 +278,7 @@ func (backend *Backend) ReadFrom(volumeName string, fileType types.FileType, obj
 
 	textResult, err := backend.config.S3Client.GetObject(requestObject)
 	if err != nil {
-		return nil, err
+		return nil, wrapNotFound(err)
 	}
 	defer textResult.Body.Close()
 

--- a/viperblock/backends/s3/s3_test.go
+++ b/viperblock/backends/s3/s3_test.go
@@ -1,0 +1,76 @@
+// Copyright 2026 Mulga Defense Corporation (MDC). All rights reserved.
+// Use of this source code is governed by an Apache 2.0 license
+// that can be found in the LICENSE file.
+
+package s3
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	awss3 "github.com/aws/aws-sdk-go/service/s3"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestWrapNotFound pins the AWS-error → os.ErrNotExist mapping that callers
+// (e.g. viperblock.LoadState) rely on to tell "object missing" apart from
+// "backend unreachable". Required by mulga-siv-25 medium-term fix.
+func TestWrapNotFound(t *testing.T) {
+	cases := []struct {
+		name         string
+		in           error
+		wantNotFound bool
+	}{
+		{
+			name:         "nil_passes_through",
+			in:           nil,
+			wantNotFound: false,
+		},
+		{
+			name:         "no_such_key_wraps_not_exist",
+			in:           awserr.New(awss3.ErrCodeNoSuchKey, "key missing", nil),
+			wantNotFound: true,
+		},
+		{
+			name:         "no_such_bucket_wraps_not_exist",
+			in:           awserr.New(awss3.ErrCodeNoSuchBucket, "bucket missing", nil),
+			wantNotFound: true,
+		},
+		{
+			name:         "head_object_404_wraps_not_exist",
+			in:           awserr.New("NotFound", "404", nil),
+			wantNotFound: true,
+		},
+		{
+			name:         "internal_error_stays_transient",
+			in:           awserr.New("InternalError", "5xx", nil),
+			wantNotFound: false,
+		},
+		{
+			name:         "raw_network_error_stays_transient",
+			in:           fmt.Errorf("connection refused"),
+			wantNotFound: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := wrapNotFound(tc.in)
+			if tc.in == nil {
+				assert.NoError(t, got)
+				return
+			}
+			assert.Error(t, got)
+			if tc.wantNotFound {
+				assert.True(t, errors.Is(got, os.ErrNotExist),
+					"want os.ErrNotExist for %v, got %v", tc.in, got)
+			} else {
+				assert.False(t, errors.Is(got, os.ErrNotExist),
+					"unexpected os.ErrNotExist for %v", tc.in)
+			}
+		})
+	}
+}

--- a/viperblock/viperblock.go
+++ b/viperblock/viperblock.go
@@ -317,6 +317,40 @@ var ErrRequestOutOfRange = errors.New("request out of range")
 var ErrRequestBlockSize = errors.New("request must be a multiple of block size")
 var ErrRequestBufferEmpty = errors.New("request requires a buffer > 0")
 
+// ErrStateNotFound is returned by LoadState when both the local file and the
+// backend object are genuinely absent (NoSuchKey/os.ErrNotExist). The volume
+// has no persisted state — caller decides whether that is expected (newly
+// created volume pre-SaveState) or a hard error (recovery of an existing
+// volume).
+var ErrStateNotFound = errors.New("viperblock: state not found")
+
+// ErrStateBackendUnavailable is returned by LoadState when the backend Read
+// failed with a non-not-found error (timeout, network, 5xx). Callers should
+// retry with backoff; the state may become available shortly.
+var ErrStateBackendUnavailable = errors.New("viperblock: state backend unavailable")
+
+// classifyStateLoad maps the local and backend LoadStateRequest errors into a
+// sentinel suitable for callers. The local read is informational — its
+// absence is normal on multi-node deployments and post-restart recovery. The
+// backend error drives the classification: a not-found there means the
+// volume has no persisted state (genuine "new volume"), anything else means
+// the backend is transiently unreachable.
+//
+// Backends signal "object missing" by wrapping os.ErrNotExist (file backend
+// returns os.PathError directly; s3 backend's wrapNotFound translates
+// NoSuchKey/NoSuchBucket/etc.). Any other error is treated as transient.
+func classifyStateLoad(localErr, backendErr error) error {
+	if backendErr != nil && !errors.Is(backendErr, os.ErrNotExist) {
+		return fmt.Errorf("%w: %w", ErrStateBackendUnavailable, backendErr)
+	}
+	localMissing := localErr == nil || errors.Is(localErr, os.ErrNotExist)
+	backendMissing := backendErr == nil || errors.Is(backendErr, os.ErrNotExist)
+	if localMissing && backendMissing {
+		return ErrStateNotFound
+	}
+	return fmt.Errorf("%w: state present but BlockSize=0", ErrStateNotFound)
+}
+
 // getSystemMemory returns the total system memory in bytes
 func getSystemMemory() uint64 {
 	var m runtime.MemStats
@@ -2393,7 +2427,8 @@ func (vb *VB) SaveState() error {
 // Load the block tracking state from disk
 func (vb *VB) LoadState() error {
 	// Step 1. Query the state locally
-	state, localErr := vb.LoadStateRequest(fmt.Sprintf("%s/%s", vb.BaseDir, types.GetFilePath(types.FileTypeConfig, 0, vb.GetVolume())))
+	localPath := fmt.Sprintf("%s/%s", vb.BaseDir, types.GetFilePath(types.FileTypeConfig, 0, vb.GetVolume()))
+	state, localErr := vb.LoadStateRequest(localPath)
 	if localErr != nil {
 		slog.Info("No state found in local file, using backend state", "error", localErr)
 	}
@@ -2402,13 +2437,19 @@ func (vb *VB) LoadState() error {
 	stateBackend, backendErr := vb.LoadStateRequest("")
 
 	if backendErr != nil {
-		slog.Warn("No state found in backend, using local state", "error", backendErr)
+		slog.Warn("Failed to load state from backend", "error", backendErr)
 	}
 
 	if stateBackend.BlockSize == 0 && state.BlockSize == 0 {
-		errMsg := "block size is 0 in both local and backend state, skipping config sync (expected for new volumes)"
-		slog.Debug(errMsg)
-		return errors.New(errMsg)
+		classified := classifyStateLoad(localErr, backendErr)
+		if errors.Is(classified, ErrStateBackendUnavailable) {
+			slog.Warn("LoadState: backend unavailable, retry recommended",
+				"volume", vb.GetVolume(), "err", backendErr)
+		} else {
+			slog.Debug("LoadState: no state in local or backend",
+				"volume", vb.GetVolume())
+		}
+		return classified
 	}
 
 	// Step 3. Compare the two states, the state with the highest SeqNum is the correct state.

--- a/viperblock/viperblock_test.go
+++ b/viperblock/viperblock_test.go
@@ -2380,3 +2380,58 @@ func TestVolumeConfig_ModificationJSONRoundTrip(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotContains(t, string(bareData), "Modification")
 }
+
+// TestClassifyStateLoad pins the local/backend error → sentinel mapping for
+// recovery callers (mulga-siv-25). The classification decides whether the
+// caller should retry (transient backend) or fail (genuine missing state).
+func TestClassifyStateLoad(t *testing.T) {
+	transient := fmt.Errorf("connection refused: tls handshake timeout")
+	notFound := fmt.Errorf("get config.json: %w", os.ErrNotExist)
+
+	cases := []struct {
+		name       string
+		localErr   error
+		backendErr error
+		wantIs     error
+	}{
+		{
+			name:       "both_missing_is_not_found",
+			localErr:   notFound,
+			backendErr: notFound,
+			wantIs:     ErrStateNotFound,
+		},
+		{
+			name:       "backend_transient_is_unavailable",
+			localErr:   notFound,
+			backendErr: transient,
+			wantIs:     ErrStateBackendUnavailable,
+		},
+		{
+			name:       "local_present_backend_missing_is_not_found",
+			localErr:   nil,
+			backendErr: notFound,
+			wantIs:     ErrStateNotFound,
+		},
+		{
+			name:       "local_missing_backend_present_is_not_found",
+			localErr:   notFound,
+			backendErr: nil,
+			wantIs:     ErrStateNotFound,
+		},
+		{
+			name:       "backend_transient_dominates_local_missing",
+			localErr:   nil,
+			backendErr: transient,
+			wantIs:     ErrStateBackendUnavailable,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := classifyStateLoad(tc.localErr, tc.backendErr)
+			require.Error(t, got)
+			assert.ErrorIs(t, got, tc.wantIs,
+				"classifyStateLoad(local=%v, backend=%v) = %v", tc.localErr, tc.backendErr, got)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `ErrStateNotFound` / `ErrStateBackendUnavailable` sentinels so `LoadState` callers can distinguish "state genuinely missing" from "backend transiently unavailable".
- S3 backend wraps `NoSuchKey` / `NoSuchBucket` / `404` / `NoSuchVersion` into `os.ErrNotExist` (file backend already does so via `os.PathError`). Classification is uniform via `errors.Is(err, os.ErrNotExist)`.
- Drops the misleading `"block size is 0 in both local and backend state (expected for new volumes)"` error that previously surfaced on transient backend failures.

Companion PR on spinifex (`feat/siv-25-mount-retry-backoff`) consumes the new sentinels to retry on transient errors during `ebs.mount`, which is where the original data-loss bug surfaced (mulga-siv-25 medium-term).

## Test plan
- [x] `make lint` clean (0 issues)
- [x] `TestWrapNotFound` covers nil / NoSuchKey / NoSuchBucket / 404 / generic-aws-err / raw-network-err
- [x] `TestClassifyStateLoad` covers both-missing / backend-transient / mixed cases
- [ ] Manual: `systemctl restart spinifex-daemon` on dev cluster, confirm recovery succeeds (validated via paired spinifex PR)

Note: full `make preflight` fails on `dev` itself due to a pre-existing `TestPendingBackendWritesDeduplication` timeout. Not introduced by this change.