### PR TITLE
feat: encryption at rest (AES-256-GCM)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -23,7 +23,8 @@ Viperblock is a high-performance, WAL-backed block storage engine that provides 
 15. [Binary Formats](#15-binary-formats)
 16. [Configuration Reference](#16-configuration-reference)
 17. [File Structure](#17-file-structure)
-18. [References](#18-references)
+18. [Encryption at Rest](#18-encryption-at-rest)
+19. [References](#19-references)
 
 ---
 
@@ -645,11 +646,15 @@ An LRU cache (`github.com/hashicorp/golang-lru`) stores clean blocks read from t
 
 ## Magic Bytes
 
-| Format | Magic | ASCII |
-|--------|-------|-------|
-| Chunk data | `0x56 0x42 0x43 0x48` | `VBCH` |
-| WAL data | `0x56 0x42 0x57 0x4C` | `VBWL` |
-| Block mapping WAL | `0x56 0x42 0x57 0x42` | `VBWB` |
+| Format | Magic | ASCII | Notes |
+|--------|-------|-------|-------|
+| Chunk data (plaintext) | `0x56 0x42 0x43 0x48` | `VBCH` | Pre-encryption layout |
+| Chunk data (encrypted) | `0x56 0x42 0x43 0x45` | `VBCE` | AES-256-GCM sealed per block, see §18 |
+| WAL data (plaintext) | `0x56 0x42 0x57 0x4C` | `VBWL` | Pre-encryption layout; sharded WAL retains this |
+| WAL data (encrypted) | `0x56 0x42 0x57 0x45` | `VBWE` | AES-256-GCM sealed per record (single-file WAL only) |
+| Block mapping WAL | `0x56 0x42 0x57 0x42` | `VBWB` | Plaintext + CRC32 in both modes (metadata, not FCI) |
+
+Volumes are mode-locked at creation: an encrypted volume never sees `VBCH`/`VBWL`, and an unencrypted volume never sees `VBCE`/`VBWE`. A magic mismatch on read is a migration error — there is no in-place upgrade path.
 
 ## File Types and Storage Paths
 
@@ -681,6 +686,11 @@ An LRU cache (`github.com/hashicorp/golang-lru`) stores clean blocks read from t
 | `ShardedWAL` | bool | Whether sharded WAL is enabled |
 | `SnapshotID` | string | Source snapshot ID (if cloned) |
 | `SourceVolumeName` | string | Source volume (if cloned) |
+| `EncryptionEnabled` | bool | Volume is sealed under the operator master key (see §18) |
+| `VolumeUUID` | [4]byte | Per-volume nonce subspace, minted via `crypto/rand` on first SaveState |
+| `SeqNumHighWater` | uint64 | Crash-safe nonce-uniqueness reservation; SeqNum resumes here on Open |
+| `StateSeqNum` | uint64 | Monotonic SaveState generation, bound into the VBState metadata HMAC |
+| `KeyFingerprint` | string | 16 hex chars of the master key fingerprint; mismatched key fails Open |
 
 ## Volume Metadata (EBS-compatible)
 
@@ -722,7 +732,101 @@ viperblock/
 
 ---
 
-# 18. References
+# 18. Encryption at Rest
+
+Viperblock seals every byte of FCI to its live code paths under AES-256-GCM using a node-shared master key, and HMACs `VBState` and `SnapshotState` metadata so a backend writer cannot pivot one volume onto another's blocks. This closes the CMMC L1 practices MP.L1-3.8.3 (cryptographic erase at node-decommission granularity), SI.L1-3.14.2 (chunk + WAL integrity via the 16-byte AEAD tag), and SC.L1-3.13.1 (backend payload is opaque ciphertext).
+
+## Scope
+
+In scope: single-file WAL, chunk write/read, `VBState` / `SnapshotState` metadata HMAC. The encryption-enabled `Open` refuses `UseShardedWAL=true`; the sharded path stays plaintext until a follow-up bead lifts the gate. `WriteBlockWAL` (the block-to-object streaming path) is a dead stub and is not encrypted. The block-to-object checkpoint stays plaintext (it is metadata, not FCI).
+
+## Master key
+
+The master key is a 32-byte raw key file, loaded via `predastore/pkg/masterkey.LoadShared` (group-readable 0640 OK, world-accessible refused). The same file serves predastore and viperblock under different unix users via a shared group. Viperblock receives the file path at startup (`-encryption-key-file` / `ENCRYPTION_KEY_FILE`); raw key bytes are never retained — `LoadShared` returns `*Key{AEAD, Fingerprint}` and viperblock caches the AEAD on `VB.aead` for the hot path.
+
+**Crypto-erase granularity is the node, not the volume.** Destroying the master key file renders every viperblock volume and every predastore object on that node unrecoverable. Per-volume `DeleteVolume` is a logical delete; whole-node decommission is the operator path for MP.L1-3.8.3. Per-volume crypto-erase via envelope encryption is a follow-up.
+
+## Nonce construction
+
+GCM nonces are 12 bytes (96 bits). Reuse with the same key is catastrophic (NIST SP 800-38D §8.3), so the construction uses three disjoint subspaces under the shared master key:
+
+```
+nonce[0:7]   = BE(SeqNum)         56 bits of monotonic counter
+nonce[7:11]  = VolumeUUID         4 random bytes per volume, persisted in VBState
+nonce[11]    = domain             0x00 chunk | 0x01 WAL | 0x02 vbstate-meta | 0x03 snapshot-meta
+```
+
+The 56-bit SeqNum gives ~2,283 years at 1M writes/sec per volume; `reserveSeqNum` refuses past `MaxSeqNum = (1<<56)-1`. `VolumeUUID` is minted via `crypto/rand` on first `SaveState` of an encrypted volume and persisted before `Open` returns. The domain byte keeps a WAL record sealed at `(SeqNum=N, VolumeUUID=V)` from colliding with the chunk block built from it at the same SeqNum / UUID after consolidation.
+
+`SeqNumHighWater` is the crash-safe nonce-uniqueness mechanism: `reserveSeqNum` hands out values lock-free until the high-water is crossed, then takes a mutex, advances by `seqNumReservation = 2^20`, and `SaveState`s before releasing. A kill -9 loses up to one reservation window of values, but every SeqNum handed out before the crash sits below the persisted high-water and cannot be re-issued.
+
+## AAD construction
+
+Data-domain AAD is 48 bytes — `SHA256(VolumeName) || BE(blockNum_8) || BE(seqNum_8)`. The volume hash defeats cross-volume swap; the blockNum defeats positional shuffle; the seqNum defeats in-place rollback.
+
+Metadata AAD substitutes a domain tag for the block slot: `SHA256(VolumeName) || domainTag || BE(StateSeqNum_8)`, where `domainTag` is `"vbstate"` for `VBState` and `"snap:"||snapshotID` for `SnapshotState`. The literal separator stops a snapshot blob from being accepted as a `VBState` blob and vice versa.
+
+## Encrypted WAL record (single-file WAL only, magic `VBWE`)
+
+```
+[SeqNum(8) | BlockNum(8) | BlockLen(8) | ciphertext(BlockLen) | tag(16)]
+= 40 + BlockLen bytes per record
+```
+
+CRC32 is deleted; the 16-byte GCM tag subsumes it. Nonce: `(SeqNum, VolumeUUID, 0x01)`. AAD: `(volumeNameHash, BlockNum, SeqNum)`. The WAL file header is `[VBWE(4) | version(2) | BlockSize(4) | timestamp(8)]` — same 18-byte shape as `VBWL`.
+
+## Encrypted chunk block (chunk magic `VBCE`)
+
+```
+[Chunk header(10): VBCE(4) | version(2) | BlockSize(4)]
+[block 0 ciphertext(BlockSize) | tag(16)]
+[block 1 ciphertext(BlockSize) | tag(16)]
+...
+```
+
+Stride = `BlockSize + 16` = 4112 bytes at default 4 KiB. Per-block nonce: `(block.SeqNum, VolumeUUID, 0x00)`. AAD: `(volumeNameHash, block.Block, block.SeqNum)`. No on-disk SeqNum, no on-disk nonce — both reconstructible from `BlockLookup.SeqNum` (which Stage 2 added to the persisted checkpoint) and `vb.VolumeUUID`.
+
+`BlockLookup` grew from 22 + 4 (CRC32) = 26 bytes per entry to 30 + 4 = 34 bytes to carry the SeqNum needed for nonce reconstruction.
+
+## Metadata HMAC — AES-GCM as MAC
+
+`VBState` and `SnapshotState` ship plaintext-readable on disk (operators can `cat config.json`) but gain a 16-byte trailing tag. `sealMeta` calls `aead.Seal(nil, nonce, nil, aad || jsonBytes)` — the JSON content is part of the covered AAD even though it ships in the clear, so any byte modification breaks verification.
+
+```
+saveMeta:
+  jsonBytes := json.Marshal(state)
+  nonce := makeNonce(StateSeqNum, VolumeUUID, 0x02 or 0x03)
+  aad   := makeMetaAAD(volumeNameHash, "vbstate" or "snap:"||snapshotID, StateSeqNum)
+  tag   := aead.Seal(nil, nonce, nil, aad || jsonBytes)
+  write: jsonBytes || tag
+
+loadMeta:
+  blob := read
+  jsonBytes, tag := blob[:len-16], blob[len-16:]
+  peek StateSeqNum + VolumeUUID from jsonBytes (and KeyFingerprint for clear errors)
+  nonce, aad := reconstruct
+  aead.Open(nil, nonce, tag, aad || jsonBytes)  → ErrIntegrity on mismatch
+```
+
+Rollback protection composes with the existing `LoadState` tie-break (highest `SeqNum` between local-fsync and backend wins): HMAC blocks cross-volume substitution and bit-flips, the SeqNum comparison blocks replay of an older authentic backend blob. The local copy is written atomically via tmp + fsync + rename + fsync(parent dir).
+
+## Snapshot identity
+
+`CreateSnapshot` persists the source volume's `VolumeUUID` (hex string, 8 chars) and `volumeNameHash` (hex string, 64 chars) into `SnapshotState`, plus the snapshot's own `StateSeqNum` for the snapshot-meta HMAC nonce. `OpenFromSnapshot` decodes these into `vb.SourceVolumeUUID` and `vb.sourceVolumeNameHash`; `fetchBaseBlocksFromBackend` uses them (not the clone's own identity) when decrypting source chunks. The clone's own writes seal under the clone's identity. This makes snapshots self-describing: a snapshot is readable as long as the source's chunks exist on the backend, independent of whether the source volume's `VBState` is still loadable.
+
+## Threat model
+
+**In scope:** confidentiality of guest block data against an attacker reading raw chunk files on the backend or raw WAL files on local NVMe; integrity/authenticity of WAL records and chunk blocks against an attacker who can modify them in place; cross-volume metadata pivot (a `VBState` or `SnapshotState` blob authentic for volume B spliced into volume A's location); within-volume positional shuffle; in-place rollback.
+
+**Out of scope:** compromise of a running viperblock host with the master key resident in memory; per-volume cryptographic erase (envelope encryption is the follow-up); migration of existing unencrypted volumes (hard cutover); encryption of the block-to-object checkpoint (metadata, not FCI); encryption of `VBState`/`SnapshotState` JSON itself (HMAC only — operators must still be able to `cat config.json`); the sharded WAL path; inbound NBD authentication.
+
+## Migration
+
+There is no in-place upgrade. A post-cutover binary refuses to open a volume with `VBCH` chunk magic or `VBWL` WAL magic under `EncryptionEnabled=true` (magic-mismatch error, then a migration message). Operators convert by creating a new encrypted volume, copying data across via guest-side tooling (`dd`, filesystem clone), and deleting the old volume. The decision is per-volume — an encrypted volume is encrypted end-to-end; an unencrypted volume runs the pre-encryption code path unchanged.
+
+---
+
+# 19. References
 
 The following research aided the design and implementation of Viperblock:
 

--- a/cmd/sfs/sfs.go
+++ b/cmd/sfs/sfs.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/mulgadc/predastore/pkg/masterkey"
 	"github.com/mulgadc/viperblock/simplefs"
 	"github.com/mulgadc/viperblock/types"
 	"github.com/mulgadc/viperblock/utils"
@@ -41,6 +42,7 @@ func main() {
 	voldata := flag.String("voldata", "", "Volume data directory to store blocks")
 
 	volsize := flag.Uint64("size", 2<<18, "Volume size in bytes")
+	encryptionKeyFile := flag.String("encryption-key-file", "", "path to AES-256 master key (32 raw bytes, 0640 or stricter); falls back to ENCRYPTION_KEY_FILE env if unset")
 
 	// S3 configuration (via environment variables)
 	// aws_profile := os.Getenv("AWS_PROFILE")
@@ -124,8 +126,26 @@ func main() {
 		}
 	}
 
+	keyPath := *encryptionKeyFile
+	if keyPath == "" {
+		keyPath = os.Getenv("ENCRYPTION_KEY_FILE")
+	}
+	var mkey *masterkey.Key
+	if keyPath != "" {
+		mkey, err = masterkey.LoadShared(keyPath)
+		if err != nil {
+			slog.Error("Could not load encryption key", "path", keyPath, "error", err)
+			os.Exit(1)
+		}
+	}
+
 	fmt.Println("Creating Viperblock backend with btype, config", *btype, cfg)
-	vb, err := viperblock.New(&viperblock.VB{VolumeName: *vol, VolumeSize: *volsize}, *btype, cfg)
+	vb, err := viperblock.New(&viperblock.VB{
+		VolumeName:        *vol,
+		VolumeSize:        *volsize,
+		MasterKey:         mkey,
+		EncryptionEnabled: mkey != nil,
+	}, *btype, cfg)
 	if err != nil {
 		slog.Error("Could not create Viperblock", "error", err)
 		os.Exit(1)

--- a/cmd/sfs/sfs.go
+++ b/cmd/sfs/sfs.go
@@ -335,7 +335,7 @@ func main() {
 		fmt.Println("fileBuffer", len(fileBuffer))
 
 		for i, block := range blocks {
-			objectID, objectOffset, err := vb.LookupBlockToObject(block)
+			objectID, objectOffset, _, err := vb.LookupBlockToObject(block)
 
 			if err != nil {
 				slog.Error("Could not lookup block to object", "error", err)

--- a/cmd/sfs/sfs.go
+++ b/cmd/sfs/sfs.go
@@ -105,7 +105,8 @@ func main() {
 		// Create a volume
 		err = sfs.CreateVolume(*vol, *volsize)
 		if err != nil {
-			fmt.Println(err)
+			slog.Error("sfs: CreateVolume failed", "error", err)
+			os.Exit(1)
 		}
 	}
 
@@ -161,7 +162,8 @@ func main() {
 	err = vb.LoadState()
 
 	if err != nil {
-		fmt.Println(err)
+		slog.Error("sfs: LoadState failed", "error", err)
+		os.Exit(1)
 	}
 
 	/*

--- a/cmd/sfs/sfs.go
+++ b/cmd/sfs/sfs.go
@@ -14,7 +14,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/mulgadc/predastore/pkg/masterkey"
 	"github.com/mulgadc/viperblock/simplefs"
 	"github.com/mulgadc/viperblock/types"
 	"github.com/mulgadc/viperblock/utils"
@@ -127,17 +126,10 @@ func main() {
 		}
 	}
 
-	keyPath := *encryptionKeyFile
-	if keyPath == "" {
-		keyPath = os.Getenv("ENCRYPTION_KEY_FILE")
-	}
-	var mkey *masterkey.Key
-	if keyPath != "" {
-		mkey, err = masterkey.LoadShared(keyPath)
-		if err != nil {
-			slog.Error("Could not load encryption key", "path", keyPath, "error", err)
-			os.Exit(1)
-		}
+	mkey, err := viperblock.LoadMasterKeyFromFlagOrEnv(*encryptionKeyFile)
+	if err != nil {
+		slog.Error("Could not load encryption key", "error", err)
+		os.Exit(1)
 	}
 
 	fmt.Println("Creating Viperblock backend with btype, config", *btype, cfg)

--- a/cmd/vblock/main.go
+++ b/cmd/vblock/main.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 
+	"github.com/mulgadc/predastore/pkg/masterkey"
 	"github.com/mulgadc/viperblock/utils"
 	"github.com/mulgadc/viperblock/viperblock"
 	"github.com/mulgadc/viperblock/viperblock/backends/s3"
@@ -28,6 +29,7 @@ func main() {
 	host := flag.String("host", "https://127.0.0.1:8443", "S3 host")
 	base_dir := flag.String("base_dir", "/tmp/vb/", "base directory for viperblock")
 	metadata := flag.String("metadata", "", "metadata (JSON) file to describe volume or AMI")
+	encryptionKeyFile := flag.String("encryption-key-file", "", "path to AES-256 master key (32 raw bytes, 0640 or stricter); falls back to ENCRYPTION_KEY_FILE env if unset")
 
 	flag.Parse()
 
@@ -110,6 +112,19 @@ func main() {
 		Host:       *host,
 	}
 
+	keyPath := *encryptionKeyFile
+	if keyPath == "" {
+		keyPath = os.Getenv("ENCRYPTION_KEY_FILE")
+	}
+	var mkey *masterkey.Key
+	if keyPath != "" {
+		var err error
+		mkey, err = masterkey.LoadShared(keyPath)
+		if err != nil {
+			log.Fatalf("Failed to load encryption key %s: %v", keyPath, err)
+		}
+	}
+
 	vbConfig := viperblock.VB{
 		VolumeName: volID,
 		VolumeSize: utils.SafeIntToUint64(*size),
@@ -119,7 +134,9 @@ func main() {
 				Size: 0,
 			},
 		},
-		VolumeConfig: volumeConfig,
+		VolumeConfig:      volumeConfig,
+		MasterKey:         mkey,
+		EncryptionEnabled: mkey != nil,
 	}
 
 	err := v_utils.ImportDiskImage(&s3Config, &vbConfig, *file)

--- a/cmd/vblock/main.go
+++ b/cmd/vblock/main.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"log/slog"
 	"os"
 
 	"github.com/mulgadc/predastore/pkg/masterkey"
@@ -121,7 +122,8 @@ func main() {
 		var err error
 		mkey, err = masterkey.LoadShared(keyPath)
 		if err != nil {
-			log.Fatalf("Failed to load encryption key %s: %v", keyPath, err)
+			slog.Error("Could not load encryption key", "path", keyPath, "error", err)
+			os.Exit(1)
 		}
 	}
 

--- a/cmd/vblock/main.go
+++ b/cmd/vblock/main.go
@@ -8,7 +8,6 @@ import (
 	"log/slog"
 	"os"
 
-	"github.com/mulgadc/predastore/pkg/masterkey"
 	"github.com/mulgadc/viperblock/utils"
 	"github.com/mulgadc/viperblock/viperblock"
 	"github.com/mulgadc/viperblock/viperblock/backends/s3"
@@ -113,18 +112,10 @@ func main() {
 		Host:       *host,
 	}
 
-	keyPath := *encryptionKeyFile
-	if keyPath == "" {
-		keyPath = os.Getenv("ENCRYPTION_KEY_FILE")
-	}
-	var mkey *masterkey.Key
-	if keyPath != "" {
-		var err error
-		mkey, err = masterkey.LoadShared(keyPath)
-		if err != nil {
-			slog.Error("Could not load encryption key", "path", keyPath, "error", err)
-			os.Exit(1)
-		}
+	mkey, err := viperblock.LoadMasterKeyFromFlagOrEnv(*encryptionKeyFile)
+	if err != nil {
+		slog.Error("Could not load encryption key", "error", err)
+		os.Exit(1)
 	}
 
 	vbConfig := viperblock.VB{
@@ -141,7 +132,7 @@ func main() {
 		EncryptionEnabled: mkey != nil,
 	}
 
-	err := v_utils.ImportDiskImage(&s3Config, &vbConfig, *file)
+	err = v_utils.ImportDiskImage(&s3Config, &vbConfig, *file)
 
 	if err != nil {
 		log.Fatalf("Failed to import disk image: %v", err)

--- a/nbd/viperblock.go
+++ b/nbd/viperblock.go
@@ -46,6 +46,12 @@ var encryption_key_file string
 
 var disk []byte
 
+// loadedMasterKey is populated once in ConfigComplete from
+// -encryption-key-file / ENCRYPTION_KEY_FILE so per-connection Open does not
+// re-read the key file on every NBD client attach. nil iff encryption is
+// disabled for this plugin instance.
+var loadedMasterKey *masterkey.Key
+
 // NOTE: For profiling viperblock/nbdkit, use Linux perf instead of Go pprof.
 // Go's pprof does NOT work correctly when running as a CGO shared library.
 //
@@ -125,6 +131,23 @@ func (p *ViperBlockPlugin) ConfigComplete() error {
 	} else if host == "" {
 		return nbdkit.PluginError{Errmsg: "host parameter is required"}
 	}
+
+	// Resolve and load the master key once at plugin startup so per-NBD-
+	// connection Open avoids a disk read + permission check on every attach.
+	keyPath := encryption_key_file
+	if keyPath == "" {
+		keyPath = os.Getenv("ENCRYPTION_KEY_FILE")
+	}
+	if keyPath != "" {
+		mkey, err := masterkey.LoadShared(keyPath)
+		if err != nil {
+			return nbdkit.PluginError{Errmsg: fmt.Sprintf("Could not load encryption key: %v", err)}
+		}
+		loadedMasterKey = mkey
+	}
+	if use_shardwal && loadedMasterKey != nil {
+		return nbdkit.PluginError{Errmsg: "shardwal is incompatible with encryption: sharded WAL is not supported on encrypted volumes"}
+	}
 	return nil
 }
 
@@ -144,27 +167,6 @@ func (p *ViperBlockPlugin) Open(readonly bool) (nbdkit.ConnectionInterface, erro
 		Host:       host,
 	}
 
-	// Resolve the encryption key path: explicit flag takes precedence over
-	// the ENCRYPTION_KEY_FILE env var so an operator running the daemon with
-	// the env set can still override per-instance.
-	keyPath := encryption_key_file
-	if keyPath == "" {
-		keyPath = os.Getenv("ENCRYPTION_KEY_FILE")
-	}
-
-	var mkey *masterkey.Key
-	if keyPath != "" {
-		var err error
-		mkey, err = masterkey.LoadShared(keyPath)
-		if err != nil {
-			return &ViperBlockConnection{}, nbdkit.PluginError{Errmsg: fmt.Sprintf("Could not load encryption key: %v", err)}
-		}
-	}
-
-	if use_shardwal && mkey != nil {
-		return &ViperBlockConnection{}, nbdkit.PluginError{Errmsg: "shardwal is incompatible with encryption: sharded WAL is not supported on encrypted volumes"}
-	}
-
 	vbconfig := viperblock.VB{
 		VolumeName: volume,
 		VolumeSize: size,
@@ -174,8 +176,8 @@ func (p *ViperBlockPlugin) Open(readonly bool) (nbdkit.ConnectionInterface, erro
 				Size: cache_size,
 			},
 		},
-		MasterKey:         mkey,
-		EncryptionEnabled: mkey != nil,
+		MasterKey:         loadedMasterKey,
+		EncryptionEnabled: loadedMasterKey != nil,
 	}
 
 	slog.Info("Creating Viperblock backend with btype, config", cfg)

--- a/nbd/viperblock.go
+++ b/nbd/viperblock.go
@@ -10,7 +10,6 @@ import (
 import (
 	"fmt"
 	"log/slog"
-	"os"
 
 	"github.com/mulgadc/predastore/pkg/masterkey"
 	"github.com/mulgadc/viperblock/types"
@@ -134,17 +133,11 @@ func (p *ViperBlockPlugin) ConfigComplete() error {
 
 	// Resolve and load the master key once at plugin startup so per-NBD-
 	// connection Open avoids a disk read + permission check on every attach.
-	keyPath := encryption_key_file
-	if keyPath == "" {
-		keyPath = os.Getenv("ENCRYPTION_KEY_FILE")
+	mkey, err := viperblock.LoadMasterKeyFromFlagOrEnv(encryption_key_file)
+	if err != nil {
+		return nbdkit.PluginError{Errmsg: fmt.Sprintf("Could not load encryption key: %v", err)}
 	}
-	if keyPath != "" {
-		mkey, err := masterkey.LoadShared(keyPath)
-		if err != nil {
-			return nbdkit.PluginError{Errmsg: fmt.Sprintf("Could not load encryption key: %v", err)}
-		}
-		loadedMasterKey = mkey
-	}
+	loadedMasterKey = mkey
 	if use_shardwal && loadedMasterKey != nil {
 		return nbdkit.PluginError{Errmsg: "shardwal is incompatible with encryption: sharded WAL is not supported on encrypted volumes"}
 	}
@@ -337,7 +330,9 @@ func (c *ViperBlockConnection) CanFlush() (bool, error) {
 
 func (c *ViperBlockConnection) Flush(flags uint32) error {
 
-	c.vb.Flush()
+	if err := c.vb.Flush(); err != nil {
+		return nbdkit.PluginError{Errmsg: fmt.Sprintf("Flush failed: %v", err)}
+	}
 
 	var err error
 	if c.vb.UseShardedWAL {

--- a/nbd/viperblock.go
+++ b/nbd/viperblock.go
@@ -162,7 +162,7 @@ func (p *ViperBlockPlugin) Open(readonly bool) (nbdkit.ConnectionInterface, erro
 	}
 
 	if use_shardwal && mkey != nil {
-		return &ViperBlockConnection{}, nbdkit.PluginError{Errmsg: "shardwal is incompatible with encryption (plan §Scope discipline — sharded WAL is out of scope for encryption-at-rest)"}
+		return &ViperBlockConnection{}, nbdkit.PluginError{Errmsg: "shardwal is incompatible with encryption: sharded WAL is not supported on encrypted volumes"}
 	}
 
 	vbconfig := viperblock.VB{

--- a/nbd/viperblock.go
+++ b/nbd/viperblock.go
@@ -10,7 +10,9 @@ import (
 import (
 	"fmt"
 	"log/slog"
+	"os"
 
+	"github.com/mulgadc/predastore/pkg/masterkey"
 	"github.com/mulgadc/viperblock/types"
 	"github.com/mulgadc/viperblock/viperblock"
 	"github.com/mulgadc/viperblock/viperblock/backends/s3"
@@ -40,6 +42,7 @@ var host string
 var base_dir string
 var cache_size int = 20
 var use_shardwal bool = false
+var encryption_key_file string
 
 var disk []byte
 
@@ -94,6 +97,9 @@ func (p *ViperBlockPlugin) Config(key string, value string) error {
 	} else if key == "shardwal" {
 		use_shardwal = value == "true" || value == "1"
 		return nil
+	} else if key == "encryption_key_file" {
+		encryption_key_file = value
+		return nil
 	} else {
 		return nbdkit.PluginError{Errmsg: "unknown parameter"}
 	}
@@ -138,6 +144,27 @@ func (p *ViperBlockPlugin) Open(readonly bool) (nbdkit.ConnectionInterface, erro
 		Host:       host,
 	}
 
+	// Resolve the encryption key path: explicit flag takes precedence over
+	// the ENCRYPTION_KEY_FILE env var so an operator running the daemon with
+	// the env set can still override per-instance.
+	keyPath := encryption_key_file
+	if keyPath == "" {
+		keyPath = os.Getenv("ENCRYPTION_KEY_FILE")
+	}
+
+	var mkey *masterkey.Key
+	if keyPath != "" {
+		var err error
+		mkey, err = masterkey.LoadShared(keyPath)
+		if err != nil {
+			return &ViperBlockConnection{}, nbdkit.PluginError{Errmsg: fmt.Sprintf("Could not load encryption key: %v", err)}
+		}
+	}
+
+	if use_shardwal && mkey != nil {
+		return &ViperBlockConnection{}, nbdkit.PluginError{Errmsg: "shardwal is incompatible with encryption (plan §Scope discipline — sharded WAL is out of scope for encryption-at-rest)"}
+	}
+
 	vbconfig := viperblock.VB{
 		VolumeName: volume,
 		VolumeSize: size,
@@ -147,6 +174,8 @@ func (p *ViperBlockPlugin) Open(readonly bool) (nbdkit.ConnectionInterface, erro
 				Size: cache_size,
 			},
 		},
+		MasterKey:         mkey,
+		EncryptionEnabled: mkey != nil,
 	}
 
 	slog.Info("Creating Viperblock backend with btype, config", cfg)

--- a/tests/import-ami.json
+++ b/tests/import-ami.json
@@ -11,8 +11,7 @@
         "VolumeType": "gp3",
         "IOPS": 1000,
         "Tags": null,
-        "SnapshotID": "",
-        "IsEncrypted": false
+        "SnapshotID": ""
     },
     "AMIMetadata": {
         "ImageID": "",

--- a/tests/import-vol.json
+++ b/tests/import-vol.json
@@ -15,7 +15,6 @@
             "env": "prod",
             "team": "infra"
         },
-        "SnapshotID": "",
-        "IsEncrypted": false
+        "SnapshotID": ""
     }
 }

--- a/viperblock/crypto.go
+++ b/viperblock/crypto.go
@@ -18,8 +18,10 @@
 package viperblock
 
 import (
+	"crypto/cipher"
 	"crypto/sha256"
 	"encoding/binary"
+	"fmt"
 )
 
 // Nonce domain bytes — disjoint nonce spaces under the shared master key so a
@@ -86,4 +88,47 @@ func makeMetaAAD(volumeNameHash [32]byte, domainTag string, stateSeqNum uint64) 
 // to avoid recomputing for every seal/open call.
 func computeVolumeNameHash(name string) [32]byte {
 	return sha256.Sum256([]byte(name))
+}
+
+// sealMeta authenticates VBState/SnapshotState JSON with AES-GCM-as-MAC: the
+// JSON bytes stay plaintext-readable so operators can still `cat config.json`,
+// while a 16-byte trailing tag binds the bytes to the structured metadata AAD
+// (volumeNameHash || domain || stateSeqNum) and to the nonce. Returns
+// jsonBytes || tag. The full AAD covered by the tag is aad || jsonBytes — the
+// JSON content is authenticated even though it ships in the clear.
+//
+// Caller is responsible for (key, nonce) uniqueness: callers must allocate a
+// fresh stateSeqNum (via VB.nextStateSeqNum.Add(1)) for every seal, since
+// domain separation only keeps metadata nonces disjoint from data-path nonces
+// — it does not protect back-to-back metadata seals on the same volume.
+func sealMeta(aead cipher.AEAD, jsonBytes, aad []byte, nonce [12]byte) []byte {
+	fullAAD := make([]byte, 0, len(aad)+len(jsonBytes))
+	fullAAD = append(fullAAD, aad...)
+	fullAAD = append(fullAAD, jsonBytes...)
+	tag := aead.Seal(nil, nonce[:], nil, fullAAD)
+	out := make([]byte, 0, len(jsonBytes)+len(tag))
+	out = append(out, jsonBytes...)
+	out = append(out, tag...)
+	return out
+}
+
+// openMeta verifies the trailing AES-GCM tag on a sealMeta blob and returns
+// the leading JSON bytes on success. Any tampering with the JSON, the tag,
+// the structured AAD, or the nonce inputs surfaces as a non-nil error;
+// callers must wrap with ErrIntegrity and fail-closed.
+func openMeta(aead cipher.AEAD, blob, aad []byte, nonce [12]byte) ([]byte, error) {
+	tagLen := aead.Overhead()
+	if len(blob) < tagLen {
+		return nil, fmt.Errorf("metadata blob %d bytes shorter than %d-byte tag", len(blob), tagLen)
+	}
+	split := len(blob) - tagLen
+	jsonBytes := blob[:split]
+	tag := blob[split:]
+	fullAAD := make([]byte, 0, len(aad)+len(jsonBytes))
+	fullAAD = append(fullAAD, aad...)
+	fullAAD = append(fullAAD, jsonBytes...)
+	if _, err := aead.Open(nil, nonce[:], tag, fullAAD); err != nil {
+		return nil, err
+	}
+	return jsonBytes, nil
 }

--- a/viperblock/crypto.go
+++ b/viperblock/crypto.go
@@ -1,0 +1,89 @@
+// Copyright 2026 Mulga Defense Corporation (MDC). All rights reserved.
+// Use of this source code is governed by an Apache 2.0 license
+// that can be found in the LICENSE file.
+
+// Package viperblock — crypto helpers for AES-256-GCM at-rest encryption.
+//
+// Nonce layout (12 bytes, big-endian throughout, NIST SP 800-38D §8.2.1
+// deterministic IV):
+//
+//	[0:7]   BE(SeqNum)   56 bits of monotonic counter (top byte of uint64 dropped)
+//	[7:11]  VolumeUUID   4 random bytes per volume, persisted in VBState
+//	[11]    domain       0x00=chunk | 0x01=WAL | 0x02=vbstate-meta | 0x03=snapshot-meta
+//
+// AAD layout (48 bytes for data domains): SHA256(VolumeName) || BE(blockNum)
+// || BE(seqNum). Metadata domains substitute the blockNum slot with a literal
+// domain tag ("vbstate", "snap:"||snapshotID) and use VBState.StateSeqNum.
+
+package viperblock
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+)
+
+// Nonce domain bytes — disjoint nonce spaces under the shared master key so a
+// WAL record sealed at (SeqNum=N, VolumeUUID=V) does not collide with the
+// chunk block built from it.
+const (
+	DomainChunk        byte = 0x00
+	DomainWAL          byte = 0x01
+	DomainVBStateMeta  byte = 0x02
+	DomainSnapshotMeta byte = 0x03
+)
+
+// MaxSeqNum is the largest sequence number representable in the 56-bit nonce
+// slot. Writes past this point are refused; at 1M writes/sec sustained per
+// volume that is ~2,283 years.
+const MaxSeqNum uint64 = (1 << 56) - 1
+
+// makeNonce builds a 12-byte GCM nonce from a sequence number, the per-volume
+// UUID, and a domain byte. SeqNum is truncated to 56 bits (top byte of the
+// uint64 is dropped); callers must enforce seqNum <= MaxSeqNum.
+func makeNonce(seqNum uint64, volumeUUID [4]byte, domain byte) [12]byte {
+	var n [12]byte
+	// Low 56 bits of seqNum, big-endian, into n[0:7]. Mask each shift result
+	// to satisfy gosec G115 — Go truncates byte(uint64) safely but the
+	// linter cannot prove it.
+	n[0] = byte((seqNum >> 48) & 0xff)
+	n[1] = byte((seqNum >> 40) & 0xff)
+	n[2] = byte((seqNum >> 32) & 0xff)
+	n[3] = byte((seqNum >> 24) & 0xff)
+	n[4] = byte((seqNum >> 16) & 0xff)
+	n[5] = byte((seqNum >> 8) & 0xff)
+	n[6] = byte(seqNum & 0xff)
+	copy(n[7:11], volumeUUID[:])
+	n[11] = domain
+	return n
+}
+
+// makeAAD builds the 48-byte AAD bound into every data-domain seal/open:
+// volumeNameHash || BE(blockNum) || BE(seqNum). Defeats cross-volume swap
+// (hash differs), in-place rollback (seqnum differs from index-trusted
+// value), and positional shuffle (blockNum differs).
+func makeAAD(volumeNameHash [32]byte, blockNum, seqNum uint64) []byte {
+	aad := make([]byte, 32+8+8)
+	copy(aad[0:32], volumeNameHash[:])
+	binary.BigEndian.PutUint64(aad[32:40], blockNum)
+	binary.BigEndian.PutUint64(aad[40:48], seqNum)
+	return aad
+}
+
+// makeMetaAAD builds the AAD for VBState and SnapshotState integrity tags:
+// volumeNameHash || domainTag || BE(stateSeqNum). The literal domainTag
+// ("vbstate" or "snap:"||snapshotID) prevents a snapshot blob tagged for
+// volume A from being accepted as volume A's VBState blob and vice versa.
+func makeMetaAAD(volumeNameHash [32]byte, domainTag string, stateSeqNum uint64) []byte {
+	aad := make([]byte, 0, 32+len(domainTag)+8)
+	aad = append(aad, volumeNameHash[:]...)
+	aad = append(aad, domainTag...)
+	var sn [8]byte
+	binary.BigEndian.PutUint64(sn[:], stateSeqNum)
+	return append(aad, sn[:]...)
+}
+
+// computeVolumeNameHash returns SHA256(volumeName), cached on the VB at Open
+// to avoid recomputing for every seal/open call.
+func computeVolumeNameHash(name string) [32]byte {
+	return sha256.Sum256([]byte(name))
+}

--- a/viperblock/crypto.go
+++ b/viperblock/crypto.go
@@ -59,16 +59,37 @@ func makeNonce(seqNum uint64, volumeUUID [4]byte, domain byte) [12]byte {
 	return n
 }
 
+// AADLen is the fixed size of the data-domain AAD: 32-byte volumeNameHash +
+// 8-byte blockNum + 8-byte seqNum.
+const AADLen = 32 + 8 + 8
+
 // makeAAD builds the 48-byte AAD bound into every data-domain seal/open:
 // volumeNameHash || BE(blockNum) || BE(seqNum). Defeats cross-volume swap
 // (hash differs), in-place rollback (seqnum differs from index-trusted
 // value), and positional shuffle (blockNum differs).
+//
+// For per-block hot loops, prefer initAAD + updateAAD against a stack-
+// allocated [AADLen]byte to avoid an allocation per block.
 func makeAAD(volumeNameHash [32]byte, blockNum, seqNum uint64) []byte {
-	aad := make([]byte, 32+8+8)
+	aad := make([]byte, AADLen)
 	copy(aad[0:32], volumeNameHash[:])
 	binary.BigEndian.PutUint64(aad[32:40], blockNum)
 	binary.BigEndian.PutUint64(aad[40:48], seqNum)
 	return aad
+}
+
+// initAAD populates the fixed volumeNameHash prefix of an AAD buffer once.
+// Per-block hot loops pair this with updateAAD to mutate only the block-
+// varying suffix without reallocating or copying the 32-byte hash each call.
+func initAAD(aad *[AADLen]byte, volumeNameHash [32]byte) {
+	copy(aad[0:32], volumeNameHash[:])
+}
+
+// updateAAD overwrites the blockNum + seqNum suffix of an AAD buffer whose
+// volumeNameHash prefix was previously set by initAAD.
+func updateAAD(aad *[AADLen]byte, blockNum, seqNum uint64) {
+	binary.BigEndian.PutUint64(aad[32:40], blockNum)
+	binary.BigEndian.PutUint64(aad[40:48], seqNum)
 }
 
 // makeMetaAAD builds the AAD for VBState and SnapshotState integrity tags:

--- a/viperblock/crypto_test.go
+++ b/viperblock/crypto_test.go
@@ -2,22 +2,40 @@
 // Use of this source code is governed by an Apache 2.0 license
 // that can be found in the LICENSE file.
 
-// Stage 1 smoke tests for the encryption-at-rest plumbing. The full Stage 5
-// test inventory (round-trip, AAD/ciphertext tamper, domain separation,
-// nonce uniqueness sweep, etc.) lands alongside the Stage 2-4 production
-// code; these tests exist to keep the global coverage gate satisfied while
-// the per-stage scope discipline is preserved.
+// Crypto-helper tests for the encryption-at-rest plumbing. Layout invariants
+// (nonce byte positions, 56-bit SeqNum truncation, AAD shape, domain
+// separation) live alongside the full Stage 5 matrix: AEAD round-trip,
+// ciphertext + tag tamper detection, sealMeta / openMeta round-trip and
+// tamper, ciphertext-level domain separation, and a 10^6-triple nonce
+// uniqueness sweep.
 
 package viperblock
 
 import (
+	"bytes"
+	"crypto/cipher"
+	"crypto/rand"
 	"crypto/sha256"
 	"encoding/binary"
 	"testing"
 
+	"github.com/mulgadc/predastore/pkg/masterkey"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// freshAEAD builds an AES-256-GCM AEAD from a random 32-byte key. Caller-
+// controlled key generation so tests can mint independent keys for
+// cross-key separation checks.
+func freshAEAD(t *testing.T) cipher.AEAD {
+	t.Helper()
+	var raw [masterkey.MasterKeySize]byte
+	_, err := rand.Read(raw[:])
+	require.NoError(t, err)
+	aead, err := masterkey.NewAEAD(raw[:])
+	require.NoError(t, err)
+	return aead
+}
 
 func TestMakeNonce_LayoutAndDomainSeparation(t *testing.T) {
 	uuid := [4]byte{0xde, 0xad, 0xbe, 0xef}
@@ -108,4 +126,224 @@ func TestMakeMetaAAD_DomainSeparation(t *testing.T) {
 func TestComputeVolumeNameHash_MatchesSHA256(t *testing.T) {
 	want := sha256.Sum256([]byte("vol-42"))
 	assert.Equal(t, want, computeVolumeNameHash("vol-42"))
+}
+
+// TestAEAD_RoundTrip exercises the full data-domain primitive: seal with
+// (nonce, aad, plaintext) and recover the plaintext via Open. The pure-
+// helper tests above only assert layout; this gates that an actual
+// aead.Seal / aead.Open round-trip through makeNonce + makeAAD is
+// symmetric. Foundation for every tamper test below.
+func TestAEAD_RoundTrip(t *testing.T) {
+	aead := freshAEAD(t)
+	hash := sha256.Sum256([]byte("vol-rt"))
+	uuid := [4]byte{0xaa, 0xbb, 0xcc, 0xdd}
+	plaintext := []byte("the only winning move is not to play")
+
+	nonce := makeNonce(42, uuid, DomainChunk)
+	aad := makeAAD(hash, 7, 42)
+	sealed := aead.Seal(nil, nonce[:], plaintext, aad)
+	require.Len(t, sealed, len(plaintext)+aead.Overhead())
+
+	opened, err := aead.Open(nil, nonce[:], sealed, aad)
+	require.NoError(t, err)
+	assert.Equal(t, plaintext, opened)
+}
+
+// TestAEAD_CiphertextTamperFails — flipping a single bit in the body or
+// the trailing 16-byte tag must surface as an aead.Open error. This is the
+// SI.L1-3.14.2 backbone: chunk-store / WAL integrity rests on these two
+// detections firing on every byte modification at rest.
+func TestAEAD_CiphertextTamperFails(t *testing.T) {
+	aead := freshAEAD(t)
+	hash := sha256.Sum256([]byte("vol-tamper"))
+	uuid := [4]byte{1, 2, 3, 4}
+	plaintext := make([]byte, 512)
+	_, err := rand.Read(plaintext)
+	require.NoError(t, err)
+
+	nonce := makeNonce(100, uuid, DomainChunk)
+	aad := makeAAD(hash, 0, 100)
+	sealed := aead.Seal(nil, nonce[:], plaintext, aad)
+
+	t.Run("body bit flip", func(t *testing.T) {
+		tampered := append([]byte(nil), sealed...)
+		tampered[5] ^= 0x01
+		_, err := aead.Open(nil, nonce[:], tampered, aad)
+		assert.Error(t, err, "body tamper must fail Open")
+	})
+
+	t.Run("tag bit flip", func(t *testing.T) {
+		tampered := append([]byte(nil), sealed...)
+		tampered[len(tampered)-1] ^= 0x01
+		_, err := aead.Open(nil, nonce[:], tampered, aad)
+		assert.Error(t, err, "tag tamper must fail Open")
+	})
+}
+
+// TestAEAD_AADTamperFails — Open must reject when any AAD field
+// (volumeNameHash, blockNum, seqNum) differs from the seal-time value.
+// This is what defeats cross-volume swap (volume hash differs), positional
+// shuffle (blockNum differs), and in-place rollback (seqNum differs).
+// makeAAD layout is asserted by TestMakeAAD_TamperDetectionPrecondition;
+// here we wire that into a real Seal/Open pair to gate the cryptographic
+// detection.
+func TestAEAD_AADTamperFails(t *testing.T) {
+	aead := freshAEAD(t)
+	hash := sha256.Sum256([]byte("vol-aad"))
+	uuid := [4]byte{0x10, 0x20, 0x30, 0x40}
+	plaintext := []byte("authenticated data binding test")
+	nonce := makeNonce(500, uuid, DomainChunk)
+	aad := makeAAD(hash, 99, 500)
+	sealed := aead.Seal(nil, nonce[:], plaintext, aad)
+
+	t.Run("wrong volumeNameHash", func(t *testing.T) {
+		other := sha256.Sum256([]byte("vol-aad-OTHER"))
+		_, err := aead.Open(nil, nonce[:], sealed, makeAAD(other, 99, 500))
+		assert.Error(t, err)
+	})
+	t.Run("wrong blockNum", func(t *testing.T) {
+		_, err := aead.Open(nil, nonce[:], sealed, makeAAD(hash, 100, 500))
+		assert.Error(t, err)
+	})
+	t.Run("wrong seqNum", func(t *testing.T) {
+		_, err := aead.Open(nil, nonce[:], sealed, makeAAD(hash, 99, 501))
+		assert.Error(t, err)
+	})
+}
+
+// TestAEAD_DomainSeparationAtCiphertext — sealing identical plaintext under
+// (same key, same seqNum, same uuid) but different domains yields distinct
+// ciphertexts AND a tag from one domain does not verify under another. This
+// is the cryptographic teeth of the domain byte: without it, consolidating
+// a WAL record (DomainWAL) into a chunk block (DomainChunk) would reuse
+// the same nonce — catastrophic for AES-GCM.
+func TestAEAD_DomainSeparationAtCiphertext(t *testing.T) {
+	aead := freshAEAD(t)
+	hash := sha256.Sum256([]byte("vol-domain"))
+	uuid := [4]byte{0xfe, 0xed, 0xfa, 0xce}
+	plaintext := []byte("same plaintext, different domain")
+	aad := makeAAD(hash, 1, 1)
+
+	chunkNonce := makeNonce(1, uuid, DomainChunk)
+	walNonce := makeNonce(1, uuid, DomainWAL)
+	require.NotEqual(t, chunkNonce, walNonce)
+
+	chunkSealed := aead.Seal(nil, chunkNonce[:], plaintext, aad)
+	walSealed := aead.Seal(nil, walNonce[:], plaintext, aad)
+	assert.False(t, bytes.Equal(chunkSealed, walSealed),
+		"identical plaintext under different domain nonces must produce different ciphertexts")
+
+	// Cross-domain Open must fail — a chunk ciphertext presented as a WAL
+	// ciphertext (or vice versa) is rejected because the nonce differs.
+	_, err := aead.Open(nil, walNonce[:], chunkSealed, aad)
+	assert.Error(t, err, "chunk ciphertext must not verify under WAL nonce")
+	_, err = aead.Open(nil, chunkNonce[:], walSealed, aad)
+	assert.Error(t, err, "WAL ciphertext must not verify under chunk nonce")
+}
+
+// TestSealMeta_RoundTrip exercises the metadata HMAC primitive: seal a
+// JSON blob with structured AAD + nonce, recover the JSON via openMeta.
+// jsonBytes ship in the clear (operators can `cat config.json`) — the tag
+// binds them to (volumeNameHash, domainTag, stateSeqNum) so cross-volume
+// substitution and bit-flip are detectable.
+func TestSealMeta_RoundTrip(t *testing.T) {
+	aead := freshAEAD(t)
+	hash := sha256.Sum256([]byte("vol-meta"))
+	jsonBytes := []byte(`{"VolumeName":"vol-meta","StateSeqNum":7}`)
+	nonce := makeNonce(7, [4]byte{1, 2, 3, 4}, DomainVBStateMeta)
+	aad := makeMetaAAD(hash, "vbstate", 7)
+
+	blob := sealMeta(aead, jsonBytes, aad, nonce)
+	require.Len(t, blob, len(jsonBytes)+aead.Overhead())
+	assert.Equal(t, jsonBytes, blob[:len(jsonBytes)], "jsonBytes ship plaintext in the prefix")
+
+	recovered, err := openMeta(aead, blob, aad, nonce)
+	require.NoError(t, err)
+	assert.Equal(t, jsonBytes, recovered)
+}
+
+// TestSealMeta_TamperFails — bit-flip in the JSON, the tag, or the
+// structured AAD inputs (domainTag / stateSeqNum / volumeNameHash) all
+// surface as openMeta errors. This is the cross-volume metadata pivot
+// closer: an attacker swapping volume A's tagged config.json into volume
+// B's prefix is rejected because the AAD's volumeNameHash differs.
+func TestSealMeta_TamperFails(t *testing.T) {
+	aead := freshAEAD(t)
+	hash := sha256.Sum256([]byte("vol-meta-tamper"))
+	jsonBytes := []byte(`{"VolumeName":"vol-meta-tamper","StateSeqNum":99}`)
+	nonce := makeNonce(99, [4]byte{9, 9, 9, 9}, DomainVBStateMeta)
+	aad := makeMetaAAD(hash, "vbstate", 99)
+	blob := sealMeta(aead, jsonBytes, aad, nonce)
+
+	t.Run("json byte flip", func(t *testing.T) {
+		tampered := append([]byte(nil), blob...)
+		tampered[3] ^= 0x01
+		_, err := openMeta(aead, tampered, aad, nonce)
+		assert.Error(t, err)
+	})
+
+	t.Run("tag byte flip", func(t *testing.T) {
+		tampered := append([]byte(nil), blob...)
+		tampered[len(tampered)-1] ^= 0x01
+		_, err := openMeta(aead, tampered, aad, nonce)
+		assert.Error(t, err)
+	})
+
+	t.Run("wrong volumeNameHash", func(t *testing.T) {
+		other := sha256.Sum256([]byte("vol-meta-OTHER"))
+		_, err := openMeta(aead, blob, makeMetaAAD(other, "vbstate", 99), nonce)
+		assert.Error(t, err, "cross-volume AAD must fail verify")
+	})
+
+	t.Run("wrong domain tag", func(t *testing.T) {
+		_, err := openMeta(aead, blob, makeMetaAAD(hash, "snap:foo", 99), nonce)
+		assert.Error(t, err, "vbstate blob must not verify under snapshot AAD")
+	})
+
+	t.Run("wrong stateSeqNum", func(t *testing.T) {
+		_, err := openMeta(aead, blob, makeMetaAAD(hash, "vbstate", 100), nonce)
+		assert.Error(t, err)
+	})
+
+	t.Run("blob shorter than tag", func(t *testing.T) {
+		short := blob[:aead.Overhead()-1]
+		_, err := openMeta(aead, short, aad, nonce)
+		assert.Error(t, err, "undersized blob must surface a clear error")
+	})
+}
+
+// TestMakeNonce_UniquenessSweep stresses the (seqNum, volumeUUID, domain)
+// nonce space over 10^6 random triples and asserts there is no collision.
+// 12 bytes of nonce gives a 2^96 space, so a million-shot collision is
+// astronomically unlikely if our construction actually uses all the bits
+// — a collision here means makeNonce dropped a field. Catches regressions
+// like "VolumeUUID slot mis-sliced" or "domain byte XORed instead of
+// assigned" that would silently shrink the effective nonce space.
+//
+// At 10^6 triples this runs in ~200ms; gated by testing.Short so the
+// short-mode preflight stays under a minute.
+func TestMakeNonce_UniquenessSweep(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping million-triple nonce sweep in short mode")
+	}
+	const N = 1_000_000
+	seen := make(map[[12]byte]struct{}, N)
+	var buf [8]byte
+	for i := range N {
+		_, err := rand.Read(buf[:])
+		require.NoError(t, err)
+		seqNum := binary.BigEndian.Uint64(buf[:]) & MaxSeqNum
+		var uuid [4]byte
+		_, err = rand.Read(uuid[:])
+		require.NoError(t, err)
+		_, err = rand.Read(buf[:1])
+		require.NoError(t, err)
+		domain := buf[0]
+		n := makeNonce(seqNum, uuid, domain)
+		if _, dup := seen[n]; dup {
+			t.Fatalf("nonce collision at iteration %d: %x (seqNum=%d uuid=%x domain=%#x)", i, n, seqNum, uuid, domain)
+		}
+		seen[n] = struct{}{}
+	}
+	assert.Len(t, seen, N)
 }

--- a/viperblock/crypto_test.go
+++ b/viperblock/crypto_test.go
@@ -4,10 +4,9 @@
 
 // Crypto-helper tests for the encryption-at-rest plumbing. Layout invariants
 // (nonce byte positions, 56-bit SeqNum truncation, AAD shape, domain
-// separation) live alongside the full Stage 5 matrix: AEAD round-trip,
-// ciphertext + tag tamper detection, sealMeta / openMeta round-trip and
-// tamper, ciphertext-level domain separation, and a 10^6-triple nonce
-// uniqueness sweep.
+// separation) live alongside AEAD round-trip, ciphertext + tag tamper
+// detection, sealMeta / openMeta round-trip and tamper, ciphertext-level
+// domain separation, and a 10^6-triple nonce uniqueness sweep.
 
 package viperblock
 
@@ -95,7 +94,7 @@ func TestMakeAAD_Layout(t *testing.T) {
 }
 
 func TestMakeAAD_TamperDetectionPrecondition(t *testing.T) {
-	// makeAAD itself is pure; Stage 3's aead.Open is what catches tampering.
+	// makeAAD itself is pure; aead.Open on the decrypt path catches tampering.
 	// What we verify here is that any single-field bit-flip yields a
 	// different AAD byte string, which is the precondition for AEAD tamper
 	// detection to fire.

--- a/viperblock/crypto_test.go
+++ b/viperblock/crypto_test.go
@@ -1,0 +1,111 @@
+// Copyright 2026 Mulga Defense Corporation (MDC). All rights reserved.
+// Use of this source code is governed by an Apache 2.0 license
+// that can be found in the LICENSE file.
+
+// Stage 1 smoke tests for the encryption-at-rest plumbing. The full Stage 5
+// test inventory (round-trip, AAD/ciphertext tamper, domain separation,
+// nonce uniqueness sweep, etc.) lands alongside the Stage 2-4 production
+// code; these tests exist to keep the global coverage gate satisfied while
+// the per-stage scope discipline is preserved.
+
+package viperblock
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMakeNonce_LayoutAndDomainSeparation(t *testing.T) {
+	uuid := [4]byte{0xde, 0xad, 0xbe, 0xef}
+	seq := uint64(0x010203040506) // fits in 56 bits
+
+	for _, tc := range []struct {
+		name   string
+		domain byte
+	}{
+		{"chunk", DomainChunk},
+		{"wal", DomainWAL},
+		{"vbstate", DomainVBStateMeta},
+		{"snapshot", DomainSnapshotMeta},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			n := makeNonce(seq, uuid, tc.domain)
+			// Bytes [0:7]: BE(seq) low-56.
+			require.Equal(t, byte(0x00), n[0])
+			require.Equal(t, byte(0x01), n[1])
+			require.Equal(t, byte(0x02), n[2])
+			require.Equal(t, byte(0x03), n[3])
+			require.Equal(t, byte(0x04), n[4])
+			require.Equal(t, byte(0x05), n[5])
+			require.Equal(t, byte(0x06), n[6])
+			// Bytes [7:11]: VolumeUUID.
+			require.Equal(t, uuid[:], n[7:11])
+			// Byte [11]: domain.
+			require.Equal(t, tc.domain, n[11])
+		})
+	}
+
+	// Same (seq, uuid) under different domains must yield different nonces —
+	// this is the whole point of the domain byte (no WAL/chunk collision).
+	chunkNonce := makeNonce(seq, uuid, DomainChunk)
+	walNonce := makeNonce(seq, uuid, DomainWAL)
+	assert.NotEqual(t, chunkNonce, walNonce)
+}
+
+func TestMakeNonce_SeqNumTopByteDropped(t *testing.T) {
+	// SeqNum top byte must not leak into the nonce — the 56-bit truncation
+	// is intentional (NIST SP 800-38D §8 deterministic IV). Compare a
+	// 56-bit-bounded value against the same value with garbage in the top
+	// byte; the two nonces must match.
+	uuid := [4]byte{1, 2, 3, 4}
+	low := uint64(0xAABBCCDDEEFF12)
+	high := low | (uint64(0xFF) << 56)
+	assert.Equal(t, makeNonce(low, uuid, DomainChunk), makeNonce(high, uuid, DomainChunk))
+}
+
+func TestMakeAAD_Layout(t *testing.T) {
+	hash := sha256.Sum256([]byte("vol-1"))
+	aad := makeAAD(hash, 12345, 67890)
+	require.Len(t, aad, 48)
+	assert.Equal(t, hash[:], aad[0:32])
+	assert.Equal(t, uint64(12345), binary.BigEndian.Uint64(aad[32:40]))
+	assert.Equal(t, uint64(67890), binary.BigEndian.Uint64(aad[40:48]))
+}
+
+func TestMakeAAD_TamperDetectionPrecondition(t *testing.T) {
+	// makeAAD itself is pure; Stage 3's aead.Open is what catches tampering.
+	// What we verify here is that any single-field bit-flip yields a
+	// different AAD byte string, which is the precondition for AEAD tamper
+	// detection to fire.
+	hash := sha256.Sum256([]byte("vol-1"))
+	base := makeAAD(hash, 100, 200)
+
+	// Bit-flip the volume hash.
+	tampered := hash
+	tampered[0] ^= 0x01
+	assert.NotEqual(t, base, makeAAD(tampered, 100, 200))
+
+	// Different blockNum.
+	assert.NotEqual(t, base, makeAAD(hash, 101, 200))
+
+	// Different seqNum.
+	assert.NotEqual(t, base, makeAAD(hash, 100, 201))
+}
+
+func TestMakeMetaAAD_DomainSeparation(t *testing.T) {
+	hash := sha256.Sum256([]byte("vol-1"))
+	vbstate := makeMetaAAD(hash, "vbstate", 42)
+	snap := makeMetaAAD(hash, "snap:snap-abc", 42)
+	assert.NotEqual(t, vbstate, snap)
+	// StateSeqNum is appended; bumping it changes the AAD.
+	assert.NotEqual(t, vbstate, makeMetaAAD(hash, "vbstate", 43))
+}
+
+func TestComputeVolumeNameHash_MatchesSHA256(t *testing.T) {
+	want := sha256.Sum256([]byte("vol-42"))
+	assert.Equal(t, want, computeVolumeNameHash("vol-42"))
+}

--- a/viperblock/encryption_meta_test.go
+++ b/viperblock/encryption_meta_test.go
@@ -1,0 +1,303 @@
+// Copyright 2026 Mulga Defense Corporation (MDC). All rights reserved.
+// Use of this source code is governed by an Apache 2.0 license
+// that can be found in the LICENSE file.
+
+// Stage 5 metadata HMAC tests. Closes the cross-volume metadata pivot
+// critical: a backend writer cannot substitute volume A's tagged
+// VBState/SnapshotState into volume B's prefix, cannot bit-flip the
+// JSON, and cannot rollback to an older authentic blob without losing
+// the LoadState SeqNum tie-break to the local fsync'd copy.
+
+package viperblock
+
+import (
+	"crypto/rand"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mulgadc/viperblock/types"
+	"github.com/mulgadc/viperblock/viperblock/backends/file"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestVBStateMeta_BitFlipFailsLoad — a one-byte flip in the persisted
+// config.json after the HMAC seal must surface as ErrIntegrity at
+// LoadStateRequest. This is the literal byte-tamper check: the JSON
+// ships plaintext, the trailing 16-byte tag binds the bytes to the
+// AAD via sealMeta, so any modification fails openMeta.
+func TestVBStateMeta_BitFlipFailsLoad(t *testing.T) {
+	key := testKey(t, 0x42)
+	vb := newFileBackedVB(t, "vol-meta-bitflip", key)
+	vb.BlockSize = DefaultBlockSize
+	require.NoError(t, vb.SaveState())
+
+	configPath := filepath.Join(vb.BaseDir, types.GetFilePath(types.FileTypeConfig, 0, vb.GetVolume()))
+	raw, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	require.Greater(t, len(raw), 20)
+	raw[5] ^= 0x01 // flip a JSON byte
+	require.NoError(t, os.WriteFile(configPath, raw, 0600))
+
+	_, err = vb.LoadStateRequest(configPath)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrIntegrity)
+}
+
+// TestVBStateMeta_TagFlipFailsLoad — flipping a byte in the trailing
+// 16-byte tag must also fail. Distinct from the body flip: tag bytes
+// are not parsed as JSON, so a regression that verifies the tag length
+// but not its contents would pass the body-flip test and fail here.
+func TestVBStateMeta_TagFlipFailsLoad(t *testing.T) {
+	key := testKey(t, 0x42)
+	vb := newFileBackedVB(t, "vol-meta-tag", key)
+	vb.BlockSize = DefaultBlockSize
+	require.NoError(t, vb.SaveState())
+
+	configPath := filepath.Join(vb.BaseDir, types.GetFilePath(types.FileTypeConfig, 0, vb.GetVolume()))
+	raw, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	raw[len(raw)-1] ^= 0x01 // flip last byte of tag
+	require.NoError(t, os.WriteFile(configPath, raw, 0600))
+
+	_, err = vb.LoadStateRequest(configPath)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrIntegrity)
+}
+
+// TestVBStateMeta_CrossVolumeSwapFailsLoad — splicing volume A's tagged
+// config.json into volume B's prefix must fail because B's runtime
+// volumeNameHash differs from the seal-time hash bound into A's AAD.
+// This is the live test of the cross-volume metadata pivot critical
+// called out in viperblock-cmmc-level1-remediation.md (closed here by
+// design, in case its archived "Complete" status was misleading).
+func TestVBStateMeta_CrossVolumeSwapFailsLoad(t *testing.T) {
+	key := testKey(t, 0x42)
+	dir := t.TempDir()
+
+	// Two VBs in the same dir, different volume names so they have
+	// different volumeNameHashes.
+	mkVB := func(name string) *VB {
+		cfg := file.FileConfig{BaseDir: dir, VolumeName: name}
+		vb, err := New(&VB{
+			VolumeName:        name,
+			VolumeSize:        4 * 1024 * 1024,
+			BaseDir:           dir,
+			MasterKey:         key,
+			EncryptionEnabled: true,
+		}, "file", cfg)
+		require.NoError(t, err)
+		require.NoError(t, vb.Backend.Init())
+		vb.BlockSize = DefaultBlockSize
+		require.NoError(t, vb.SaveState())
+		return vb
+	}
+	volA := mkVB("vol-A-meta")
+	volB := mkVB("vol-B-meta")
+
+	configA := filepath.Join(dir, types.GetFilePath(types.FileTypeConfig, 0, volA.GetVolume()))
+	configB := filepath.Join(dir, types.GetFilePath(types.FileTypeConfig, 0, volB.GetVolume()))
+	rawA, err := os.ReadFile(configA)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(configB, rawA, 0600))
+
+	_, err = volB.LoadStateRequest(configB)
+	require.Error(t, err, "cross-volume swap must fail HMAC verify")
+	assert.ErrorIs(t, err, ErrIntegrity)
+}
+
+// TestVBStateMeta_RollbackLosesTieToFsync — write VBState v1, then v2,
+// then substitute the v1 backend copy. LoadState's existing tie-break
+// (highest SeqNum wins between local fsync and backend) must select
+// the local v2 copy; HMAC verify of v2 succeeds. This gates the
+// composition: HMAC alone does not stop replay of an older authentic
+// blob — the SeqNum comparison does. An attacker who rewinds the
+// backend copy is foiled because the local fsync'd copy holds a higher
+// StateSeqNum and wins the tie-break.
+func TestVBStateMeta_RollbackLosesTieToFsync(t *testing.T) {
+	key := testKey(t, 0x42)
+	dir := t.TempDir()
+	cfg := file.FileConfig{BaseDir: dir, VolumeName: "vol-rollback"}
+	vb, err := New(&VB{
+		VolumeName:        "vol-rollback",
+		VolumeSize:        4 * 1024 * 1024,
+		BaseDir:           dir,
+		MasterKey:         key,
+		EncryptionEnabled: true,
+	}, "file", cfg)
+	require.NoError(t, err)
+	require.NoError(t, vb.Backend.Init())
+	vb.BlockSize = DefaultBlockSize
+
+	// v1: first SaveState. Snapshot the backend blob.
+	require.NoError(t, vb.SaveState())
+	// Force a write to bump SeqNum on disk so v1 vs v2 differ by more
+	// than just StateSeqNum.
+	vb.SeqNum.Store(100)
+	require.NoError(t, vb.SaveState())
+	v1Backend, err := vb.Backend.Read(types.FileTypeConfig, 0, 0, 0)
+	require.NoError(t, err)
+
+	// v2: bump SeqNum and persist again.
+	vb.SeqNum.Store(200)
+	require.NoError(t, vb.SaveState())
+
+	// Roll the BACKEND copy back to v1, leave the local fsync'd copy at
+	// v2. LoadState's tie-break by SeqNum (or StateSeqNum) must prefer
+	// local v2; HMAC verify of v2 succeeds.
+	emptyHeaders := []byte{}
+	require.NoError(t, vb.Backend.Write(types.FileTypeConfig, 0, &emptyHeaders, &v1Backend))
+
+	// Reopen — must succeed and surface the v2 SeqNum, proving the
+	// backend rollback lost the tie-break.
+	vb2 := newFileBackedVB(t, "vol-rollback", key)
+	vb2.BaseDir = vb.BaseDir
+	require.NoError(t, vb2.LoadState())
+	assert.GreaterOrEqual(t, vb2.SeqNum.Load(), uint64(200),
+		"LoadState must select the higher-SeqNum local copy over the rolled-back backend")
+}
+
+// TestVBStateMeta_FirstOpenNoPriorState — a fresh encrypted volume with
+// no persisted VBState must bootstrap on the first SaveState (mint
+// VolumeUUID, seal a fresh blob with StateSeqNum=1). Subsequent
+// LoadState must verify successfully. This is the "blank slate"
+// case the metadata-HMAC chicken-and-egg discussion in the plan
+// resolves: no prior tag, no verify; the helper falls through to the
+// mint path.
+func TestVBStateMeta_FirstOpenNoPriorState(t *testing.T) {
+	key := testKey(t, 0x42)
+	dir := t.TempDir()
+	cfg := file.FileConfig{BaseDir: dir, VolumeName: "vol-fresh-meta"}
+	vb, err := New(&VB{
+		VolumeName:        "vol-fresh-meta",
+		VolumeSize:        4 * 1024 * 1024,
+		BaseDir:           dir,
+		MasterKey:         key,
+		EncryptionEnabled: true,
+	}, "file", cfg)
+	require.NoError(t, err)
+	require.NoError(t, vb.Backend.Init())
+	vb.BlockSize = DefaultBlockSize
+
+	// Pre-condition: no VBState on disk yet.
+	configPath := filepath.Join(dir, types.GetFilePath(types.FileTypeConfig, 0, vb.GetVolume()))
+	_, statErr := os.Stat(configPath)
+	require.True(t, os.IsNotExist(statErr), "fresh volume must not have a persisted VBState")
+
+	require.NoError(t, vb.SaveState(), "first SaveState bootstraps VolumeUUID and seals fresh blob")
+	var zero [4]byte
+	assert.NotEqual(t, zero, vb.VolumeUUID, "first SaveState must mint VolumeUUID")
+
+	// Reopen — LoadState must verify the freshly-sealed blob.
+	vb2 := newFileBackedVB(t, "vol-fresh-meta", key)
+	vb2.BaseDir = vb.BaseDir
+	require.NoError(t, vb2.LoadState())
+	assert.Equal(t, vb.VolumeUUID, vb2.VolumeUUID)
+}
+
+// TestSnapshotMeta_BitFlipFailsLoad — same primitive as VBState but
+// scoped to SnapshotState. A bit-flip in the persisted snapshot config
+// (post-seal) must fail at LoadSnapshotBlockMap.
+func TestSnapshotMeta_BitFlipFailsLoad(t *testing.T) {
+	env := newSnapshotEnv(t, "vol-snapmeta-bitflip", testKey(t, 0x42))
+	data := make([]byte, env.source.BlockSize)
+	_, err := rand.Read(data)
+	require.NoError(t, err)
+	require.NoError(t, env.source.Write(0, data))
+	require.NoError(t, env.source.Flush())
+	require.NoError(t, env.source.WriteWALToChunk(true))
+
+	snapshotID := "snap-bitflip"
+	_, err = env.source.CreateSnapshot(snapshotID)
+	require.NoError(t, err)
+
+	configPath := filepath.Join(env.dir, types.GetFilePath(types.FileTypeConfig, 0, snapshotID))
+	raw, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	raw[10] ^= 0x01
+	require.NoError(t, os.WriteFile(configPath, raw, 0600))
+
+	_, _, err = env.source.LoadSnapshotBlockMap(snapshotID)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrIntegrity)
+}
+
+// TestBlockStoreReadEncrypted — the BlockStore-enabled read path
+// (readBlockStore in viperblock.go) is a parallel implementation to the
+// legacy `read`. Each must independently decrypt chunks under the
+// volume's identity. The smoke covered by TestEncryptedRoundTrip_*
+// only checks one round-trip; this is the explicit assertion that the
+// BlockStore path's openChunkRun call wraps integrity failures the same
+// way as the legacy path.
+func TestBlockStoreReadEncrypted(t *testing.T) {
+	env := newEncryptedTamperEnv(t, "vol-blockstore-decrypt", testKey(t, 0x42))
+
+	plaintext := make([]byte, env.blockSize)
+	_, err := rand.Read(plaintext)
+	require.NoError(t, err)
+
+	env.vb.UseBlockStore = true
+	env.writeAndChunk(t, 0, plaintext)
+
+	// Sanity: BlockStore path returns plaintext.
+	got, err := env.vb.ReadAt(0, uint64(env.blockSize))
+	require.NoError(t, err)
+	require.Equal(t, plaintext, got, "BlockStore decrypt baseline failed")
+
+	// Now tamper a byte on the chunk and verify the BlockStore path
+	// also fails closed.
+	env.vb.BlockStore = NewUnifiedBlockStore(env.vb.BlockSize)
+	env.vb.BlocksToObject.mu.Lock()
+	env.vb.BlocksToObject.BlockLookup[0] = BlockLookup{
+		StartBlock:   0,
+		NumBlocks:    1,
+		ObjectID:     0,
+		ObjectOffset: uint32(env.blockOffset(0)),
+		SeqNum:       1,
+	}
+	env.vb.BlocksToObject.mu.Unlock()
+	env.vb.BlockStore.SetPersisted(0, 0, uint32(env.blockOffset(0)), 1)
+
+	raw, err := os.ReadFile(env.chunkPath(env.vb.VolumeName, 0))
+	require.NoError(t, err)
+	raw[env.blockOffset(0)+8] ^= 0x01
+	require.NoError(t, os.WriteFile(env.chunkPath(env.vb.VolumeName, 0), raw, 0600))
+
+	_, err = env.vb.ReadAt(0, uint64(env.blockSize))
+	require.Error(t, err, "BlockStore path must surface integrity failure")
+	assert.ErrorIs(t, err, ErrIntegrity)
+}
+
+// TestVBStateMeta_TruncatedBlobFails — a backend-side truncation of
+// the VBState blob below the 16-byte tag boundary must surface a
+// clear error rather than panic on the slice arithmetic in
+// LoadStateRequest. Defensive: an external operator who half-uploads
+// a backend object should see a refused open, not a runtime panic.
+func TestVBStateMeta_TruncatedBlobFails(t *testing.T) {
+	key := testKey(t, 0x42)
+	dir := t.TempDir()
+	cfg := file.FileConfig{BaseDir: dir, VolumeName: "vol-trunc"}
+	vb, err := New(&VB{
+		VolumeName:        "vol-trunc",
+		VolumeSize:        4 * 1024 * 1024,
+		BaseDir:           dir,
+		MasterKey:         key,
+		EncryptionEnabled: true,
+	}, "file", cfg)
+	require.NoError(t, err)
+	require.NoError(t, vb.Backend.Init())
+	vb.BlockSize = DefaultBlockSize
+	require.NoError(t, vb.SaveState())
+
+	configPath := filepath.Join(dir, types.GetFilePath(types.FileTypeConfig, 0, vb.GetVolume()))
+	// Truncate to fewer bytes than the tag length — must fail with a
+	// clear "shorter than tag" message, not a slice-bounds panic.
+	require.NoError(t, os.WriteFile(configPath, []byte{0x01, 0x02, 0x03}, 0600))
+
+	_, err = vb.LoadStateRequest(configPath)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrIntegrity)
+	// Make sure the error message is informative.
+	assert.Contains(t, err.Error(), "shorter")
+}

--- a/viperblock/encryption_meta_test.go
+++ b/viperblock/encryption_meta_test.go
@@ -108,21 +108,30 @@ func TestVBStateMeta_CrossVolumeSwapFailsLoad(t *testing.T) {
 }
 
 // TestVBStateMeta_RollbackLosesTieToFsync — write VBState v1, then v2,
-// then substitute the v1 backend copy. LoadState's existing tie-break
-// (highest SeqNum wins between local fsync and backend) must select
-// the local v2 copy; HMAC verify of v2 succeeds. This gates the
-// composition: HMAC alone does not stop replay of an older authentic
-// blob — the SeqNum comparison does. An attacker who rewinds the
-// backend copy is foiled because the local fsync'd copy holds a higher
-// StateSeqNum and wins the tie-break.
+// then v3, then substitute the v1 backend copy. LoadState's tie-break
+// by StateSeqNum (the SaveState generation counter, monotonic even
+// without data writes) must select the local v3 copy; HMAC verify of
+// v3 succeeds. This gates the composition: HMAC alone does not stop
+// replay of an older authentic blob — the StateSeqNum comparison does.
+// An attacker who rewinds the backend copy is foiled because the local
+// fsync'd copy holds a strictly higher StateSeqNum.
+//
+// The file backend writes config.json to {BaseDir}/{volume}/config.json,
+// which is the same path persistStateLocal uses. To genuinely simulate a
+// backend-only rollback we point the file backend at a separate directory
+// from vb.BaseDir, so local fsync'd state and the backend "object" live
+// in independent locations.
 func TestVBStateMeta_RollbackLosesTieToFsync(t *testing.T) {
 	key := testKey(t, 0x42)
-	dir := t.TempDir()
-	cfg := file.FileConfig{BaseDir: dir, VolumeName: "vol-rollback"}
+	localDir := t.TempDir()
+	backendDir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(localDir, "vol-rollback"), 0750))
+
+	cfg := file.FileConfig{BaseDir: backendDir, VolumeName: "vol-rollback"}
 	vb, err := New(&VB{
 		VolumeName:        "vol-rollback",
 		VolumeSize:        4 * 1024 * 1024,
-		BaseDir:           dir,
+		BaseDir:           localDir,
 		MasterKey:         key,
 		EncryptionEnabled: true,
 	}, "file", cfg)
@@ -131,34 +140,49 @@ func TestVBStateMeta_RollbackLosesTieToFsync(t *testing.T) {
 	vb.BlockSize = DefaultBlockSize
 
 	// v1: first SaveState. Snapshot the backend blob immediately so
-	// v1Backend captures the true v1 bytes (SeqNum=0), not a later rev.
+	// v1Backend captures the true v1 bytes (StateSeqNum=1), not a later rev.
 	require.NoError(t, vb.SaveState())
 	v1Backend, err := vb.Backend.Read(types.FileTypeConfig, 0, 0, 0)
 	require.NoError(t, err)
-	// v1Backend now holds the sealed v1 blob (SeqNum=0, StateSeqNum=1).
 
-	// v2: bump SeqNum and persist (overwrites backend and local fsync).
-	vb.SeqNum.Store(100)
+	// v2 and v3: two more SaveStates with no data writes between them.
+	// Each bump advances StateSeqNum (1 → 2 → 3) while the data-path
+	// SeqNum stays put. The bumpless interval is the exact case a
+	// data-path-SeqNum tiebreak would degenerate on.
+	require.NoError(t, vb.SaveState())
 	require.NoError(t, vb.SaveState())
 
-	// v3: bump SeqNum again and persist (overwrites backend and local
-	// fsync). After this, both backend and local hold v3 (SeqNum=200).
-	vb.SeqNum.Store(200)
-	require.NoError(t, vb.SaveState())
-
-	// Roll the BACKEND copy back to v1, leave the local fsync'd copy at
-	// v3. LoadState's tie-break by SeqNum (or StateSeqNum) must prefer
-	// the local higher-SeqNum copy; HMAC verify of v3 succeeds.
+	// Roll the BACKEND copy back to v1; local fsync'd copy still holds v3.
 	emptyHeaders := []byte{}
 	require.NoError(t, vb.Backend.Write(types.FileTypeConfig, 0, &emptyHeaders, &v1Backend))
 
-	// Reopen — must succeed and surface the v3 SeqNum, proving the
+	// Sanity: confirm local and backend now hold different bytes — local v3,
+	// backend v1. Without this guard a regression in the test setup (e.g.
+	// the file backend reverting to vb.BaseDir) would silently degenerate
+	// the assertion into a same-bytes comparison that passes trivially.
+	localPath := filepath.Join(vb.BaseDir, types.GetFilePath(types.FileTypeConfig, 0, "vol-rollback"))
+	localBytes, err := os.ReadFile(localPath)
+	require.NoError(t, err)
+	backendBytes, err := vb.Backend.Read(types.FileTypeConfig, 0, 0, 0)
+	require.NoError(t, err)
+	require.NotEqual(t, localBytes, backendBytes, "test setup must produce divergent local vs backend bytes")
+	require.Equal(t, v1Backend, backendBytes, "backend must hold rolled-back v1 bytes")
+
+	// Reopen — must succeed and surface the v3 StateSeqNum, proving the
 	// backend rollback lost the tie-break.
-	vb2 := newFileBackedVB(t, "vol-rollback", key)
-	vb2.BaseDir = vb.BaseDir
+	cfg2 := file.FileConfig{BaseDir: backendDir, VolumeName: "vol-rollback"}
+	vb2, err := New(&VB{
+		VolumeName:        "vol-rollback",
+		VolumeSize:        4 * 1024 * 1024,
+		BaseDir:           localDir,
+		MasterKey:         key,
+		EncryptionEnabled: true,
+	}, "file", cfg2)
+	require.NoError(t, err)
+	require.NoError(t, vb2.Backend.Init())
 	require.NoError(t, vb2.LoadState())
-	assert.GreaterOrEqual(t, vb2.SeqNum.Load(), uint64(200),
-		"LoadState must select the higher-SeqNum local copy over the rolled-back backend")
+	assert.GreaterOrEqual(t, vb2.nextStateSeqNum.Load(), uint64(3),
+		"LoadState must select the higher-StateSeqNum local copy over the rolled-back backend")
 }
 
 // TestVBStateMeta_FirstOpenNoPriorState — a fresh encrypted volume with

--- a/viperblock/encryption_meta_test.go
+++ b/viperblock/encryption_meta_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by an Apache 2.0 license
 // that can be found in the LICENSE file.
 
-// Stage 5 metadata HMAC tests. Closes the cross-volume metadata pivot
+// Metadata HMAC tests. Closes the cross-volume metadata pivot
 // critical: a backend writer cannot substitute volume A's tagged
 // VBState/SnapshotState into volume B's prefix, cannot bit-flip the
 // JSON, and cannot rollback to an older authentic blob without losing

--- a/viperblock/encryption_meta_test.go
+++ b/viperblock/encryption_meta_test.go
@@ -130,26 +130,29 @@ func TestVBStateMeta_RollbackLosesTieToFsync(t *testing.T) {
 	require.NoError(t, vb.Backend.Init())
 	vb.BlockSize = DefaultBlockSize
 
-	// v1: first SaveState. Snapshot the backend blob.
-	require.NoError(t, vb.SaveState())
-	// Force a write to bump SeqNum on disk so v1 vs v2 differ by more
-	// than just StateSeqNum.
-	vb.SeqNum.Store(100)
+	// v1: first SaveState. Snapshot the backend blob immediately so
+	// v1Backend captures the true v1 bytes (SeqNum=0), not a later rev.
 	require.NoError(t, vb.SaveState())
 	v1Backend, err := vb.Backend.Read(types.FileTypeConfig, 0, 0, 0)
 	require.NoError(t, err)
+	// v1Backend now holds the sealed v1 blob (SeqNum=0, StateSeqNum=1).
 
-	// v2: bump SeqNum and persist again.
+	// v2: bump SeqNum and persist (overwrites backend and local fsync).
+	vb.SeqNum.Store(100)
+	require.NoError(t, vb.SaveState())
+
+	// v3: bump SeqNum again and persist (overwrites backend and local
+	// fsync). After this, both backend and local hold v3 (SeqNum=200).
 	vb.SeqNum.Store(200)
 	require.NoError(t, vb.SaveState())
 
 	// Roll the BACKEND copy back to v1, leave the local fsync'd copy at
-	// v2. LoadState's tie-break by SeqNum (or StateSeqNum) must prefer
-	// local v2; HMAC verify of v2 succeeds.
+	// v3. LoadState's tie-break by SeqNum (or StateSeqNum) must prefer
+	// the local higher-SeqNum copy; HMAC verify of v3 succeeds.
 	emptyHeaders := []byte{}
 	require.NoError(t, vb.Backend.Write(types.FileTypeConfig, 0, &emptyHeaders, &v1Backend))
 
-	// Reopen — must succeed and surface the v2 SeqNum, proving the
+	// Reopen — must succeed and surface the v3 SeqNum, proving the
 	// backend rollback lost the tie-break.
 	vb2 := newFileBackedVB(t, "vol-rollback", key)
 	vb2.BaseDir = vb.BaseDir

--- a/viperblock/encryption_read_test.go
+++ b/viperblock/encryption_read_test.go
@@ -2,11 +2,11 @@
 // Use of this source code is governed by an Apache 2.0 license
 // that can be found in the LICENSE file.
 
-// Stage 3 round-trip smoke tests for the decrypt-on-read paths. The
-// comprehensive matrix (tamper detection, cross-volume swap, in-place
-// replay, snapshot-clone source identity, magic-bump rejection, property
-// tests) lands in Stage 5; these are the minimum to gate that the read
-// paths see plaintext after Stage 2 sealed it on write.
+// Round-trip smoke tests for the decrypt-on-read paths — the minimum to
+// gate that reads see plaintext after the write path sealed it. Deeper
+// coverage (tamper detection, cross-volume swap, in-place replay,
+// snapshot-clone source identity, magic-bump rejection, property tests)
+// lives in the dedicated tamper and snapshot test files.
 
 package viperblock
 

--- a/viperblock/encryption_read_test.go
+++ b/viperblock/encryption_read_test.go
@@ -1,0 +1,96 @@
+// Copyright 2026 Mulga Defense Corporation (MDC). All rights reserved.
+// Use of this source code is governed by an Apache 2.0 license
+// that can be found in the LICENSE file.
+
+// Stage 3 round-trip smoke tests for the decrypt-on-read paths. The
+// comprehensive matrix (tamper detection, cross-volume swap, in-place
+// replay, snapshot-clone source identity, magic-bump rejection, property
+// tests) lands in Stage 5; these are the minimum to gate that the read
+// paths see plaintext after Stage 2 sealed it on write.
+
+package viperblock
+
+import (
+	"bytes"
+	"crypto/rand"
+	"fmt"
+	"testing"
+
+	"github.com/mulgadc/viperblock/types"
+	"github.com/stretchr/testify/require"
+)
+
+func openWALsForReadTest(t *testing.T, vb *VB) {
+	t.Helper()
+	require.NoError(t, vb.OpenWAL(&vb.WAL, fmt.Sprintf("%s/%s", vb.WAL.BaseDir, types.GetFilePath(types.FileTypeWALChunk, vb.WAL.WallNum.Load(), vb.GetVolume()))))
+	require.NoError(t, vb.OpenWAL(&vb.BlockToObjectWAL, fmt.Sprintf("%s/%s", vb.BlockToObjectWAL.BaseDir, types.GetFilePath(types.FileTypeWALBlock, vb.BlockToObjectWAL.WallNum.Load(), vb.GetVolume()))))
+}
+
+func TestEncryptedRoundTrip_LegacyReadPath(t *testing.T) {
+	key := testKey(t, 0x42)
+	vb := newFileBackedVB(t, "vol-rt-legacy", key)
+	vb.BlockSize = DefaultBlockSize
+	vb.ObjBlockSize = 16 * DefaultBlockSize
+	require.NoError(t, vb.SaveState())
+	openWALsForReadTest(t, vb)
+
+	blockSize := uint64(vb.BlockSize)
+	payload := make([]byte, 2*blockSize)
+	_, err := rand.Read(payload)
+	require.NoError(t, err)
+
+	require.NoError(t, vb.WriteAt(0, payload))
+	require.NoError(t, vb.Flush())
+	require.NoError(t, vb.WriteWALToChunk(true))
+
+	got, err := vb.ReadAt(0, 2*blockSize)
+	require.NoError(t, err)
+	require.True(t, bytes.Equal(payload, got), "encrypted round-trip plaintext mismatch (legacy read)")
+}
+
+func TestEncryptedRoundTrip_BlockStorePath(t *testing.T) {
+	key := testKey(t, 0x42)
+	vb := newFileBackedVB(t, "vol-rt-blockstore", key)
+	vb.BlockSize = DefaultBlockSize
+	vb.ObjBlockSize = 16 * DefaultBlockSize
+	vb.UseBlockStore = true
+	vb.BlockStore = NewUnifiedBlockStore(vb.BlockSize)
+	require.NoError(t, vb.SaveState())
+	openWALsForReadTest(t, vb)
+
+	blockSize := uint64(vb.BlockSize)
+	payload := make([]byte, 3*blockSize)
+	_, err := rand.Read(payload)
+	require.NoError(t, err)
+
+	require.NoError(t, vb.WriteAt(0, payload))
+	require.NoError(t, vb.Flush())
+	require.NoError(t, vb.WriteWALToChunk(true))
+
+	got, err := vb.ReadAt(0, 3*blockSize)
+	require.NoError(t, err)
+	require.True(t, bytes.Equal(payload, got), "encrypted round-trip plaintext mismatch (blockstore read)")
+}
+
+func TestEncryptedRoundTrip_MultiChunk(t *testing.T) {
+	key := testKey(t, 0x42)
+	vb := newFileBackedVB(t, "vol-rt-multichunk", key)
+	vb.BlockSize = DefaultBlockSize
+	// Force two chunks: 2 blocks per chunk, write 5 blocks across them.
+	vb.ObjBlockSize = 2 * DefaultBlockSize
+	require.NoError(t, vb.SaveState())
+	openWALsForReadTest(t, vb)
+
+	blockSize := uint64(vb.BlockSize)
+	payload := make([]byte, 5*blockSize)
+	_, err := rand.Read(payload)
+	require.NoError(t, err)
+
+	require.NoError(t, vb.WriteAt(0, payload))
+	require.NoError(t, vb.Flush())
+	require.NoError(t, vb.WriteWALToChunk(true))
+
+	got, err := vb.ReadAt(0, 5*blockSize)
+	require.NoError(t, err)
+	require.True(t, bytes.Equal(payload, got), "encrypted multi-chunk round-trip plaintext mismatch")
+}

--- a/viperblock/encryption_snapshot_test.go
+++ b/viperblock/encryption_snapshot_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by an Apache 2.0 license
 // that can be found in the LICENSE file.
 
-// Stage 5 snapshot/clone encryption tests. Snapshot clones inherit the
+// Snapshot/clone encryption tests. Snapshot clones inherit the
 // source volume's encryption identity (SourceVolumeUUID,
 // SourceVolumeNameHash) so base-chunk reads decrypt under the source's
 // nonce + AAD, not the clone's. Any drift between source and clone

--- a/viperblock/encryption_snapshot_test.go
+++ b/viperblock/encryption_snapshot_test.go
@@ -1,0 +1,256 @@
+// Copyright 2026 Mulga Defense Corporation (MDC). All rights reserved.
+// Use of this source code is governed by an Apache 2.0 license
+// that can be found in the LICENSE file.
+
+// Stage 5 snapshot/clone encryption tests. Snapshot clones inherit the
+// source volume's encryption identity (SourceVolumeUUID,
+// SourceVolumeNameHash) so base-chunk reads decrypt under the source's
+// nonce + AAD, not the clone's. Any drift between source and clone
+// identity surfaces as ErrIntegrity; any tampering of the SnapshotState
+// blob surfaces as a metadata HMAC failure.
+
+package viperblock
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mulgadc/predastore/pkg/masterkey"
+	"github.com/mulgadc/viperblock/types"
+	"github.com/mulgadc/viperblock/viperblock/backends/file"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// snapshotEnv pairs a source VB with a shared file-backend BaseDir so
+// clones can reach the source's chunks via Backend.ReadFrom. Both VBs
+// place data under {baseDir}/{volumeName}/... so a clone opened with
+// SourceVolumeName=source.VolumeName will resolve the source's chunks
+// without any S3 indirection.
+type snapshotEnv struct {
+	source *VB
+	dir    string
+	key    *masterkey.Key
+}
+
+func newSnapshotEnv(t *testing.T, sourceName string, key *masterkey.Key) *snapshotEnv {
+	t.Helper()
+	dir := t.TempDir()
+	source := openEncryptedVBInDir(t, dir, sourceName, key)
+	return &snapshotEnv{source: source, dir: dir, key: key}
+}
+
+// openEncryptedVBInDir constructs an encrypted VB with file backend rooted
+// at dir, opens WAL files, and seeds VBState. Shared between source and
+// clone construction so the BaseDir + backend BaseDir + volume layout
+// stays consistent.
+func openEncryptedVBInDir(t *testing.T, dir, volumeName string, key *masterkey.Key) *VB {
+	t.Helper()
+	cfg := file.FileConfig{BaseDir: dir, VolumeName: volumeName}
+	vb, err := New(&VB{
+		VolumeName:        volumeName,
+		VolumeSize:        64 * 1024 * 1024,
+		BaseDir:           dir,
+		MasterKey:         key,
+		EncryptionEnabled: key != nil,
+		WALSyncInterval:   -1,
+	}, "file", cfg)
+	require.NoError(t, err)
+	require.NoError(t, vb.Backend.Init())
+	vb.BlockSize = DefaultBlockSize
+	vb.ObjBlockSize = 16 * DefaultBlockSize
+	require.NoError(t, vb.SaveState())
+	require.NoError(t, vb.OpenWAL(&vb.WAL,
+		fmt.Sprintf("%s/%s", vb.WAL.BaseDir, types.GetFilePath(types.FileTypeWALChunk, vb.WAL.WallNum.Load(), vb.GetVolume()))))
+	require.NoError(t, vb.OpenWAL(&vb.BlockToObjectWAL,
+		fmt.Sprintf("%s/%s", vb.BlockToObjectWAL.BaseDir, types.GetFilePath(types.FileTypeWALBlock, vb.BlockToObjectWAL.WallNum.Load(), vb.GetVolume()))))
+	return vb
+}
+
+// openEncryptedClone constructs an encrypted clone VB rooted at the same
+// dir as its source, loads the snapshot's base map, and returns the clone
+// ready for reads/writes.
+func (env *snapshotEnv) openEncryptedClone(t *testing.T, cloneName, snapshotID string) *VB {
+	t.Helper()
+	clone := openEncryptedVBInDir(t, env.dir, cloneName, env.key)
+	require.NoError(t, clone.OpenFromSnapshot(snapshotID))
+	return clone
+}
+
+// TestSnapshotEncrypted_PersistsSourceIdentity gates that CreateSnapshot
+// writes the source's VolumeUUID and volumeNameHash into SnapshotState in
+// hex form, and that LoadSnapshotBlockMap recovers both verbatim. Without
+// this, an encrypted clone has no way to reconstruct the source's nonce
+// + AAD and every base-chunk read fails.
+func TestSnapshotEncrypted_PersistsSourceIdentity(t *testing.T) {
+	env := newSnapshotEnv(t, "src-persist", testKey(t, 0x42))
+
+	data := make([]byte, env.source.BlockSize*4)
+	_, err := rand.Read(data)
+	require.NoError(t, err)
+	require.NoError(t, env.source.Write(0, data))
+	require.NoError(t, env.source.Flush())
+	require.NoError(t, env.source.WriteWALToChunk(true))
+
+	snapshotID := "snap-persist"
+	snap, err := env.source.CreateSnapshot(snapshotID)
+	require.NoError(t, err)
+	require.NotNil(t, snap)
+
+	assert.Equal(t, hex.EncodeToString(env.source.VolumeUUID[:]), snap.SourceVolumeUUID,
+		"snapshot must persist source VolumeUUID in hex")
+	assert.Equal(t, hex.EncodeToString(env.source.volumeNameHash[:]), snap.SourceVolumeNameHash,
+		"snapshot must persist source volumeNameHash in hex")
+	assert.NotZero(t, snap.StateSeqNum, "snapshot must allocate a StateSeqNum so its metadata HMAC is unique")
+
+	_, ident, err := env.source.LoadSnapshotBlockMap(snapshotID)
+	require.NoError(t, err)
+	assert.Equal(t, env.source.VolumeUUID, ident.SourceVolumeUUID,
+		"LoadSnapshotBlockMap must hex-decode SourceVolumeUUID back to [4]byte")
+	assert.Equal(t, env.source.volumeNameHash, ident.SourceVolumeNameHash)
+}
+
+// TestSnapshotEncrypted_CloneReadsBaseChunks — the clone opens the
+// snapshot and reads blocks 0-3 through the base-chunk path. Each read
+// must decrypt the source's chunks under the source's identity (the
+// clone's own VolumeUUID would produce a nonce mismatch and ErrIntegrity).
+// This is the end-to-end gate that SourceVolumeUUID / sourceVolumeNameHash
+// are plumbed correctly through OpenFromSnapshot →
+// fetchBaseBlocksFromBackend → openChunkRun.
+func TestSnapshotEncrypted_CloneReadsBaseChunks(t *testing.T) {
+	env := newSnapshotEnv(t, "src-clone-read", testKey(t, 0x42))
+
+	blockCount := uint64(4)
+	plaintext := make([]byte, uint64(env.source.BlockSize)*blockCount)
+	_, err := rand.Read(plaintext)
+	require.NoError(t, err)
+
+	require.NoError(t, env.source.Write(0, plaintext))
+	require.NoError(t, env.source.Flush())
+	require.NoError(t, env.source.WriteWALToChunk(true))
+
+	snapshotID := "snap-clone-read"
+	_, err = env.source.CreateSnapshot(snapshotID)
+	require.NoError(t, err)
+
+	clone := env.openEncryptedClone(t, "clone-base", snapshotID)
+	require.NotEqual(t, env.source.VolumeUUID, clone.VolumeUUID,
+		"clone must have its own VolumeUUID — otherwise this test is meaningless")
+	require.Equal(t, env.source.VolumeUUID, clone.SourceVolumeUUID,
+		"clone must carry the source VolumeUUID for base-chunk decrypt")
+
+	for i := range blockCount {
+		got, err := clone.ReadAt(i*uint64(clone.BlockSize), uint64(clone.BlockSize))
+		require.NoError(t, err, "clone read of block %d failed", i)
+		want := plaintext[i*uint64(env.source.BlockSize) : (i+1)*uint64(env.source.BlockSize)]
+		assert.True(t, bytes.Equal(want, got), "block %d plaintext mismatch", i)
+	}
+}
+
+// TestSnapshotEncrypted_CrossVolumeSubstitutionFailsHMAC — splicing a
+// snapshot from a different source into this snapshot's prefix (or
+// rewriting the hex SourceVolumeUUID field) must fail the metadata tag.
+// The AAD binds volumeNameHash, "snap:"||snapshotID, and StateSeqNum;
+// the JSON bytes are covered by the tag (sealMeta appends them to the
+// AAD), so any modification to the JSON content fails before any base
+// chunk is read. This is the cross-volume metadata pivot closer for
+// snapshots — the symmetric counterpart of the VBState test.
+func TestSnapshotEncrypted_CrossVolumeSubstitutionFailsHMAC(t *testing.T) {
+	env := newSnapshotEnv(t, "src-substitute", testKey(t, 0x42))
+
+	data := make([]byte, env.source.BlockSize)
+	_, err := rand.Read(data)
+	require.NoError(t, err)
+	require.NoError(t, env.source.Write(0, data))
+	require.NoError(t, env.source.Flush())
+	require.NoError(t, env.source.WriteWALToChunk(true))
+
+	snapshotID := "snap-substitute"
+	_, err = env.source.CreateSnapshot(snapshotID)
+	require.NoError(t, err)
+
+	// Tamper the SourceVolumeUUID in the JSON — this is what an attacker
+	// with backend write access would do to pivot a clone onto a
+	// different volume's chunks.
+	configPath := filepath.Join(env.dir, types.GetFilePath(types.FileTypeConfig, 0, snapshotID))
+	raw, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	// Decode the JSON (without the trailing tag) so we can find the
+	// SourceVolumeUUID field and flip a byte in the hex string.
+	tagLen := env.source.aead.Overhead()
+	jsonBytes := raw[:len(raw)-tagLen]
+	var snap SnapshotState
+	require.NoError(t, json.Unmarshal(jsonBytes, &snap))
+	require.NotEmpty(t, snap.SourceVolumeUUID)
+	// Flip the first hex char.
+	tampered := []byte(snap.SourceVolumeUUID)
+	if tampered[0] == '0' {
+		tampered[0] = '1'
+	} else {
+		tampered[0] = '0'
+	}
+	snap.SourceVolumeUUID = string(tampered)
+	tamperedJSON, err := json.Marshal(snap)
+	require.NoError(t, err)
+	// Append the original tag — verify must fail because the JSON bytes
+	// (which are part of the AAD via sealMeta) have changed.
+	newBlob := append(tamperedJSON, raw[len(raw)-tagLen:]...)
+	require.NoError(t, os.WriteFile(configPath, newBlob, 0600))
+
+	_, _, err = env.source.LoadSnapshotBlockMap(snapshotID)
+	require.Error(t, err, "tampered SnapshotState must fail HMAC verify")
+	assert.ErrorIs(t, err, ErrIntegrity)
+}
+
+// TestSnapshotEncrypted_CloneWriteUsesCloneIdentity — after the clone
+// writes to a block that wasn't in the snapshot, that block must be
+// sealed under the clone's own VolumeUUID + volumeNameHash (not the
+// source's). Read back via the clone returns the plaintext.
+//
+// Reading a block that IS in the snapshot still goes via the source
+// identity. Branching on (BlocksToObject hit vs BaseBlockMap hit) is
+// the production-side switch this test gates.
+func TestSnapshotEncrypted_CloneWriteUsesCloneIdentity(t *testing.T) {
+	env := newSnapshotEnv(t, "src-clone-write", testKey(t, 0x42))
+
+	srcData := make([]byte, env.source.BlockSize)
+	_, err := rand.Read(srcData)
+	require.NoError(t, err)
+	require.NoError(t, env.source.Write(0, srcData))
+	require.NoError(t, env.source.Flush())
+	require.NoError(t, env.source.WriteWALToChunk(true))
+
+	snapshotID := "snap-clone-write"
+	_, err = env.source.CreateSnapshot(snapshotID)
+	require.NoError(t, err)
+
+	clone := env.openEncryptedClone(t, "clone-write", snapshotID)
+
+	// Clone writes a new block (not in the snapshot) — must seal under
+	// clone identity.
+	cloneData := make([]byte, clone.BlockSize)
+	_, err = rand.Read(cloneData)
+	require.NoError(t, err)
+	require.NoError(t, clone.Write(10, cloneData))
+	require.NoError(t, clone.Flush())
+	require.NoError(t, clone.WriteWALToChunk(true))
+
+	// Read block 10 via clone — its own backend chunk, sealed under
+	// clone identity.
+	got, err := clone.ReadAt(10*uint64(clone.BlockSize), uint64(clone.BlockSize))
+	require.NoError(t, err)
+	assert.True(t, bytes.Equal(cloneData, got),
+		"clone read of its own block must round-trip plaintext")
+
+	// And block 0 still reads from the snapshot under source identity.
+	got, err = clone.ReadAt(0, uint64(clone.BlockSize))
+	require.NoError(t, err)
+	assert.True(t, bytes.Equal(srcData, got),
+		"clone read of source-snapshot block must still decrypt under source identity")
+}

--- a/viperblock/encryption_tamper_test.go
+++ b/viperblock/encryption_tamper_test.go
@@ -499,10 +499,11 @@ func randUint64(t *testing.T, upper uint64) uint64 {
 
 // TestEncryptedWAL_RecoveryAEADTamperSurfacesErrIntegrity — flipping a
 // single byte in an encrypted WAL record on the recovery path must
-// surface as ErrIntegrity from readWALFileForRecovery and the WAL file
-// must remain on disk so RecoverLocalWALs does NOT silently truncate
-// recovery. The legacy CRC path tolerates bit-rot and breaks the read
-// loop; AEAD failure is tamper, not rot, so we fail closed.
+// surface as ErrIntegrity from both readWALFileForRecovery and
+// RecoverLocalWALs. The tampered file stays on disk for forensics +
+// retry, and the caller refuses to bring the volume up. The legacy CRC
+// path tolerates bit-rot and breaks the read loop; AEAD failure is
+// tamper, not rot, so we fail closed and propagate.
 func TestEncryptedWAL_RecoveryAEADTamperSurfacesErrIntegrity(t *testing.T) {
 	env := newEncryptedTamperEnv(t, "vol-wal-recovery-tamper", testKey(t, 0x42))
 
@@ -543,13 +544,17 @@ func TestEncryptedWAL_RecoveryAEADTamperSurfacesErrIntegrity(t *testing.T) {
 	assert.ErrorIs(t, err, ErrIntegrity)
 	assert.Nil(t, blocks, "no blocks must be returned alongside an integrity error")
 
-	// 2) RecoverLocalWALs must NOT delete the tampered WAL file.
+	// 2) RecoverLocalWALs must propagate ErrIntegrity to the caller AND
+	// leave the tampered WAL file on disk. Silently continuing past a
+	// tampered file and reporting success would drop sealed writes that
+	// have no plaintext fallback.
 	_, statErr := os.Stat(walPath)
 	require.NoError(t, statErr, "WAL must still exist before RecoverLocalWALs")
 
-	require.NoError(t, env.vb.RecoverLocalWALs(),
-		"RecoverLocalWALs keeps tampered files for retry; it must not propagate the per-file error")
+	recoverErr := env.vb.RecoverLocalWALs()
+	require.Error(t, recoverErr, "RecoverLocalWALs must surface ErrIntegrity, not swallow it")
+	assert.ErrorIs(t, recoverErr, ErrIntegrity)
 
 	_, statErr = os.Stat(walPath)
-	assert.NoError(t, statErr, "tampered WAL must NOT be deleted by RecoverLocalWALs — silent truncation of recovery is the bug being fixed")
+	assert.NoError(t, statErr, "tampered WAL must NOT be deleted by RecoverLocalWALs — kept on disk for forensics + retry")
 }

--- a/viperblock/encryption_tamper_test.go
+++ b/viperblock/encryption_tamper_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by an Apache 2.0 license
 // that can be found in the LICENSE file.
 
-// Stage 5 tamper and on-disk integrity tests. Every test here exercises an
+// Tamper and on-disk integrity tests. Every test here exercises an
 // adversary action that the AEAD construction is supposed to detect:
 // - on-disk plaintext leakage (confidentiality — SC.L1-3.13.1)
 // - ciphertext / tag bit-flip (integrity — SI.L1-3.14.2)

--- a/viperblock/encryption_tamper_test.go
+++ b/viperblock/encryption_tamper_test.go
@@ -442,3 +442,60 @@ func randUint64(t *testing.T, upper uint64) uint64 {
 	require.NoError(t, err)
 	return n.Uint64()
 }
+
+// TestEncryptedWAL_RecoveryAEADTamperSurfacesErrIntegrity — flipping a
+// single byte in an encrypted WAL record on the recovery path must
+// surface as ErrIntegrity from readWALFileForRecovery and the WAL file
+// must remain on disk so RecoverLocalWALs does NOT silently truncate
+// recovery. The legacy CRC path tolerates bit-rot and breaks the read
+// loop; AEAD failure is tamper, not rot, so we fail closed.
+func TestEncryptedWAL_RecoveryAEADTamperSurfacesErrIntegrity(t *testing.T) {
+	env := newEncryptedTamperEnv(t, "vol-wal-recovery-tamper", testKey(t, 0x42))
+
+	// Write two records: tampering the SECOND one must not allow the
+	// caller to silently drop it (or any later records) on the floor.
+	plain0 := make([]byte, env.blockSize)
+	plain1 := make([]byte, env.blockSize)
+	_, err := rand.Read(plain0)
+	require.NoError(t, err)
+	_, err = rand.Read(plain1)
+	require.NoError(t, err)
+
+	require.NoError(t, env.vb.Write(0, plain0))
+	require.NoError(t, env.vb.Write(1, plain1))
+	require.NoError(t, env.vb.Flush())
+
+	walPath := filepath.Join(env.vb.WAL.BaseDir,
+		types.GetFilePath(types.FileTypeWALChunk, env.vb.WAL.WallNum.Load(), env.vb.GetVolume()))
+	env.vb.WAL.mu.Lock()
+	require.NoError(t, env.vb.WAL.DB[len(env.vb.WAL.DB)-1].Sync())
+	env.vb.WAL.mu.Unlock()
+
+	raw, err := os.ReadFile(walPath)
+	require.NoError(t, err)
+
+	headerSize := env.vb.WALHeaderSize()
+	recordSize := 40 + env.blockSize // 24-byte hdr + ct + 16-byte tag
+	// Flip a byte in the SECOND record's ciphertext body.
+	secondRecordStart := headerSize + recordSize
+	tamperOff := secondRecordStart + 24 + 10
+	require.Greater(t, len(raw), tamperOff)
+	raw[tamperOff] ^= 0x01
+	require.NoError(t, os.WriteFile(walPath, raw, 0600))
+
+	// 1) Direct call: readWALFileForRecovery must return ErrIntegrity.
+	blocks, _, err := env.vb.readWALFileForRecovery(walPath)
+	require.Error(t, err, "AEAD tamper must NOT be swallowed as a bit-rot tear")
+	assert.ErrorIs(t, err, ErrIntegrity)
+	assert.Nil(t, blocks, "no blocks must be returned alongside an integrity error")
+
+	// 2) RecoverLocalWALs must NOT delete the tampered WAL file.
+	_, statErr := os.Stat(walPath)
+	require.NoError(t, statErr, "WAL must still exist before RecoverLocalWALs")
+
+	require.NoError(t, env.vb.RecoverLocalWALs(),
+		"RecoverLocalWALs keeps tampered files for retry; it must not propagate the per-file error")
+
+	_, statErr = os.Stat(walPath)
+	assert.NoError(t, statErr, "tampered WAL must NOT be deleted by RecoverLocalWALs — silent truncation of recovery is the bug being fixed")
+}

--- a/viperblock/encryption_tamper_test.go
+++ b/viperblock/encryption_tamper_test.go
@@ -16,6 +16,7 @@ package viperblock
 import (
 	"bytes"
 	"crypto/rand"
+	"errors"
 	"fmt"
 	"math/big"
 	"os"
@@ -394,10 +395,63 @@ func TestEncryptedWAL_PreEncryptionMagicRejected(t *testing.T) {
 
 	err = env.vb.WriteWALToChunk(true)
 	require.Error(t, err, "VBWL magic must be rejected under encryption")
-	// Production returns "magic mismatch"; we don't constrain the
-	// exact text but it must not silently succeed and must not return
-	// an unrelated error like ErrZeroBlock.
+	// Under encryption, the magic mismatch must surface as
+	// ErrPreEncryptionFormat so callers (and operators) get an
+	// actionable migration signal rather than an opaque "magic
+	// mismatch" or a deep ErrIntegrity from a downstream AEAD open.
+	assert.ErrorIs(t, err, ErrPreEncryptionFormat)
 	assert.Contains(t, err.Error(), "magic")
+}
+
+// TestEncryptedChunk_PreEncryptionMagicRejected — an encrypted runtime
+// opening a chunk file that still carries the legacy VBCH magic must
+// surface ErrPreEncryptionFormat before any AEAD-open is attempted on
+// the body. Without this preflight, the chunk read path would feed
+// pre-encryption plaintext bytes to aead.Open and return a generic
+// ErrIntegrity, leaving operators with no actionable migration cue.
+func TestEncryptedChunk_PreEncryptionMagicRejected(t *testing.T) {
+	env := newEncryptedTamperEnv(t, "vol-chunk-vbch", testKey(t, 0x42))
+
+	plaintext := make([]byte, env.blockSize)
+	_, err := rand.Read(plaintext)
+	require.NoError(t, err)
+	env.writeAndChunk(t, 0, plaintext)
+
+	// Bypass caches so the next Read hits the backend (and therefore
+	// the magic preflight).
+	env.vb.BlockStore = NewUnifiedBlockStore(env.vb.BlockSize)
+	env.vb.UseBlockStore = false
+	env.vb.BlocksToObject.mu.Lock()
+	env.vb.BlocksToObject.BlockLookup[0] = BlockLookup{
+		StartBlock:   0,
+		NumBlocks:    1,
+		ObjectID:     0,
+		ObjectOffset: uint32(env.blockOffset(0)),
+		SeqNum:       1,
+	}
+	env.vb.BlocksToObject.mu.Unlock()
+
+	// Rewrite the chunk file's first 4 bytes to the legacy VBCH magic
+	// in place. The body stays valid VBCE ciphertext, but the
+	// preflight must reject before any decrypt is attempted.
+	chunkFile := env.chunkPath(env.vb.VolumeName, 0)
+	raw, err := os.ReadFile(chunkFile)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(raw), 4)
+	copy(raw[:4], []byte{'V', 'B', 'C', 'H'})
+	require.NoError(t, os.WriteFile(chunkFile, raw, 0600))
+
+	// Clear the magic-preflight memo so the preflight re-reads.
+	env.vb.chunkMagicChecked.Delete(fmt.Sprintf("%s:%d", env.vb.VolumeName, uint64(0)))
+
+	_, err = env.vb.ReadAt(0, uint64(env.blockSize))
+	require.Error(t, err, "VBCH chunk magic must be rejected under encryption")
+	assert.ErrorIs(t, err, ErrPreEncryptionFormat,
+		"chunk magic mismatch must surface as ErrPreEncryptionFormat, not a generic ErrIntegrity")
+	// Should NOT be ErrIntegrity — the whole point of the preflight is
+	// to avoid the AEAD-open path on pre-encryption data.
+	assert.False(t, errors.Is(err, ErrIntegrity),
+		"preflight must reject before AEAD open; got integrity error instead")
 }
 
 // TestEncrypted_PropertyRoundTrip — randomised write/read round-trip

--- a/viperblock/encryption_tamper_test.go
+++ b/viperblock/encryption_tamper_test.go
@@ -1,0 +1,444 @@
+// Copyright 2026 Mulga Defense Corporation (MDC). All rights reserved.
+// Use of this source code is governed by an Apache 2.0 license
+// that can be found in the LICENSE file.
+
+// Stage 5 tamper and on-disk integrity tests. Every test here exercises an
+// adversary action that the AEAD construction is supposed to detect:
+// - on-disk plaintext leakage (confidentiality — SC.L1-3.13.1)
+// - ciphertext / tag bit-flip (integrity — SI.L1-3.14.2)
+// - cross-volume chunk splice (AAD volumeNameHash binding)
+// - in-place rollback (AAD seqNum binding)
+// - WAL replay tamper (same primitive, WAL domain)
+// - pre-encryption WAL magic under encrypted runtime (migration gate)
+
+package viperblock
+
+import (
+	"bytes"
+	"crypto/rand"
+	"fmt"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mulgadc/predastore/pkg/masterkey"
+	"github.com/mulgadc/viperblock/types"
+	"github.com/mulgadc/viperblock/viperblock/backends/file"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// encryptedTamperEnv is the shared fixture for chunk/WAL tamper tests: a
+// file-backed encrypted VB with WAL files already open and a known
+// (BlockSize, ObjBlockSize) so on-disk offsets are predictable. ObjBlockSize
+// is intentionally small (16 blocks) so most tests fit in a single chunk
+// and the cross-chunk plumbing isn't on the critical path.
+type encryptedTamperEnv struct {
+	vb        *VB
+	dir       string
+	key       *masterkey.Key
+	blockSize int
+	stride    int // BlockSize + 16 (AEAD tag)
+	chunkHdr  int // ChunkHeaderSize()
+}
+
+func newEncryptedTamperEnv(t *testing.T, volume string, key *masterkey.Key) *encryptedTamperEnv {
+	t.Helper()
+	dir := t.TempDir()
+	cfg := file.FileConfig{BaseDir: dir, VolumeName: volume}
+	vb, err := New(&VB{
+		VolumeName:        volume,
+		VolumeSize:        64 * 1024 * 1024,
+		BaseDir:           dir,
+		MasterKey:         key,
+		EncryptionEnabled: key != nil,
+		WALSyncInterval:   -1,
+	}, "file", cfg)
+	require.NoError(t, err)
+	require.NoError(t, vb.Backend.Init())
+
+	vb.BlockSize = DefaultBlockSize
+	vb.ObjBlockSize = 16 * DefaultBlockSize
+	require.NoError(t, vb.SaveState())
+
+	require.NoError(t, vb.OpenWAL(&vb.WAL,
+		fmt.Sprintf("%s/%s", vb.WAL.BaseDir, types.GetFilePath(types.FileTypeWALChunk, vb.WAL.WallNum.Load(), vb.GetVolume()))))
+	require.NoError(t, vb.OpenWAL(&vb.BlockToObjectWAL,
+		fmt.Sprintf("%s/%s", vb.BlockToObjectWAL.BaseDir, types.GetFilePath(types.FileTypeWALBlock, vb.BlockToObjectWAL.WallNum.Load(), vb.GetVolume()))))
+
+	return &encryptedTamperEnv{
+		vb:        vb,
+		dir:       dir,
+		key:       key,
+		blockSize: int(vb.BlockSize),
+		stride:    int(vb.BlockSize) + 16,
+		chunkHdr:  vb.ChunkHeaderSize(),
+	}
+}
+
+// writeAndChunk writes data starting at the given block, flushes to WAL,
+// and consolidates the WAL into a chunk file. After it returns the block
+// lookup points to the new chunk; reads exercise the backend decrypt path.
+func (env *encryptedTamperEnv) writeAndChunk(t *testing.T, block uint64, data []byte) {
+	t.Helper()
+	require.NoError(t, env.vb.Write(block, data))
+	require.NoError(t, env.vb.Flush())
+	require.NoError(t, env.vb.WriteWALToChunk(true))
+}
+
+// chunkPath returns the on-disk path of the file backend's chunk file. The
+// file backend writes to {BaseDir}/{volume}/chunks/chunk.NNNNNNNN.bin —
+// see types.GetFilePath(FileTypeChunk, ...).
+func (env *encryptedTamperEnv) chunkPath(volume string, chunkID uint64) string {
+	return filepath.Join(env.dir, types.GetFilePath(types.FileTypeChunk, chunkID, volume))
+}
+
+// blockOffset returns the on-disk byte offset of the i-th block's
+// ciphertext within an encrypted chunk file (header + i*stride).
+func (env *encryptedTamperEnv) blockOffset(i int) int {
+	return env.chunkHdr + i*env.stride
+}
+
+// patternBlock fills a block-sized buffer with a recognizable byte
+// pattern so the on-disk plaintext-leakage test can check whether the
+// raw bytes contain the plaintext.
+func patternBlock(blockSize int, marker byte) []byte {
+	b := make([]byte, blockSize)
+	for i := range b {
+		b[i] = marker
+	}
+	return b
+}
+
+// TestEncryptedChunk_OnDiskNotPlaintext writes a recognizable plaintext
+// pattern, consolidates to a chunk file, and asserts (a) the chunk header
+// carries the VBCE magic, (b) the plaintext pattern does not appear
+// anywhere in the on-disk bytes. The block body and the 16-byte tag are
+// the only payload after the header, so a leak here means seal-on-write
+// regressed.
+func TestEncryptedChunk_OnDiskNotPlaintext(t *testing.T) {
+	env := newEncryptedTamperEnv(t, "vol-onsite-plain", testKey(t, 0x42))
+
+	data := patternBlock(env.blockSize, 0xAB) // a 4KiB run of 0xAB
+	env.writeAndChunk(t, 0, data)
+
+	raw, err := os.ReadFile(env.chunkPath(env.vb.VolumeName, 0))
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, len(raw), env.chunkHdr+env.stride, "chunk must contain header + one sealed block")
+	assert.Equal(t, "VBCE", string(raw[:4]), "encrypted chunks must carry VBCE magic")
+
+	// The whole-block 0xAB pattern as a contiguous run must not appear in
+	// the on-disk bytes — AEAD ciphertext is indistinguishable from random
+	// to an attacker without the key. We allow short coincidental 0xAB
+	// runs (a 16-byte run has ~2^-128 expected occurrences in random
+	// bytes) but a full BlockSize run is statistically impossible.
+	assert.False(t, bytes.Contains(raw, data), "encrypted chunk must not contain block-sized plaintext run")
+}
+
+// TestEncryptedChunk_TamperByteFailsRead — flipping a single byte inside
+// a sealed block's ciphertext body must surface as ErrIntegrity on read.
+// Sliced thin: the AEAD already catches this; we gate that the wrapper
+// path (openChunkRun in viperblock.go) wraps it in ErrIntegrity and
+// returns fail-closed rather than handing back partial plaintext.
+func TestEncryptedChunk_TamperByteFailsRead(t *testing.T) {
+	env := newEncryptedTamperEnv(t, "vol-byte-tamper", testKey(t, 0x42))
+
+	plaintext := make([]byte, env.blockSize)
+	_, err := rand.Read(plaintext)
+	require.NoError(t, err)
+	env.writeAndChunk(t, 0, plaintext)
+
+	// Read once via the decrypt path to confirm the baseline works — if
+	// this fails, the tamper test is meaningless because we'd be reading
+	// from the in-memory cache instead of the backend.
+	got, err := env.vb.ReadAt(0, uint64(env.blockSize))
+	require.NoError(t, err)
+	require.True(t, bytes.Equal(plaintext, got), "baseline decrypt failed; tamper test would be meaningless")
+
+	// Clear caches so the next read must hit the backend.
+	env.vb.BlockStore = NewUnifiedBlockStore(env.vb.BlockSize)
+	env.vb.BlocksToObject.mu.Lock()
+	env.vb.BlocksToObject.BlockLookup[0] = BlockLookup{
+		StartBlock:   0,
+		NumBlocks:    1,
+		ObjectID:     0,
+		ObjectOffset: uint32(env.blockOffset(0)),
+		SeqNum:       1, // first write under a fresh VB allocates SeqNum 1
+	}
+	env.vb.BlocksToObject.mu.Unlock()
+	env.vb.UseBlockStore = false
+
+	chunkFile := env.chunkPath(env.vb.VolumeName, 0)
+	raw, err := os.ReadFile(chunkFile)
+	require.NoError(t, err)
+	// Flip a byte in the middle of the ciphertext body.
+	raw[env.blockOffset(0)+10] ^= 0x01
+	require.NoError(t, os.WriteFile(chunkFile, raw, 0600))
+
+	_, err = env.vb.ReadAt(0, uint64(env.blockSize))
+	require.Error(t, err, "byte-tampered chunk must fail integrity check")
+	assert.ErrorIs(t, err, ErrIntegrity)
+}
+
+// TestEncryptedChunk_TagTamperFailsRead — flipping a byte inside the
+// trailing 16-byte tag, not the ciphertext body, must also fail. Same
+// primitive; this exercises the tag-region detection specifically so a
+// regression that excludes the tag from the verify step shows up here.
+func TestEncryptedChunk_TagTamperFailsRead(t *testing.T) {
+	env := newEncryptedTamperEnv(t, "vol-tag-tamper", testKey(t, 0x42))
+
+	plaintext := make([]byte, env.blockSize)
+	_, err := rand.Read(plaintext)
+	require.NoError(t, err)
+	env.writeAndChunk(t, 0, plaintext)
+
+	env.vb.BlockStore = NewUnifiedBlockStore(env.vb.BlockSize)
+	env.vb.UseBlockStore = false
+	env.vb.BlocksToObject.mu.Lock()
+	env.vb.BlocksToObject.BlockLookup[0] = BlockLookup{
+		StartBlock:   0,
+		NumBlocks:    1,
+		ObjectID:     0,
+		ObjectOffset: uint32(env.blockOffset(0)),
+		SeqNum:       1,
+	}
+	env.vb.BlocksToObject.mu.Unlock()
+
+	chunkFile := env.chunkPath(env.vb.VolumeName, 0)
+	raw, err := os.ReadFile(chunkFile)
+	require.NoError(t, err)
+	// Last byte of the first block's tag.
+	raw[env.blockOffset(0)+env.stride-1] ^= 0x01
+	require.NoError(t, os.WriteFile(chunkFile, raw, 0600))
+
+	_, err = env.vb.ReadAt(0, uint64(env.blockSize))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrIntegrity)
+}
+
+// TestEncryptedChunk_CrossVolumeSpliceFailsRead — sealing volume A's
+// chunk file, then overwriting volume B's chunk file with A's bytes at
+// the same offset, must fail integrity on B because the AAD's
+// volumeNameHash bound at seal time was A's, but B reconstructs the AAD
+// using B's volumeNameHash. This is SI.L1-3.14.2's positive case: a
+// backend writer with access to A's chunks cannot splice them into B's
+// prefix and have B read them as plaintext.
+func TestEncryptedChunk_CrossVolumeSpliceFailsRead(t *testing.T) {
+	key := testKey(t, 0x42) // same key — only the volume identity differs
+	envA := newEncryptedTamperEnv(t, "vol-A", key)
+	envB := newEncryptedTamperEnv(t, "vol-B", key)
+
+	// Both volumes must share an on-disk root so swapping the chunk file
+	// path is meaningful — but each test env uses its own t.TempDir(),
+	// so we copy A's chunk bytes into B's chunk file directly.
+	plaintext := make([]byte, envA.blockSize)
+	_, err := rand.Read(plaintext)
+	require.NoError(t, err)
+
+	envA.writeAndChunk(t, 0, plaintext)
+	// Make B write *something* so its chunk-0 file exists with the right
+	// header. We overwrite the body in-place below.
+	envB.writeAndChunk(t, 0, plaintext)
+
+	aBytes, err := os.ReadFile(envA.chunkPath(envA.vb.VolumeName, 0))
+	require.NoError(t, err)
+
+	// Splice block 0's sealed bytes from A into B's chunk file. Header
+	// stays B's (same magic, same version, same blocksize for an
+	// encrypted chunk), only the [ciphertext|tag] region is swapped.
+	bBytes, err := os.ReadFile(envB.chunkPath(envB.vb.VolumeName, 0))
+	require.NoError(t, err)
+	copy(bBytes[envB.blockOffset(0):envB.blockOffset(0)+envB.stride],
+		aBytes[envA.blockOffset(0):envA.blockOffset(0)+envA.stride])
+	require.NoError(t, os.WriteFile(envB.chunkPath(envB.vb.VolumeName, 0), bBytes, 0600))
+
+	// Force B's read to hit the backend rather than its in-memory cache.
+	envB.vb.BlockStore = NewUnifiedBlockStore(envB.vb.BlockSize)
+	envB.vb.UseBlockStore = false
+	envB.vb.BlocksToObject.mu.Lock()
+	envB.vb.BlocksToObject.BlockLookup[0] = BlockLookup{
+		StartBlock:   0,
+		NumBlocks:    1,
+		ObjectID:     0,
+		ObjectOffset: uint32(envB.blockOffset(0)),
+		SeqNum:       1,
+	}
+	envB.vb.BlocksToObject.mu.Unlock()
+
+	_, err = envB.vb.ReadAt(0, uint64(envB.blockSize))
+	require.Error(t, err, "cross-volume chunk splice must fail integrity")
+	assert.ErrorIs(t, err, ErrIntegrity)
+}
+
+// TestEncryptedChunk_InPlaceReplayFailsRead — block 5 written at SeqNum X
+// then again at SeqNum Y lives in two different chunks (the second write
+// allocates a new SeqNum and a new chunk). Splicing the SeqNum-X
+// ciphertext+tag into the SeqNum-Y chunk at the same per-block offset
+// must fail integrity: the BlockLookup says SeqNum Y, so the read
+// reconstructs the AAD with Y, but the sealed bytes were bound to X.
+// This is the only way to detect within-volume rollback when the
+// attacker has both an old ciphertext and write access to the backend.
+func TestEncryptedChunk_InPlaceReplayFailsRead(t *testing.T) {
+	env := newEncryptedTamperEnv(t, "vol-replay", testKey(t, 0x42))
+
+	older := make([]byte, env.blockSize)
+	newer := make([]byte, env.blockSize)
+	_, err := rand.Read(older)
+	require.NoError(t, err)
+	_, err = rand.Read(newer)
+	require.NoError(t, err)
+
+	// First write+chunk: block 5 at SeqNum N. Lookup -> chunk 0.
+	env.writeAndChunk(t, 5, older)
+
+	// Second write+chunk: block 5 at SeqNum N+something. Lookup -> chunk 1.
+	env.writeAndChunk(t, 5, newer)
+
+	env.vb.BlocksToObject.mu.RLock()
+	cur := env.vb.BlocksToObject.BlockLookup[5]
+	env.vb.BlocksToObject.mu.RUnlock()
+	require.Equal(t, uint64(1), cur.ObjectID, "second write must land in chunk 1")
+
+	// Splice the older sealed bytes from chunk 0 into chunk 1 at the
+	// same per-block offset. cur.ObjectOffset is where the SeqNum-N+x
+	// ciphertext currently lives in chunk 1; we overwrite that region
+	// with the SeqNum-N bytes from chunk 0.
+	chunk0, err := os.ReadFile(env.chunkPath(env.vb.VolumeName, 0))
+	require.NoError(t, err)
+	chunk1, err := os.ReadFile(env.chunkPath(env.vb.VolumeName, 1))
+	require.NoError(t, err)
+	// Both chunks have block 5 at the same per-block offset (single
+	// block per chunk in this scenario, header + 0*stride).
+	off0 := env.blockOffset(0)
+	off1 := int(cur.ObjectOffset)
+	copy(chunk1[off1:off1+env.stride], chunk0[off0:off0+env.stride])
+	require.NoError(t, os.WriteFile(env.chunkPath(env.vb.VolumeName, 1), chunk1, 0600))
+
+	// Force a backend re-read for block 5.
+	env.vb.BlockStore = NewUnifiedBlockStore(env.vb.BlockSize)
+	env.vb.UseBlockStore = false
+
+	_, err = env.vb.ReadAt(5*uint64(env.blockSize), uint64(env.blockSize))
+	require.Error(t, err, "in-place rollback splice must fail integrity")
+	assert.ErrorIs(t, err, ErrIntegrity)
+}
+
+// TestEncryptedWAL_TamperFailsReplay — a WAL record with a flipped body
+// byte must fail at WriteWALToChunk replay (AEAD on the WAL domain). The
+// 16-byte GCM tag subsumes the dropped CRC32; the legacy path returned
+// "checksum mismatch" — encrypted path returns ErrIntegrity.
+func TestEncryptedWAL_TamperFailsReplay(t *testing.T) {
+	env := newEncryptedTamperEnv(t, "vol-wal-tamper", testKey(t, 0x42))
+
+	plaintext := make([]byte, env.blockSize)
+	_, err := rand.Read(plaintext)
+	require.NoError(t, err)
+	require.NoError(t, env.vb.Write(0, plaintext))
+	require.NoError(t, env.vb.Flush())
+	// Don't WriteWALToChunk yet — we want to tamper the WAL bytes first.
+
+	walPath := filepath.Join(env.vb.WAL.BaseDir,
+		types.GetFilePath(types.FileTypeWALChunk, env.vb.WAL.WallNum.Load(), env.vb.GetVolume()))
+	// Sync so the WAL file on disk has the flushed record. The WAL
+	// syncer is disabled (WALSyncInterval=-1) so no background work
+	// will rewrite our tamper.
+	env.vb.WAL.mu.Lock()
+	require.NoError(t, env.vb.WAL.DB[len(env.vb.WAL.DB)-1].Sync())
+	env.vb.WAL.mu.Unlock()
+
+	raw, err := os.ReadFile(walPath)
+	require.NoError(t, err)
+	headerSize := env.vb.WALHeaderSize()
+	// Encrypted WAL record: [SeqNum(8)|BlockNum(8)|BlockLen(8)|ct(BlockSize)|tag(16)]
+	// Flip a byte inside the ciphertext.
+	require.Greater(t, len(raw), headerSize+24+10)
+	raw[headerSize+24+10] ^= 0x01
+	require.NoError(t, os.WriteFile(walPath, raw, 0600))
+
+	err = env.vb.WriteWALToChunk(true)
+	require.Error(t, err, "WAL replay must fail integrity on body tamper")
+	assert.ErrorIs(t, err, ErrIntegrity)
+}
+
+// TestEncryptedWAL_PreEncryptionMagicRejected — an encrypted runtime
+// opening a WAL file with the legacy VBWL magic must refuse before any
+// decrypt is attempted. The current production code path checks the
+// magic at the top of WriteWALToChunk's per-record loop (line ~1807) and
+// returns "magic mismatch". This is the migration gate: if a pre-cutover
+// WAL bleeds into a post-cutover daemon, it fails loud rather than
+// trying to AEAD-decrypt non-ciphertext and returning ErrIntegrity 4 MiB
+// into the read.
+func TestEncryptedWAL_PreEncryptionMagicRejected(t *testing.T) {
+	env := newEncryptedTamperEnv(t, "vol-wal-vbwl", testKey(t, 0x42))
+
+	// Write something so the WAL file exists, then rewrite its first 4
+	// bytes to the legacy VBWL magic in place.
+	plaintext := make([]byte, env.blockSize)
+	_, err := rand.Read(plaintext)
+	require.NoError(t, err)
+	require.NoError(t, env.vb.Write(0, plaintext))
+	require.NoError(t, env.vb.Flush())
+
+	walPath := filepath.Join(env.vb.WAL.BaseDir,
+		types.GetFilePath(types.FileTypeWALChunk, env.vb.WAL.WallNum.Load(), env.vb.GetVolume()))
+	env.vb.WAL.mu.Lock()
+	require.NoError(t, env.vb.WAL.DB[len(env.vb.WAL.DB)-1].Sync())
+	env.vb.WAL.mu.Unlock()
+
+	raw, err := os.ReadFile(walPath)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(raw), 4)
+	copy(raw[:4], []byte{'V', 'B', 'W', 'L'})
+	require.NoError(t, os.WriteFile(walPath, raw, 0600))
+
+	err = env.vb.WriteWALToChunk(true)
+	require.Error(t, err, "VBWL magic must be rejected under encryption")
+	// Production returns "magic mismatch"; we don't constrain the
+	// exact text but it must not silently succeed and must not return
+	// an unrelated error like ErrZeroBlock.
+	assert.Contains(t, err.Error(), "magic")
+}
+
+// TestEncrypted_PropertyRoundTrip — randomised write/read round-trip
+// across varying block alignments, run lengths, and starting offsets.
+// Catches stride / offset / AAD-binding regressions that fixed-pattern
+// tests would miss (e.g. a missing seqNum slot in BlockLookup
+// serialisation would only surface on the second or third chunk).
+func TestEncrypted_PropertyRoundTrip(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping property round-trip in short mode")
+	}
+	env := newEncryptedTamperEnv(t, "vol-property", testKey(t, 0x42))
+
+	const trials = 32
+	bs := uint64(env.blockSize)
+	// Volume has 64 MiB / 4 KiB = 16384 blocks; we cap at 64 blocks per
+	// run and 1024 starting blocks to keep the per-trial cost low.
+	for trial := range trials {
+		startBlock := randUint64(t, 1024)
+		runBlocks := randUint64(t, 64) + 1
+		buf := make([]byte, runBlocks*bs)
+		_, err := rand.Read(buf)
+		require.NoError(t, err)
+
+		require.NoError(t, env.vb.Write(startBlock, buf))
+		require.NoError(t, env.vb.Flush())
+		require.NoError(t, env.vb.WriteWALToChunk(true))
+
+		got, err := env.vb.ReadAt(startBlock*bs, runBlocks*bs)
+		require.NoError(t, err, "trial %d: read failed", trial)
+		require.True(t, bytes.Equal(buf, got),
+			"trial %d: plaintext mismatch (startBlock=%d runBlocks=%d)", trial, startBlock, runBlocks)
+	}
+}
+
+// randUint64 returns a uniformly random uint64 in [0, upper) using
+// crypto/rand. Test-only — fail the test on any RNG error rather than
+// silently returning 0 (which would skew the property distribution).
+func randUint64(t *testing.T, upper uint64) uint64 {
+	t.Helper()
+	n, err := rand.Int(rand.Reader, big.NewInt(int64(upper)))
+	require.NoError(t, err)
+	return n.Uint64()
+}

--- a/viperblock/encryption_test.go
+++ b/viperblock/encryption_test.go
@@ -2,10 +2,10 @@
 // Use of this source code is governed by an Apache 2.0 license
 // that can be found in the LICENSE file.
 
-// Stage 1 unit tests for the encryption-at-rest plumbing — minimal coverage
-// for the new code paths (New validation, writeFileAtomic, SaveState first-
-// open bootstrap, LoadState fingerprint + high-water advance, reserveSeqNum
-// slow path, bumpSeqNumHighWater). Stage 5 lands the comprehensive matrix.
+// Unit tests for the encryption-at-rest plumbing — coverage for New
+// validation, writeFileAtomic, SaveState first-open bootstrap, LoadState
+// fingerprint + high-water advance, reserveSeqNum slow path, and
+// bumpSeqNumHighWater.
 
 package viperblock
 

--- a/viperblock/encryption_test.go
+++ b/viperblock/encryption_test.go
@@ -270,6 +270,42 @@ func TestReserveSeqNum_ConcurrentCallersSerializeHighWaterBumps(t *testing.T) {
 	assert.Zero(t, hw%seqNumReservation, "high-water advances in multiples of seqNumReservation")
 }
 
+// A failed SaveState in the high-water slow path must not publish the
+// speculative high-water to vb.seqNumHighWater. If it did, concurrent
+// fast-path callers would issue SeqNums above the persisted high-water; a
+// crash + restart would restore vb.SeqNum from the lower on-disk value and
+// re-issue the same SeqNums, causing AES-GCM nonce reuse under the same
+// (key, VolumeUUID, domain) triple (NIST SP 800-38D §8.3 — catastrophic).
+func TestReserveSeqNum_FailedSaveStateDoesNotPublishHighWater(t *testing.T) {
+	key := testKey(t, 0x42)
+	vb := newFileBackedVB(t, "vol-faulty", key)
+	vb.BlockSize = DefaultBlockSize
+	require.NoError(t, vb.SaveState())
+
+	hwBefore := vb.seqNumHighWater.Load()
+
+	// Wedge both writeFileAtomic (local) and Backend.Write (file backend) by
+	// removing the directory both target. The next SaveState's tmp-file
+	// OpenFile fails immediately.
+	configDir := filepath.Join(vb.BaseDir, vb.GetVolume())
+	require.NoError(t, os.RemoveAll(configDir))
+
+	vb.SeqNum.Store(hwBefore + 5)
+	_, err := vb.reserveSeqNum(1)
+	require.Error(t, err, "reserveSeqNum must propagate SaveState failure")
+
+	assert.Equal(t, hwBefore, vb.seqNumHighWater.Load(),
+		"failed SaveState must not publish the speculative high-water")
+
+	// And after the failure is cleared, a successor reservation must persist
+	// and publish the same target hw — no skipped window, no double-count.
+	require.NoError(t, os.MkdirAll(configDir, 0700))
+	_, err = vb.reserveSeqNum(1)
+	require.NoError(t, err)
+	assert.Greater(t, vb.seqNumHighWater.Load(), hwBefore,
+		"successor reservation persists and publishes new high-water")
+}
+
 func TestSaveState_AtomicRenameLeavesNoTmp(t *testing.T) {
 	key := testKey(t, 0x42)
 	vb := newFileBackedVB(t, "vol-atomic", key)

--- a/viperblock/encryption_test.go
+++ b/viperblock/encryption_test.go
@@ -1,0 +1,295 @@
+// Copyright 2026 Mulga Defense Corporation (MDC). All rights reserved.
+// Use of this source code is governed by an Apache 2.0 license
+// that can be found in the LICENSE file.
+
+// Stage 1 unit tests for the encryption-at-rest plumbing — minimal coverage
+// for the new code paths (New validation, writeFileAtomic, SaveState first-
+// open bootstrap, LoadState fingerprint + high-water advance, reserveSeqNum
+// slow path, bumpSeqNumHighWater). Stage 5 lands the comprehensive matrix.
+
+package viperblock
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/mulgadc/predastore/pkg/masterkey"
+	"github.com/mulgadc/viperblock/viperblock/backends/file"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testKey builds a deterministic *masterkey.Key from a single seed byte so
+// tests can assert against KeyFingerprint mismatch by varying the seed.
+func testKey(t *testing.T, seed byte) *masterkey.Key {
+	t.Helper()
+	var raw [masterkey.MasterKeySize]byte
+	for i := range raw {
+		raw[i] = seed
+	}
+	aead, err := masterkey.NewAEAD(raw[:])
+	require.NoError(t, err)
+	return &masterkey.Key{
+		AEAD:        aead,
+		Fingerprint: masterkey.Fingerprint(raw[:]),
+	}
+}
+
+// newFileBackedVB stands up a viperblock instance against a file backend in a
+// temp dir — no predastore server required, so these tests run cheaply.
+func newFileBackedVB(t *testing.T, name string, key *masterkey.Key) *VB {
+	t.Helper()
+	dir := t.TempDir()
+	cfg := file.FileConfig{BaseDir: dir, VolumeName: name}
+	vb, err := New(&VB{
+		VolumeName:        name,
+		VolumeSize:        4 * 1024 * 1024,
+		BaseDir:           dir,
+		MasterKey:         key,
+		EncryptionEnabled: key != nil,
+	}, "file", cfg)
+	require.NoError(t, err)
+	require.NoError(t, vb.Backend.Init())
+	return vb
+}
+
+func TestNew_EncryptionInvariants(t *testing.T) {
+	dir := t.TempDir()
+	cfg := file.FileConfig{BaseDir: dir, VolumeName: "vol-1"}
+
+	t.Run("flag without key", func(t *testing.T) {
+		_, err := New(&VB{
+			VolumeName:        "vol-1",
+			VolumeSize:        4096,
+			BaseDir:           dir,
+			EncryptionEnabled: true,
+		}, "file", cfg)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrEncryptionMismatch)
+	})
+
+	t.Run("key without flag", func(t *testing.T) {
+		_, err := New(&VB{
+			VolumeName: "vol-1",
+			VolumeSize: 4096,
+			BaseDir:    dir,
+			MasterKey:  testKey(t, 0x42),
+		}, "file", cfg)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrEncryptionMismatch)
+	})
+
+	t.Run("encryption with sharded WAL", func(t *testing.T) {
+		_, err := New(&VB{
+			VolumeName:        "vol-1",
+			VolumeSize:        4096,
+			BaseDir:           dir,
+			MasterKey:         testKey(t, 0x42),
+			EncryptionEnabled: true,
+			UseShardedWAL:     true,
+		}, "file", cfg)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrEncryptionMismatch)
+	})
+
+	t.Run("happy path", func(t *testing.T) {
+		vb, err := New(&VB{
+			VolumeName:        "vol-1",
+			VolumeSize:        4096,
+			BaseDir:           dir,
+			MasterKey:         testKey(t, 0x42),
+			EncryptionEnabled: true,
+		}, "file", cfg)
+		require.NoError(t, err)
+		require.NotNil(t, vb.aead)
+		assert.Equal(t, computeVolumeNameHash("vol-1"), vb.volumeNameHash)
+	})
+}
+
+func TestWriteFileAtomic_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "atomic.bin")
+	payload := []byte("hello, durable world")
+
+	require.NoError(t, writeFileAtomic(path, payload, 0600))
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, payload, got)
+
+	// Overwrite — atomic rename must replace cleanly without leaving the tmp.
+	updated := []byte("second generation")
+	require.NoError(t, writeFileAtomic(path, updated, 0600))
+	got, err = os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, updated, got)
+	_, err = os.Stat(path + ".tmp")
+	assert.True(t, errors.Is(err, os.ErrNotExist), "tmp file should not remain after rename")
+}
+
+func TestSaveState_BootstrapsVolumeUUIDAndHighWater(t *testing.T) {
+	key := testKey(t, 0x42)
+	vb := newFileBackedVB(t, "vol-bootstrap", key)
+	vb.BlockSize = DefaultBlockSize
+
+	var zero [4]byte
+	require.Equal(t, zero, vb.VolumeUUID, "fresh VB starts with zero UUID")
+	require.NoError(t, vb.SaveState())
+
+	assert.NotEqual(t, zero, vb.VolumeUUID, "SaveState mints UUID on first encrypted persist")
+	assert.Equal(t, seqNumReservation, vb.seqNumHighWater.Load(), "first SaveState seeds high-water to one reservation")
+
+	// Round-trip via a second VB and LoadState — fingerprint must match,
+	// high-water must advance, and SeqNum must restart at the prior high-water.
+	vb2 := newFileBackedVB(t, "vol-bootstrap", key)
+	vb2.BaseDir = vb.BaseDir
+	vb2.BlockSize = DefaultBlockSize
+	require.NoError(t, vb2.LoadState())
+	assert.Equal(t, vb.VolumeUUID, vb2.VolumeUUID, "VolumeUUID survives LoadState")
+	assert.Equal(t, seqNumReservation, vb2.SeqNum.Load(), "SeqNum restarts at the persisted high-water")
+	assert.Equal(t, 2*seqNumReservation, vb2.seqNumHighWater.Load(), "LoadState advances high-water by one reservation")
+}
+
+func TestLoadState_KeyFingerprintMismatch(t *testing.T) {
+	keyA := testKey(t, 0x01)
+	keyB := testKey(t, 0x02)
+	require.NotEqual(t, keyA.Fingerprint, keyB.Fingerprint)
+
+	vb := newFileBackedVB(t, "vol-fp", keyA)
+	vb.BlockSize = DefaultBlockSize
+	require.NoError(t, vb.SaveState())
+
+	// Reopen with the wrong key. The mismatch must surface as a clear error,
+	// not silent decrypt failure later.
+	vb2 := newFileBackedVB(t, "vol-fp", keyB)
+	vb2.BaseDir = vb.BaseDir
+	err := vb2.LoadState()
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrEncryptionMismatch)
+}
+
+func TestLoadState_RuntimeEncryptionFlagMustMatchPersisted(t *testing.T) {
+	key := testKey(t, 0x99)
+	vb := newFileBackedVB(t, "vol-enc", key)
+	vb.BlockSize = DefaultBlockSize
+	require.NoError(t, vb.SaveState())
+
+	// Reopen claiming no encryption — must refuse.
+	plain := newFileBackedVB(t, "vol-enc", nil)
+	plain.BaseDir = vb.BaseDir
+	err := plain.LoadState()
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrEncryptionMismatch)
+}
+
+func TestReserveSeqNum_FastAndSlowPath(t *testing.T) {
+	key := testKey(t, 0x42)
+	vb := newFileBackedVB(t, "vol-reserve", key)
+	vb.BlockSize = DefaultBlockSize
+	require.NoError(t, vb.SaveState())
+
+	hwBefore := vb.seqNumHighWater.Load()
+
+	// Fast path: a single reservation well below the high-water must not
+	// bump it (no extra SaveState).
+	start, err := vb.reserveSeqNum(10)
+	require.NoError(t, err)
+	assert.Equal(t, hwBefore, vb.seqNumHighWater.Load(), "fast path must not advance high-water")
+	assert.Equal(t, start+10, vb.SeqNum.Load(), "reservation advances SeqNum by n")
+
+	// Slow path: jump SeqNum past the current window and reserve one. The
+	// helper must bump the high-water and persist.
+	vb.SeqNum.Store(hwBefore + 5)
+	_, err = vb.reserveSeqNum(1)
+	require.NoError(t, err)
+	assert.Greater(t, vb.seqNumHighWater.Load(), hwBefore, "slow path must advance high-water")
+}
+
+func TestReserveSeqNum_UnencryptedFallthrough(t *testing.T) {
+	dir := t.TempDir()
+	cfg := file.FileConfig{BaseDir: dir, VolumeName: "vol-plain"}
+	vb, err := New(&VB{
+		VolumeName: "vol-plain",
+		VolumeSize: 4096,
+		BaseDir:    dir,
+	}, "file", cfg)
+	require.NoError(t, err)
+	require.NoError(t, vb.Backend.Init())
+
+	// Plain atomic.Add — no high-water consultation.
+	start, err := vb.reserveSeqNum(5)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(0), start)
+	assert.Equal(t, uint64(5), vb.SeqNum.Load())
+}
+
+func TestReserveSeqNum_RefusesPastMaxSeqNum(t *testing.T) {
+	key := testKey(t, 0x42)
+	vb := newFileBackedVB(t, "vol-overflow", key)
+	vb.BlockSize = DefaultBlockSize
+	require.NoError(t, vb.SaveState())
+
+	// Set SeqNum to one below the limit so a 2-wide reservation would cross it.
+	vb.SeqNum.Store(MaxSeqNum - 1)
+	_, err := vb.reserveSeqNum(2)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds 56-bit nonce limit")
+}
+
+func TestReserveSeqNum_ConcurrentCallersSerializeHighWaterBumps(t *testing.T) {
+	key := testKey(t, 0x42)
+	vb := newFileBackedVB(t, "vol-concurrent", key)
+	vb.BlockSize = DefaultBlockSize
+	require.NoError(t, vb.SaveState())
+
+	// Drive reservations past the initial window from multiple goroutines —
+	// the slow path is mutex-protected, so the final high-water must be a
+	// multiple of seqNumReservation and bounded by SeqNum.
+	const (
+		goroutines = 8
+		perWorker  = 16
+	)
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for range goroutines {
+		go func() {
+			defer wg.Done()
+			for range perWorker {
+				_, err := vb.reserveSeqNum(1)
+				assert.NoError(t, err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	hw := vb.seqNumHighWater.Load()
+	assert.GreaterOrEqual(t, hw, vb.SeqNum.Load(), "high-water must cover all handed-out SeqNums")
+	assert.Zero(t, hw%seqNumReservation, "high-water advances in multiples of seqNumReservation")
+}
+
+func TestSaveState_AtomicRenameLeavesNoTmp(t *testing.T) {
+	key := testKey(t, 0x42)
+	vb := newFileBackedVB(t, "vol-atomic", key)
+	vb.BlockSize = DefaultBlockSize
+	require.NoError(t, vb.SaveState())
+	require.NoError(t, vb.SaveState())
+
+	// The config.json must exist, the .tmp must not.
+	configDir := filepath.Join(vb.BaseDir, vb.GetVolume())
+	entries, err := os.ReadDir(configDir)
+	require.NoError(t, err)
+	var sawConfig bool
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		assert.False(t, strings.HasSuffix(e.Name(), ".tmp"), "no .tmp should remain: %s", e.Name())
+		if e.Name() == "config.json" {
+			sawConfig = true
+		}
+	}
+	assert.True(t, sawConfig, "config.json must exist after SaveState")
+}

--- a/viperblock/masterkey_load.go
+++ b/viperblock/masterkey_load.go
@@ -1,0 +1,30 @@
+// Copyright 2026 Mulga Defense Corporation (MDC). All rights reserved.
+// Use of this source code is governed by an Apache 2.0 license
+// that can be found in the LICENSE file.
+
+package viperblock
+
+import (
+	"os"
+
+	"github.com/mulgadc/predastore/pkg/masterkey"
+)
+
+// EncryptionKeyEnv names the environment variable that supplies the master
+// key file path when no CLI flag is given.
+const EncryptionKeyEnv = "ENCRYPTION_KEY_FILE"
+
+// LoadMasterKeyFromFlagOrEnv resolves a master-key file path from flagValue,
+// falling back to the ENCRYPTION_KEY_FILE environment variable when flagValue
+// is empty. Returns (nil, nil) when neither is set so the caller can run the
+// volume unencrypted; otherwise loads via masterkey.LoadShared.
+func LoadMasterKeyFromFlagOrEnv(flagValue string) (*masterkey.Key, error) {
+	keyPath := flagValue
+	if keyPath == "" {
+		keyPath = os.Getenv(EncryptionKeyEnv)
+	}
+	if keyPath == "" {
+		return nil, nil
+	}
+	return masterkey.LoadShared(keyPath)
+}

--- a/viperblock/snapshot.go
+++ b/viperblock/snapshot.go
@@ -133,10 +133,10 @@ func (vb *VB) LoadSnapshotBlockMap(snapshotID string) (*BlocksToObject, string, 
 		return nil, "", fmt.Errorf("snapshot checkpoint version mismatch")
 	}
 
-	// 4. Validate checkpoint size: must contain only complete 26-byte entries after header
+	// 4. Validate checkpoint size: must contain only complete entries after header.
 	dataSize := len(checkpoint) - headerSize
-	if dataSize%26 != 0 {
-		return nil, "", fmt.Errorf("snapshot checkpoint has %d trailing bytes (data section %d bytes is not a multiple of 26-byte entries)", dataSize%26, dataSize)
+	if dataSize%blockWalChunkSize != 0 {
+		return nil, "", fmt.Errorf("snapshot checkpoint has %d trailing bytes (data section %d bytes is not a multiple of %d-byte entries)", dataSize%blockWalChunkSize, dataSize, blockWalChunkSize)
 	}
 
 	// 5. Deserialize block lookup entries
@@ -145,13 +145,13 @@ func (vb *VB) LoadSnapshotBlockMap(snapshotID string) (*BlocksToObject, string, 
 	}
 
 	offset := headerSize
-	for offset+26 <= len(checkpoint) {
-		block, err := vb.readBlockWalChunk(checkpoint[offset : offset+26])
+	for offset+blockWalChunkSize <= len(checkpoint) {
+		block, err := vb.readBlockWalChunk(checkpoint[offset : offset+blockWalChunkSize])
 		if err != nil {
 			return nil, "", fmt.Errorf("failed to read snapshot block entry at offset %d: %w", offset, err)
 		}
 		baseMap.BlockLookup[block.StartBlock] = block
-		offset += 26
+		offset += blockWalChunkSize
 	}
 
 	// 6. Validate block count against metadata if available (BlockCount > 0 means

--- a/viperblock/snapshot.go
+++ b/viperblock/snapshot.go
@@ -25,6 +25,11 @@ import (
 // keep SnapshotState plaintext-readable for operator debugging — JSON would
 // base64-encode fixed-size byte arrays. Empty on snapshots of unencrypted
 // volumes (zero-valued, ignored on the read path).
+//
+// StateSeqNum is the source volume's VB.nextStateSeqNum value at the moment
+// CreateSnapshot sealed this state — bound into the snapshot-meta nonce so
+// back-to-back snapshots on the same volume use disjoint nonces (domain
+// separation alone does not protect two seals in the same domain).
 type SnapshotState struct {
 	SnapshotID           string    `json:"SnapshotID"`
 	SourceVolumeName     string    `json:"SourceVolumeName"`
@@ -36,6 +41,7 @@ type SnapshotState struct {
 	CreatedAt            time.Time `json:"CreatedAt"`
 	SourceVolumeUUID     string    `json:"SourceVolumeUUID,omitempty"`
 	SourceVolumeNameHash string    `json:"SourceVolumeNameHash,omitempty"`
+	StateSeqNum          uint64    `json:"StateSeqNum,omitempty"`
 }
 
 // CreateSnapshot flushes all in-flight data and creates a frozen snapshot of
@@ -98,6 +104,18 @@ func (vb *VB) CreateSnapshot(snapshotID string) (*SnapshotState, error) {
 	if vb.EncryptionEnabled {
 		snap.SourceVolumeUUID = hex.EncodeToString(vb.VolumeUUID[:])
 		snap.SourceVolumeNameHash = hex.EncodeToString(vb.volumeNameHash[:])
+		snap.StateSeqNum = vb.nextStateSeqNum.Add(1)
+		// Persist the bumped counter before sealing under it: a crash
+		// between this Add and the next SaveState would otherwise reset
+		// nextStateSeqNum to the previously persisted value on restart,
+		// letting a subsequent snapshot re-issue snap.StateSeqNum and
+		// reuse this nonce under the same (key, VolumeUUID, domain=0x03)
+		// triple — catastrophic for AES-GCM. SaveState bumps once more
+		// for its own VBState, so the durable high-water lands at
+		// snap.StateSeqNum + 1 (or higher under concurrent saves).
+		if err := vb.SaveState(); err != nil {
+			return nil, fmt.Errorf("snapshot StateSeqNum persist: %w", err)
+		}
 	}
 
 	snapJSON, err := json.Marshal(snap)
@@ -105,7 +123,19 @@ func (vb *VB) CreateSnapshot(snapshotID string) (*SnapshotState, error) {
 		return nil, fmt.Errorf("failed to marshal snapshot state: %w", err)
 	}
 
-	if err := vb.Backend.WriteTo(snapshotID, types.FileTypeConfig, 0, &emptyHeaders, &snapJSON); err != nil {
+	// Encrypted snapshots append a 16-byte AES-GCM tag binding the JSON to
+	// (volumeNameHash, "snap:"||snapshotID, StateSeqNum). The snapshotID
+	// literal in the AAD prevents cross-snapshot splicing under the same key;
+	// tampering with any persisted field (SourceVolumeUUID, BlockCount, etc.)
+	// breaks verification because the JSON bytes are part of the covered AAD.
+	persisted := snapJSON
+	if vb.EncryptionEnabled {
+		nonce := makeNonce(snap.StateSeqNum, vb.VolumeUUID, DomainSnapshotMeta)
+		aad := makeMetaAAD(vb.volumeNameHash, "snap:"+snapshotID, snap.StateSeqNum)
+		persisted = sealMeta(vb.aead, snapJSON, aad, nonce)
+	}
+
+	if err := vb.Backend.WriteTo(snapshotID, types.FileTypeConfig, 0, &emptyHeaders, &persisted); err != nil {
 		return nil, fmt.Errorf("failed to write snapshot config: %w", err)
 	}
 
@@ -134,6 +164,48 @@ func (vb *VB) LoadSnapshotBlockMap(snapshotID string) (*BlocksToObject, Snapshot
 	configData, err := vb.Backend.ReadFrom(snapshotID, types.FileTypeConfig, 0, 0, 0)
 	if err != nil {
 		return nil, ident, fmt.Errorf("failed to read snapshot config %s: %w", snapshotID, err)
+	}
+
+	// Encrypted snapshots carry a trailing 16-byte AES-GCM tag. Two-stage
+	// parse: peek the pre-tag bytes for SourceVolumeUUID +
+	// SourceVolumeNameHash + StateSeqNum (needed to reconstruct nonce + AAD),
+	// verify, then unmarshal the verified bytes into the full struct. The
+	// snapshotID parameter is the trusted external identity bound into the
+	// AAD — splicing in another snapshot's blob fails because the literal
+	// "snap:"||snapshotID differs from the seal-time value.
+	if vb.EncryptionEnabled {
+		tagLen := vb.aead.Overhead()
+		if len(configData) < tagLen {
+			return nil, ident, fmt.Errorf("%w: snapshot %s config %d bytes shorter than %d-byte tag", ErrIntegrity, snapshotID, len(configData), tagLen)
+		}
+		var peek struct {
+			SourceVolumeUUID     string `json:"SourceVolumeUUID"`
+			SourceVolumeNameHash string `json:"SourceVolumeNameHash"`
+			StateSeqNum          uint64 `json:"StateSeqNum"`
+		}
+		peekJSON := configData[:len(configData)-tagLen]
+		if err := json.Unmarshal(peekJSON, &peek); err != nil {
+			return nil, ident, fmt.Errorf("%w: snapshot %s peek parse: %w", ErrIntegrity, snapshotID, err)
+		}
+		uuid, uuidErr := hex.DecodeString(peek.SourceVolumeUUID)
+		if uuidErr != nil || len(uuid) != 4 {
+			return nil, ident, fmt.Errorf("%w: snapshot %s SourceVolumeUUID invalid", ErrIntegrity, snapshotID)
+		}
+		nameHash, nhErr := hex.DecodeString(peek.SourceVolumeNameHash)
+		if nhErr != nil || len(nameHash) != 32 {
+			return nil, ident, fmt.Errorf("%w: snapshot %s SourceVolumeNameHash invalid", ErrIntegrity, snapshotID)
+		}
+		var nonceUUID [4]byte
+		copy(nonceUUID[:], uuid)
+		var aadNameHash [32]byte
+		copy(aadNameHash[:], nameHash)
+		nonce := makeNonce(peek.StateSeqNum, nonceUUID, DomainSnapshotMeta)
+		aad := makeMetaAAD(aadNameHash, "snap:"+snapshotID, peek.StateSeqNum)
+		verified, openErr := openMeta(vb.aead, configData, aad, nonce)
+		if openErr != nil {
+			return nil, ident, fmt.Errorf("%w: snapshot %s tag verify: %w", ErrIntegrity, snapshotID, openErr)
+		}
+		configData = verified
 	}
 
 	var snap SnapshotState

--- a/viperblock/snapshot.go
+++ b/viperblock/snapshot.go
@@ -7,6 +7,7 @@ package viperblock
 import (
 	"bytes"
 	"encoding/binary"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -16,15 +17,25 @@ import (
 )
 
 // SnapshotState holds metadata for a frozen snapshot stored on the backend.
+//
+// SourceVolumeUUID + SourceVolumeNameHash carry the source volume's
+// encryption identity forward so a clone reading base chunks via
+// fetchBaseBlocksFromBackend reconstructs the source's nonce + AAD, not the
+// clone's. Both are hex strings (8 chars / 64 chars) rather than [N]byte to
+// keep SnapshotState plaintext-readable for operator debugging — JSON would
+// base64-encode fixed-size byte arrays. Empty on snapshots of unencrypted
+// volumes (zero-valued, ignored on the read path).
 type SnapshotState struct {
-	SnapshotID       string    `json:"SnapshotID"`
-	SourceVolumeName string    `json:"SourceVolumeName"`
-	SeqNum           uint64    `json:"SeqNum"`
-	ObjectNum        uint64    `json:"ObjectNum"`
-	BlockSize        uint32    `json:"BlockSize"`
-	ObjBlockSize     uint32    `json:"ObjBlockSize"`
-	BlockCount       uint64    `json:"BlockCount"`
-	CreatedAt        time.Time `json:"CreatedAt"`
+	SnapshotID           string    `json:"SnapshotID"`
+	SourceVolumeName     string    `json:"SourceVolumeName"`
+	SeqNum               uint64    `json:"SeqNum"`
+	ObjectNum            uint64    `json:"ObjectNum"`
+	BlockSize            uint32    `json:"BlockSize"`
+	ObjBlockSize         uint32    `json:"ObjBlockSize"`
+	BlockCount           uint64    `json:"BlockCount"`
+	CreatedAt            time.Time `json:"CreatedAt"`
+	SourceVolumeUUID     string    `json:"SourceVolumeUUID,omitempty"`
+	SourceVolumeNameHash string    `json:"SourceVolumeNameHash,omitempty"`
 }
 
 // CreateSnapshot flushes all in-flight data and creates a frozen snapshot of
@@ -84,6 +95,11 @@ func (vb *VB) CreateSnapshot(snapshotID string) (*SnapshotState, error) {
 		CreatedAt:        time.Now(),
 	}
 
+	if vb.EncryptionEnabled {
+		snap.SourceVolumeUUID = hex.EncodeToString(vb.VolumeUUID[:])
+		snap.SourceVolumeNameHash = hex.EncodeToString(vb.volumeNameHash[:])
+	}
+
 	snapJSON, err := json.Marshal(snap)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal snapshot state: %w", err)
@@ -97,46 +113,74 @@ func (vb *VB) CreateSnapshot(snapshotID string) (*SnapshotState, error) {
 	return snap, nil
 }
 
+// SnapshotIdentity carries the source volume's encryption-identity fields
+// recovered from SnapshotState so clone reads can reconstruct the source's
+// nonce + AAD. Zero-valued on snapshots of unencrypted volumes; callers
+// branch on vb.EncryptionEnabled rather than testing zero.
+type SnapshotIdentity struct {
+	SourceVolumeName     string
+	SourceVolumeUUID     [4]byte
+	SourceVolumeNameHash [32]byte
+}
+
 // LoadSnapshotBlockMap reads a snapshot's frozen block-to-object map from the
-// backend and returns it along with the source volume name. The returned
-// BlocksToObject is intended to be used as a read-only base map for clone
-// volumes.
-func (vb *VB) LoadSnapshotBlockMap(snapshotID string) (*BlocksToObject, string, error) {
+// backend and returns it along with the source volume's encryption identity.
+// The returned BlocksToObject is intended to be used as a read-only base map
+// for clone volumes.
+func (vb *VB) LoadSnapshotBlockMap(snapshotID string) (*BlocksToObject, SnapshotIdentity, error) {
+	var ident SnapshotIdentity
+
 	// 1. Read snapshot config
 	configData, err := vb.Backend.ReadFrom(snapshotID, types.FileTypeConfig, 0, 0, 0)
 	if err != nil {
-		return nil, "", fmt.Errorf("failed to read snapshot config %s: %w", snapshotID, err)
+		return nil, ident, fmt.Errorf("failed to read snapshot config %s: %w", snapshotID, err)
 	}
 
 	var snap SnapshotState
 	if err := json.Unmarshal(configData, &snap); err != nil {
-		return nil, "", fmt.Errorf("failed to parse snapshot config %s: %w", snapshotID, err)
+		return nil, ident, fmt.Errorf("failed to parse snapshot config %s: %w", snapshotID, err)
+	}
+
+	ident.SourceVolumeName = snap.SourceVolumeName
+	if snap.SourceVolumeUUID != "" {
+		uuid, err := hex.DecodeString(snap.SourceVolumeUUID)
+		if err != nil || len(uuid) != 4 {
+			return nil, ident, fmt.Errorf("snapshot %s: invalid SourceVolumeUUID %q", snapshotID, snap.SourceVolumeUUID)
+		}
+		copy(ident.SourceVolumeUUID[:], uuid)
+	}
+	if snap.SourceVolumeNameHash != "" {
+		nameHash, err := hex.DecodeString(snap.SourceVolumeNameHash)
+		if err != nil || len(nameHash) != 32 {
+			return nil, ident, fmt.Errorf("snapshot %s: invalid SourceVolumeNameHash", snapshotID)
+		}
+		copy(ident.SourceVolumeNameHash[:], nameHash)
 	}
 
 	// 2. Read the checkpoint
 	checkpoint, err := vb.Backend.ReadFrom(snapshotID, types.FileTypeBlockCheckpoint, 0, 0, 0)
 	if err != nil {
-		return nil, "", fmt.Errorf("failed to read snapshot checkpoint %s: %w", snapshotID, err)
+		return nil, ident, fmt.Errorf("failed to read snapshot checkpoint %s: %w", snapshotID, err)
 	}
 
 	// 3. Validate header
 	headerSize := vb.BlockToObjectWALHeaderSize()
 	if len(checkpoint) < headerSize {
-		return nil, "", fmt.Errorf("snapshot checkpoint too small: %d bytes", len(checkpoint))
+		return nil, ident, fmt.Errorf("snapshot checkpoint too small: %d bytes", len(checkpoint))
 	}
 
 	headers := checkpoint[:headerSize]
 	if !bytes.Equal(headers[:4], vb.BlockToObjectWAL.WALMagic[:]) {
-		return nil, "", fmt.Errorf("snapshot checkpoint magic mismatch")
+		return nil, ident, fmt.Errorf("snapshot checkpoint magic mismatch")
 	}
 	if binary.BigEndian.Uint16(headers[4:6]) != vb.Version {
-		return nil, "", fmt.Errorf("snapshot checkpoint version mismatch")
+		return nil, ident, fmt.Errorf("snapshot checkpoint version mismatch")
 	}
 
 	// 4. Validate checkpoint size: must contain only complete entries after header.
 	dataSize := len(checkpoint) - headerSize
 	if dataSize%blockWalChunkSize != 0 {
-		return nil, "", fmt.Errorf("snapshot checkpoint has %d trailing bytes (data section %d bytes is not a multiple of %d-byte entries)", dataSize%blockWalChunkSize, dataSize, blockWalChunkSize)
+		return nil, ident, fmt.Errorf("snapshot checkpoint has %d trailing bytes (data section %d bytes is not a multiple of %d-byte entries)", dataSize%blockWalChunkSize, dataSize, blockWalChunkSize)
 	}
 
 	// 5. Deserialize block lookup entries
@@ -148,7 +192,7 @@ func (vb *VB) LoadSnapshotBlockMap(snapshotID string) (*BlocksToObject, string, 
 	for offset+blockWalChunkSize <= len(checkpoint) {
 		block, err := vb.readBlockWalChunk(checkpoint[offset : offset+blockWalChunkSize])
 		if err != nil {
-			return nil, "", fmt.Errorf("failed to read snapshot block entry at offset %d: %w", offset, err)
+			return nil, ident, fmt.Errorf("failed to read snapshot block entry at offset %d: %w", offset, err)
 		}
 		baseMap.BlockLookup[block.StartBlock] = block
 		offset += blockWalChunkSize
@@ -157,7 +201,7 @@ func (vb *VB) LoadSnapshotBlockMap(snapshotID string) (*BlocksToObject, string, 
 	// 6. Validate block count against metadata if available (BlockCount > 0 means
 	// the snapshot was created with the block count field present)
 	if snap.BlockCount > 0 && uint64(len(baseMap.BlockLookup)) != snap.BlockCount {
-		return nil, "", fmt.Errorf("snapshot block count mismatch: metadata says %d, checkpoint has %d", snap.BlockCount, len(baseMap.BlockLookup))
+		return nil, ident, fmt.Errorf("snapshot block count mismatch: metadata says %d, checkpoint has %d", snap.BlockCount, len(baseMap.BlockLookup))
 	}
 
 	slog.Debug("LoadSnapshotBlockMap: loaded",
@@ -165,31 +209,37 @@ func (vb *VB) LoadSnapshotBlockMap(snapshotID string) (*BlocksToObject, string, 
 		"sourceVolume", snap.SourceVolumeName,
 		"blocks", len(baseMap.BlockLookup))
 
-	return baseMap, snap.SourceVolumeName, nil
+	return baseMap, ident, nil
 }
 
 // OpenFromSnapshot loads the base block map from a snapshot and configures
 // this volume for copy-on-write reads. After calling this, reads that miss
 // in the volume's own block map will fall through to the snapshot's frozen
 // map and read chunk data from the source volume.
+//
+// For encrypted clones the source volume's VolumeUUID + volumeNameHash are
+// plumbed onto vb so fetchBaseBlocksFromBackend can decrypt source chunks
+// under the source's identity (its nonce/AAD), not the clone's own.
 func (vb *VB) OpenFromSnapshot(snapshotID string) error {
-	baseMap, sourceVolume, err := vb.LoadSnapshotBlockMap(snapshotID)
+	baseMap, ident, err := vb.LoadSnapshotBlockMap(snapshotID)
 	if err != nil {
 		return err
 	}
 
-	if sourceVolume == "" {
+	if ident.SourceVolumeName == "" {
 		return fmt.Errorf("snapshot %s has empty SourceVolumeName", snapshotID)
 	}
 
 	vb.BaseBlockMap = baseMap
-	vb.SourceVolumeName = sourceVolume
+	vb.SourceVolumeName = ident.SourceVolumeName
 	vb.SnapshotID = snapshotID
+	vb.SourceVolumeUUID = ident.SourceVolumeUUID
+	vb.sourceVolumeNameHash = ident.SourceVolumeNameHash
 
 	slog.Debug("OpenFromSnapshot: clone ready",
 		"volume", vb.VolumeName,
 		"snapshotID", snapshotID,
-		"sourceVolume", sourceVolume,
+		"sourceVolume", ident.SourceVolumeName,
 		"baseBlocks", len(baseMap.BlockLookup))
 
 	return nil
@@ -197,9 +247,11 @@ func (vb *VB) OpenFromSnapshot(snapshotID string) error {
 
 // LookupBaseBlockToObject looks up a block in the base (snapshot) block map.
 // Returns ErrZeroBlock if the block was never written in the snapshot either.
-func (vb *VB) LookupBaseBlockToObject(block uint64) (uint64, uint32, error) {
+// The SeqNum return drives source-volume nonce + AAD reconstruction for
+// encrypted clones; on unencrypted volumes callers ignore it.
+func (vb *VB) LookupBaseBlockToObject(block uint64) (uint64, uint32, uint64, error) {
 	if vb.BaseBlockMap == nil {
-		return 0, 0, ErrZeroBlock
+		return 0, 0, 0, ErrZeroBlock
 	}
 
 	vb.BaseBlockMap.mu.RLock()
@@ -207,7 +259,7 @@ func (vb *VB) LookupBaseBlockToObject(block uint64) (uint64, uint32, error) {
 	vb.BaseBlockMap.mu.RUnlock()
 
 	if !ok {
-		return 0, 0, ErrZeroBlock
+		return 0, 0, 0, ErrZeroBlock
 	}
-	return lookup.ObjectID, lookup.ObjectOffset, nil
+	return lookup.ObjectID, lookup.ObjectOffset, lookup.SeqNum, nil
 }

--- a/viperblock/snapshot_test.go
+++ b/viperblock/snapshot_test.go
@@ -42,9 +42,9 @@ func TestCreateSnapshot(t *testing.T) {
 		assert.Equal(t, vb.ObjBlockSize, snap.ObjBlockSize)
 
 		// Verify we can load the snapshot block map back
-		baseMap, sourceVol, err := vb.LoadSnapshotBlockMap(snapshotID)
+		baseMap, ident, err := vb.LoadSnapshotBlockMap(snapshotID)
 		require.NoError(t, err)
-		assert.Equal(t, vb.VolumeName, sourceVol)
+		assert.Equal(t, vb.VolumeName, ident.SourceVolumeName)
 		assert.Equal(t, len(vb.BlocksToObject.BlockLookup), len(baseMap.BlockLookup))
 
 		// Verify each block mapping matches

--- a/viperblock/viperblock.go
+++ b/viperblock/viperblock.go
@@ -82,7 +82,7 @@ type VBState struct {
 	// encrypted volume. SeqNumHighWater is the durable upper bound on the
 	// next SeqNum the volume may hand out post-restart — crash-safe nonce
 	// uniqueness. StateSeqNum is a monotonic SaveState generation counter
-	// used by the metadata HMAC (Stage 4) and to break ties in LoadState.
+	// used by the metadata HMAC and to break ties in LoadState.
 	// KeyFingerprint surfaces master-key mismatch at Open with a clear error
 	// instead of silent decrypt failure.
 	EncryptionEnabled bool    `json:"EncryptionEnabled,omitempty"`
@@ -181,8 +181,8 @@ type VB struct {
 	// refuses. volumeNameHash is SHA256(VolumeName) cached at New for AAD
 	// construction. VolumeUUID is the per-volume nonce subspace, persisted in
 	// VBState. SourceVolumeUUID / sourceVolumeNameHash carry the source
-	// volume's identity when this is a snapshot clone (Stage 3 populates
-	// them from SnapshotState; Stage 1 leaves them zero).
+	// volume's identity when this is a snapshot clone, populated from
+	// SnapshotState on OpenFromSnapshot and zero otherwise.
 	MasterKey            *masterkey.Key
 	EncryptionEnabled    bool
 	aead                 cipher.AEAD
@@ -210,9 +210,9 @@ type VB struct {
 	seqNumHighWaterMu sync.Mutex
 
 	// nextStateSeqNum is the monotonic SaveState generation counter mirrored
-	// from VBState.StateSeqNum. Each SaveState increments it before marshal.
-	// Stage 4 binds the value into the VBState metadata HMAC; Stage 1 uses
-	// it only for LoadState tie-breaking.
+	// from VBState.StateSeqNum. Each SaveState increments it before marshal;
+	// the value is bound into the VBState metadata HMAC and breaks ties when
+	// LoadState picks between local and backend copies.
 	nextStateSeqNum atomic.Uint64
 }
 
@@ -1517,9 +1517,9 @@ func (vb *VB) WriteBlockWAL(blocks *[]BlockLookup) (err error) {
 //
 //	[StartBlock(8) | NumBlocks(2) | ObjectID(8) | ObjectOffset(4) | SeqNum(8) | CRC32(4)]
 //
-// SeqNum was added to drive nonce + AAD reconstruction on the decrypt path
-// (Stage 3); the field is populated unconditionally so encrypted and
-// unencrypted volumes share a single checkpoint format. Pre-encryption
+// SeqNum drives nonce + AAD reconstruction on the decrypt path; the field
+// is populated unconditionally so encrypted and unencrypted volumes share
+// a single checkpoint format. Pre-encryption
 // checkpoints written under the previous 26-byte layout are unreadable by
 // post-cutover binaries — volumes must be recreated. CRC32 is retained on
 // metadata because the checkpoint stays plaintext (not AEAD-sealed).
@@ -2768,8 +2768,8 @@ func (vb *VB) LookupBlockToObject(block uint64) (objectID uint64, objectOffset u
 // For encrypted volumes, SaveState bootstraps the per-volume nonce subspace
 // on first call: if VolumeUUID is zero we mint it via crypto/rand and seed
 // SeqNumHighWater = seqNumReservation. Subsequent calls preserve the existing
-// UUID and advance StateSeqNum monotonically (Stage 4 binds the value into
-// the metadata HMAC). The local write is atomic — tmp file + fsync + rename
+// UUID and advance StateSeqNum monotonically (the value is bound into the
+// metadata HMAC). The local write is atomic — tmp file + fsync + rename
 // + fsync parent dir — so a crash mid-persist cannot leave a torn config.json
 // that would let reserveSeqNum re-hand-out values on restart.
 func (vb *VB) SaveState() error {
@@ -2810,7 +2810,7 @@ func (vb *VB) SaveState() error {
 		SeqNumHighWater:     vb.seqNumHighWater.Load(),
 	}
 
-	if vb.EncryptionEnabled && vb.MasterKey != nil {
+	if vb.EncryptionEnabled {
 		state.KeyFingerprint = vb.MasterKey.Fingerprint
 	}
 
@@ -2999,12 +2999,11 @@ func (vb *VB) LoadState() error {
 		if vb.MasterKey == nil {
 			return fmt.Errorf("%w: volume %s requires master key", ErrEncryptionMismatch, vb.VolumeName)
 		}
-		if state.KeyFingerprint != "" && state.KeyFingerprint != vb.MasterKey.Fingerprint {
+		if state.KeyFingerprint != vb.MasterKey.Fingerprint {
 			return fmt.Errorf("%w: volume %s sealed under key %s, supplied key is %s",
 				ErrEncryptionMismatch, vb.VolumeName, state.KeyFingerprint, vb.MasterKey.Fingerprint)
 		}
 		vb.VolumeUUID = state.VolumeUUID
-		vb.volumeNameHash = computeVolumeNameHash(state.VolumeName)
 		vb.SeqNum.Store(state.SeqNumHighWater)
 		vb.seqNumHighWater.Store(state.SeqNumHighWater)
 		if err := vb.bumpSeqNumHighWater(); err != nil {
@@ -3120,7 +3119,7 @@ func (vb *VB) LoadStateRequest(filename string) (state VBState, err error) {
 		if err := json.Unmarshal(peekJSON, &peek); err != nil {
 			return state, fmt.Errorf("%w: VBState peek parse: %w", ErrIntegrity, err)
 		}
-		if peek.KeyFingerprint != "" && peek.KeyFingerprint != vb.MasterKey.Fingerprint {
+		if peek.KeyFingerprint != vb.MasterKey.Fingerprint {
 			return state, fmt.Errorf("%w: volume %s sealed under key %s, supplied key is %s",
 				ErrEncryptionMismatch, vb.VolumeName, peek.KeyFingerprint, vb.MasterKey.Fingerprint)
 		}

--- a/viperblock/viperblock.go
+++ b/viperblock/viperblock.go
@@ -2699,14 +2699,27 @@ func (vb *VB) SaveState() error {
 		return err
 	}
 
+	// Encrypted volumes append a 16-byte AES-GCM tag binding the JSON bytes to
+	// (volumeNameHash, "vbstate", StateSeqNum). Closes the cross-volume
+	// metadata pivot: an attacker swapping volume A's config.json into volume
+	// B's prefix is rejected at LoadStateRequest because the AAD
+	// reconstruction uses vb.volumeNameHash (our own identity), which differs
+	// from the seal-time hash for volume A.
+	persisted := jsonData
+	if vb.EncryptionEnabled {
+		nonce := makeNonce(state.StateSeqNum, vb.VolumeUUID, DomainVBStateMeta)
+		aad := makeMetaAAD(vb.volumeNameHash, "vbstate", state.StateSeqNum)
+		persisted = sealMeta(vb.aead, jsonData, aad, nonce)
+	}
+
 	filename := fmt.Sprintf("%s/%s", vb.BaseDir, types.GetFilePath(types.FileTypeConfig, 0, vb.GetVolume()))
-	if err := writeFileAtomic(filename, jsonData, 0600); err != nil {
+	if err := writeFileAtomic(filename, persisted, 0600); err != nil {
 		return fmt.Errorf("SaveState: atomic write %s: %w", filename, err)
 	}
 
 	// Next, write to the backend.
 	headers := []byte{}
-	if err := vb.Backend.Write(types.FileTypeConfig, 0, &headers, &jsonData); err != nil {
+	if err := vb.Backend.Write(types.FileTypeConfig, 0, &headers, &persisted); err != nil {
 		return err
 	}
 
@@ -2765,6 +2778,9 @@ func (vb *VB) LoadState() error {
 	// Step 1. Query the state locally
 	localPath := fmt.Sprintf("%s/%s", vb.BaseDir, types.GetFilePath(types.FileTypeConfig, 0, vb.GetVolume()))
 	state, localErr := vb.LoadStateRequest(localPath)
+	if errors.Is(localErr, ErrIntegrity) || errors.Is(localErr, ErrEncryptionMismatch) {
+		return fmt.Errorf("LoadState: local %s: %w", localPath, localErr)
+	}
 	if localErr != nil {
 		slog.Info("No state found in local file, using backend state", "error", localErr)
 	}
@@ -2772,6 +2788,9 @@ func (vb *VB) LoadState() error {
 	// Step 2. Query the state from the backend
 	stateBackend, backendErr := vb.LoadStateRequest("")
 
+	if errors.Is(backendErr, ErrIntegrity) || errors.Is(backendErr, ErrEncryptionMismatch) {
+		return fmt.Errorf("LoadState: backend: %w", backendErr)
+	}
 	if backendErr != nil {
 		slog.Warn("Failed to load state from backend", "error", backendErr)
 	}
@@ -2952,8 +2971,51 @@ func (vb *VB) LoadStateRequest(filename string) (state VBState, err error) {
 		}
 	}
 
-	// Parse JSON
-	err = json.Unmarshal(jsonData, &state)
+	// Encrypted volumes carry a trailing 16-byte AES-GCM tag binding the JSON
+	// to (volumeNameHash, "vbstate", StateSeqNum). The nonce + structured AAD
+	// reconstruction needs StateSeqNum + VolumeUUID, both of which live in
+	// the JSON — extract them via a minimal peek struct over the pre-tag
+	// bytes, then verify before unmarshalling the full state. The peek's
+	// VolumeUUID is the nonce subspace identifier (binds the seal-time
+	// nonce); vb.volumeNameHash is the trusted volume identity (caller-
+	// supplied at New, untouched by the parsed JSON) — splicing in another
+	// volume's blob is rejected because the AAD's volumeNameHash differs.
+	// KeyFingerprint is checked pre-verify so a wrong-key open surfaces as
+	// ErrEncryptionMismatch (with both fingerprints in the error) rather
+	// than the generic "tag verify failed" that AEAD would otherwise return.
+	if vb.EncryptionEnabled {
+		tagLen := vb.aead.Overhead()
+		if len(jsonData) < tagLen {
+			return state, fmt.Errorf("%w: VBState blob %d bytes shorter than %d-byte tag", ErrIntegrity, len(jsonData), tagLen)
+		}
+		var peek struct {
+			VolumeUUID     [4]byte `json:"VolumeUUID"`
+			StateSeqNum    uint64  `json:"StateSeqNum"`
+			KeyFingerprint string  `json:"KeyFingerprint"`
+		}
+		peekJSON := jsonData[:len(jsonData)-tagLen]
+		if err := json.Unmarshal(peekJSON, &peek); err != nil {
+			return state, fmt.Errorf("%w: VBState peek parse: %w", ErrIntegrity, err)
+		}
+		if peek.KeyFingerprint != "" && peek.KeyFingerprint != vb.MasterKey.Fingerprint {
+			return state, fmt.Errorf("%w: volume %s sealed under key %s, supplied key is %s",
+				ErrEncryptionMismatch, vb.VolumeName, peek.KeyFingerprint, vb.MasterKey.Fingerprint)
+		}
+		nonce := makeNonce(peek.StateSeqNum, peek.VolumeUUID, DomainVBStateMeta)
+		aad := makeMetaAAD(vb.volumeNameHash, "vbstate", peek.StateSeqNum)
+		verified, openErr := openMeta(vb.aead, jsonData, aad, nonce)
+		if openErr != nil {
+			return state, fmt.Errorf("%w: VBState tag verify: %w", ErrIntegrity, openErr)
+		}
+		jsonData = verified
+	}
+
+	// Use a Decoder rather than Unmarshal so a plain-mode runtime reading a
+	// sealed blob does not error on the trailing 16-byte tag. The Decoder
+	// reads one JSON value and stops; LoadState's existing
+	// EncryptionEnabled mismatch check then surfaces the misconfig as
+	// ErrEncryptionMismatch instead of swallowing it as parse failure.
+	err = json.NewDecoder(bytes.NewReader(jsonData)).Decode(&state)
 
 	return state, err
 }

--- a/viperblock/viperblock.go
+++ b/viperblock/viperblock.go
@@ -75,13 +75,11 @@ type VBState struct {
 	SourceVolumeName string `json:"SourceVolumeName,omitempty"`
 
 	// Encryption-at-rest fields (populated when EncryptionEnabled is true).
-	// EncryptionEnabled is the authoritative persistent flag; replaces the
-	// dead VolumeMetadata.IsEncrypted (which remains deprecated pending
-	// spinifex caller migration). VolumeUUID seeds the per-volume nonce
-	// subspace and is generated via crypto/rand on first SaveState of an
-	// encrypted volume. SeqNumHighWater is the durable upper bound on the
-	// next SeqNum the volume may hand out post-restart — crash-safe nonce
-	// uniqueness. StateSeqNum is a monotonic SaveState generation counter
+	// EncryptionEnabled is the authoritative persistent flag. VolumeUUID seeds
+	// the per-volume nonce subspace and is generated via crypto/rand on first
+	// SaveState of an encrypted volume. SeqNumHighWater is the durable upper
+	// bound on the next SeqNum the volume may hand out post-restart — crash-safe
+	// nonce uniqueness. StateSeqNum is a monotonic SaveState generation counter
 	// used by the metadata HMAC and to break ties in LoadState.
 	// KeyFingerprint surfaces master-key mismatch at Open with a clear error
 	// instead of silent decrypt failure.
@@ -385,7 +383,6 @@ type VolumeMetadata struct {
 	IOPS                int               `json:"IOPS"`                // For provisioned volumes
 	Tags                map[string]string `json:"Tags"`                // User-defined metadata
 	SnapshotID          string            `json:"SnapshotID"`          // If created from a snapshot
-	IsEncrypted         bool              `json:"IsEncrypted"`         // Deprecated: superseded by VBState.EncryptionEnabled. Field retained until spinifex callers migrate to the VBState source of truth; do not branch on this for encryption decisions.
 	DeleteOnTermination bool              `json:"DeleteOnTermination"` // Whether to delete volume when instance terminates
 }
 

--- a/viperblock/viperblock.go
+++ b/viperblock/viperblock.go
@@ -191,6 +191,16 @@ type VB struct {
 	SourceVolumeUUID     [4]byte
 	sourceVolumeNameHash [32]byte
 
+	// chunkMagicChecked memoises the per-(volume,objectID) result of the chunk
+	// magic preflight in checkChunkMagic. The chunk-read fast path is hit once
+	// per consecutive run; without this cache every coalesced run would issue
+	// an extra 4-byte backend Read just to validate the header. Keyed by
+	// "<volumeName>:<objectID>" so snapshot-clone reads against the source
+	// volume's chunks don't collide with our own. Stores struct{} for
+	// validated-OK; errors are not cached (transient backend failures must
+	// re-try).
+	chunkMagicChecked sync.Map
+
 	// SeqNumHighWater is the in-memory mirror of VBState.SeqNumHighWater —
 	// the largest SeqNum that may be handed out without persisting a new
 	// VBState. reserveSeqNum hands out values lock-free via SeqNum.Add until
@@ -422,6 +432,15 @@ var ErrEncryptionMismatch = errors.New("viperblock: encryption configuration mis
 // one volume's chunk into another's prefix, or replayed an older authentic
 // ciphertext at the same offset. Callers must fail-closed on any wrap.
 var ErrIntegrity = errors.New("viperblock: integrity check failed")
+
+// ErrPreEncryptionFormat is returned when an encrypted runtime
+// (EncryptionEnabled=true) encounters an on-disk artifact that still carries
+// the pre-encryption magic — VBCH for chunks, VBWL for the single-file WAL.
+// Without this dedicated signal the chunk read path would try to AEAD-open
+// plaintext bytes and surface a generic ErrIntegrity, leaving operators with
+// no actionable migration cue. Callers must refuse to open the volume and
+// direct the operator to the migration tool before retrying.
+var ErrPreEncryptionFormat = errors.New("viperblock: chunk has pre-encryption format (VBCH) but volume opened with EncryptionEnabled=true; migrate via the viperblock migration tool before re-opening")
 
 // classifyStateLoad maps the local and backend LoadStateRequest errors into a
 // sentinel suitable for callers. The local read is informational — its
@@ -1849,7 +1868,14 @@ func (vb *VB) WriteWALToChunk(force bool) error {
 	}
 
 	if !bytes.Equal(headers[:4], vb.WAL.WALMagic[:]) {
-		return fmt.Errorf("magic mismatch")
+		// Under encryption a VBWL header here means a pre-encryption WAL
+		// file is being replayed by an encrypted runtime; surface the
+		// dedicated migration error so callers can route the operator to
+		// the migration tool instead of an opaque "magic mismatch".
+		if vb.EncryptionEnabled && bytes.Equal(headers[:4], []byte{'V', 'B', 'W', 'L'}) {
+			return fmt.Errorf("%w: WAL magic mismatch in %s (file=VBWL, runtime=VBWE)", ErrPreEncryptionFormat, filename)
+		}
+		return fmt.Errorf("WAL magic mismatch in %s: got %q, expected %q", filename, headers[:4], vb.WAL.WALMagic[:])
 	}
 
 	if binary.BigEndian.Uint16(headers[4:6]) != vb.Version {
@@ -2383,7 +2409,10 @@ func (vb *VB) readWALFileForRecovery(filename string) ([]Block, uint64, error) {
 	}
 
 	if !bytes.Equal(header[:4], vb.WAL.WALMagic[:]) {
-		return nil, 0, fmt.Errorf("WAL magic mismatch in %s", filename)
+		if vb.EncryptionEnabled && bytes.Equal(header[:4], []byte{'V', 'B', 'W', 'L'}) {
+			return nil, 0, fmt.Errorf("%w: WAL magic mismatch in %s (file=VBWL, runtime=VBWE)", ErrPreEncryptionFormat, filename)
+		}
+		return nil, 0, fmt.Errorf("WAL magic mismatch in %s: got %q, expected %q", filename, header[:4], vb.WAL.WALMagic[:])
 	}
 	if binary.BigEndian.Uint16(header[4:6]) != vb.Version {
 		return nil, 0, fmt.Errorf("WAL version mismatch in %s", filename)
@@ -2627,6 +2656,46 @@ func (vb *VB) RecoverLocalWALs() error {
 
 	slog.Info("WAL recovery: complete", "recovered_blocks", len(sortedBlocks))
 
+	return nil
+}
+
+// checkChunkMagic preflights the first 4 bytes of a chunk file before the
+// body decrypt path runs, so a pre-encryption volume opened under
+// EncryptionEnabled=true fails with a dedicated, actionable
+// ErrPreEncryptionFormat instead of a generic ErrIntegrity from aead.Open on
+// every read. The result is memoised in vb.chunkMagicChecked: hot read paths
+// (coalesced consecutive runs) hit one extra 4-byte backend Read per chunk
+// per process lifetime, not per run.
+//
+// volumeName parameterises the cache key so snapshot-clone reads of the
+// source volume's chunks (fetchBaseBlocksFromBackend, ReadFrom path) don't
+// collide with the local volume's entries. read is a function so the caller
+// can pass the right backend method — Backend.Read for self, Backend.ReadFrom
+// for source-volume reads.
+func (vb *VB) checkChunkMagic(volumeName string, objectID uint64, read func(offset, length uint32) ([]byte, error)) error {
+	if !vb.EncryptionEnabled {
+		return nil
+	}
+	key := fmt.Sprintf("%s:%d", volumeName, objectID)
+	if _, ok := vb.chunkMagicChecked.Load(key); ok {
+		return nil
+	}
+	header, err := read(0, 4)
+	if err != nil {
+		return fmt.Errorf("chunk magic preflight: read object %d: %w", objectID, err)
+	}
+	if len(header) < 4 {
+		return fmt.Errorf("chunk magic preflight: short header on object %d (got %d bytes)", objectID, len(header))
+	}
+	preEncrypted := [4]byte{'V', 'B', 'C', 'H'}
+	encrypted := [4]byte{'V', 'B', 'C', 'E'}
+	if bytes.Equal(header[:4], preEncrypted[:]) {
+		return fmt.Errorf("%w (volume=%q objectID=%d)", ErrPreEncryptionFormat, volumeName, objectID)
+	}
+	if !bytes.Equal(header[:4], encrypted[:]) {
+		return fmt.Errorf("chunk magic preflight: object %d in volume %q has unknown magic %q", objectID, volumeName, header[:4])
+	}
+	vb.chunkMagicChecked.Store(key, struct{}{})
 	return nil
 }
 
@@ -3262,6 +3331,13 @@ func (vb *VB) read(block uint64, blockLen uint64) (data []byte, err error) {
 		start := cb.BlockPosition * uint64(vb.BlockSize)
 		end := start + uint64(cb.NumBlocks)*uint64(vb.BlockSize)
 
+		objectID := cb.ObjectID
+		if err := vb.checkChunkMagic(vb.VolumeName, objectID, func(off, length uint32) ([]byte, error) {
+			return vb.Backend.Read(types.FileTypeChunk, objectID, off, length)
+		}); err != nil {
+			return nil, err
+		}
+
 		blockData, err := vb.Backend.Read(types.FileTypeChunk, cb.ObjectID, cb.ObjectOffset, consecutiveBlockOffset)
 		if err != nil {
 			return nil, err
@@ -3717,6 +3793,13 @@ func (vb *VB) fetchConsecutiveBlocksFromBackend(consecutiveBlocks ConsecutiveBlo
 		start := cb.BlockPosition * uint64(vb.BlockSize)
 		end := start + uint64(cb.NumBlocks)*uint64(vb.BlockSize)
 
+		objectID := cb.ObjectID
+		if err := vb.checkChunkMagic(vb.VolumeName, objectID, func(off, length uint32) ([]byte, error) {
+			return vb.Backend.Read(types.FileTypeChunk, objectID, off, length)
+		}); err != nil {
+			return err
+		}
+
 		blockData, err := vb.Backend.Read(types.FileTypeChunk, cb.ObjectID, cb.ObjectOffset, consecutiveBlockOffset)
 		if err != nil {
 			return err
@@ -3817,6 +3900,13 @@ func (vb *VB) fetchBaseBlocksFromBackend(sourceVolume string, consecutiveBlocks 
 		consecutiveBlockOffset := uint32(cb.NumBlocks) * stride
 		start := cb.BlockPosition * uint64(vb.BlockSize)
 		end := start + uint64(cb.NumBlocks)*uint64(vb.BlockSize)
+
+		objectID := cb.ObjectID
+		if err := vb.checkChunkMagic(sourceVolume, objectID, func(off, length uint32) ([]byte, error) {
+			return vb.Backend.ReadFrom(sourceVolume, types.FileTypeChunk, objectID, off, length)
+		}); err != nil {
+			return fmt.Errorf("ReadFrom source %s: %w", sourceVolume, err)
+		}
 
 		blockData, err := vb.Backend.ReadFrom(sourceVolume, types.FileTypeChunk, cb.ObjectID, cb.ObjectOffset, consecutiveBlockOffset)
 		if err != nil {

--- a/viperblock/viperblock.go
+++ b/viperblock/viperblock.go
@@ -6,6 +6,8 @@ package viperblock
 
 import (
 	"bytes"
+	"crypto/cipher"
+	"crypto/rand"
 	"crypto/sha256"
 	"encoding/binary"
 	"encoding/hex"
@@ -27,6 +29,7 @@ import (
 	"time"
 
 	lru "github.com/hashicorp/golang-lru/v2"
+	"github.com/mulgadc/predastore/pkg/masterkey"
 	"github.com/mulgadc/viperblock/types"
 	"github.com/mulgadc/viperblock/utils"
 	"github.com/mulgadc/viperblock/viperblock/backends/file"
@@ -38,6 +41,16 @@ const DefaultObjBlockSize uint32 = 1024 * 1024 * 4
 const DefaultFlushInterval time.Duration = 5 * time.Second
 const DefaultFlushSize uint32 = 64 * 1024 * 1024
 const DefaultWALSyncInterval time.Duration = 200 * time.Millisecond
+
+// seqNumReservation is the size of each SeqNum high-water reservation window.
+// reserveSeqNum hands out values lock-free via atomic.Add until the persisted
+// high-water is crossed; the slow path advances by seqNumReservation and
+// fsyncs VBState before any of the newly reserved values are handed out. A
+// kill -9 between the bump and the next persist can lose up to one window;
+// the loaded SeqNum on restart starts from the persisted high-water, so no
+// value handed out before the crash is reused. 1<<20 keeps the slow path off
+// the per-write critical path (one fsync per million writes).
+const seqNumReservation uint64 = 1 << 20
 
 type VBState struct {
 	VolumeName string `json:"VolumeName"`
@@ -60,6 +73,23 @@ type VBState struct {
 
 	SnapshotID       string `json:"SnapshotID,omitempty"`
 	SourceVolumeName string `json:"SourceVolumeName,omitempty"`
+
+	// Encryption-at-rest fields (populated when EncryptionEnabled is true).
+	// EncryptionEnabled is the authoritative persistent flag; replaces the
+	// dead VolumeMetadata.IsEncrypted (which remains deprecated pending
+	// spinifex caller migration). VolumeUUID seeds the per-volume nonce
+	// subspace and is generated via crypto/rand on first SaveState of an
+	// encrypted volume. SeqNumHighWater is the durable upper bound on the
+	// next SeqNum the volume may hand out post-restart — crash-safe nonce
+	// uniqueness. StateSeqNum is a monotonic SaveState generation counter
+	// used by the metadata HMAC (Stage 4) and to break ties in LoadState.
+	// KeyFingerprint surfaces master-key mismatch at Open with a clear error
+	// instead of silent decrypt failure.
+	EncryptionEnabled bool    `json:"EncryptionEnabled,omitempty"`
+	VolumeUUID        [4]byte `json:"VolumeUUID,omitempty"`
+	SeqNumHighWater   uint64  `json:"SeqNumHighWater,omitempty"`
+	StateSeqNum       uint64  `json:"StateSeqNum,omitempty"`
+	KeyFingerprint    string  `json:"KeyFingerprint,omitempty"`
 }
 
 type VB struct {
@@ -143,6 +173,38 @@ type VB struct {
 
 	// SnapshotID is set when this volume was created from a snapshot.
 	SnapshotID string
+
+	// Encryption-at-rest. MasterKey is supplied by the caller (NBD plugin /
+	// CLI) via masterkey.LoadShared; aead caches MasterKey.AEAD for the hot
+	// path. EncryptionEnabled is the caller-supplied flag for this volume; it
+	// must agree with VBState.EncryptionEnabled on LoadState or LoadState
+	// refuses. volumeNameHash is SHA256(VolumeName) cached at New for AAD
+	// construction. VolumeUUID is the per-volume nonce subspace, persisted in
+	// VBState. SourceVolumeUUID / sourceVolumeNameHash carry the source
+	// volume's identity when this is a snapshot clone (Stage 3 populates
+	// them from SnapshotState; Stage 1 leaves them zero).
+	MasterKey         *masterkey.Key
+	EncryptionEnabled bool
+	aead              cipher.AEAD
+	volumeNameHash    [32]byte
+	VolumeUUID        [4]byte
+	SourceVolumeUUID  [4]byte
+	//nolint:unused // Stage 3 populates this from SnapshotState when reading clone base chunks.
+	sourceVolumeNameHash [32]byte
+
+	// SeqNumHighWater is the in-memory mirror of VBState.SeqNumHighWater —
+	// the largest SeqNum that may be handed out without persisting a new
+	// VBState. reserveSeqNum hands out values lock-free via SeqNum.Add until
+	// the high-water is crossed; the slow path takes seqNumHighWaterMu,
+	// advances by seqNumReservation, and SaveStates before releasing.
+	seqNumHighWater   atomic.Uint64
+	seqNumHighWaterMu sync.Mutex
+
+	// nextStateSeqNum is the monotonic SaveState generation counter mirrored
+	// from VBState.StateSeqNum. Each SaveState increments it before marshal.
+	// Stage 4 binds the value into the VBState metadata HMAC; Stage 1 uses
+	// it only for LoadState tie-breaking.
+	nextStateSeqNum atomic.Uint64
 }
 
 // CacheConfig holds configuration for the LRU cache
@@ -290,7 +352,7 @@ type VolumeMetadata struct {
 	IOPS                int               `json:"IOPS"`                // For provisioned volumes
 	Tags                map[string]string `json:"Tags"`                // User-defined metadata
 	SnapshotID          string            `json:"SnapshotID"`          // If created from a snapshot
-	IsEncrypted         bool              `json:"IsEncrypted"`         // Encryption flag
+	IsEncrypted         bool              `json:"IsEncrypted"`         // Deprecated: superseded by VBState.EncryptionEnabled. Field retained until spinifex callers migrate to the VBState source of truth; do not branch on this for encryption decisions.
 	DeleteOnTermination bool              `json:"DeleteOnTermination"` // Whether to delete volume when instance terminates
 }
 
@@ -331,6 +393,13 @@ var ErrStateNotFound = errors.New("viperblock: state not found")
 // failed with a non-not-found error (timeout, network, 5xx). Callers should
 // retry with backoff; the state may become available shortly.
 var ErrStateBackendUnavailable = errors.New("viperblock: state backend unavailable")
+
+// ErrEncryptionMismatch is returned when the runtime master key and the
+// persisted VBState disagree on whether the volume is encrypted, when the
+// KeyFingerprint on disk does not match the loaded key, or when an encrypted
+// configuration is combined with UseShardedWAL (refused for the duration of
+// the single-file-WAL-only encryption scope).
+var ErrEncryptionMismatch = errors.New("viperblock: encryption configuration mismatch")
 
 // classifyStateLoad maps the local and backend LoadStateRequest errors into a
 // sentinel suitable for callers. The local read is informational — its
@@ -435,6 +504,21 @@ func New(config *VB, btype string, backendConfig any) (vb *VB, err error) {
 		return nil, fmt.Errorf("volume name and size must be set")
 	}
 
+	// Encryption invariants: flag and key must agree, and sharded WAL is
+	// refused for encrypted volumes (plan §Scope discipline — only the
+	// single-file WAL is in scope; refusing here makes the unsupported combo
+	// a startup-time error instead of a silent fall-through to unencrypted
+	// writes via the sharded path).
+	if config.EncryptionEnabled && config.MasterKey == nil {
+		return nil, fmt.Errorf("%w: EncryptionEnabled=true requires MasterKey", ErrEncryptionMismatch)
+	}
+	if !config.EncryptionEnabled && config.MasterKey != nil {
+		return nil, fmt.Errorf("%w: MasterKey provided but EncryptionEnabled=false", ErrEncryptionMismatch)
+	}
+	if config.EncryptionEnabled && config.UseShardedWAL {
+		return nil, fmt.Errorf("%w: EncryptionEnabled is incompatible with UseShardedWAL", ErrEncryptionMismatch)
+	}
+
 	switch btype {
 	case "file":
 		//volumeName = backendConfig.(file.FileConfig).VolumeName
@@ -523,6 +607,14 @@ func New(config *VB, btype string, backendConfig any) (vb *VB, err error) {
 
 		UseShardedWAL: false,
 		ShardedWAL:    NewShardedWAL(config.BaseDir, [4]byte{'V', 'B', 'W', 'L'}),
+
+		MasterKey:         config.MasterKey,
+		EncryptionEnabled: config.EncryptionEnabled,
+	}
+
+	if config.EncryptionEnabled {
+		vb.aead = config.MasterKey.AEAD
+		vb.volumeNameHash = computeVolumeNameHash(config.VolumeName)
 	}
 
 	vb.BlocksToObject.BlockLookup = make(map[uint64]BlockLookup)
@@ -2377,10 +2469,28 @@ func (vb *VB) LookupBlockToObject(block uint64) (objectID uint64, objectOffset u
 	}
 }
 
-// Save the block tracking state to disk
+// Save the block tracking state to disk.
+//
+// For encrypted volumes, SaveState bootstraps the per-volume nonce subspace
+// on first call: if VolumeUUID is zero we mint it via crypto/rand and seed
+// SeqNumHighWater = seqNumReservation. Subsequent calls preserve the existing
+// UUID and advance StateSeqNum monotonically (Stage 4 binds the value into
+// the metadata HMAC). The local write is atomic — tmp file + fsync + rename
+// + fsync parent dir — so a crash mid-persist cannot leave a torn config.json
+// that would let reserveSeqNum re-hand-out values on restart.
 func (vb *VB) SaveState() error {
 	vb.BlocksToObject.mu.Lock()
 	defer vb.BlocksToObject.mu.Unlock()
+
+	if vb.EncryptionEnabled {
+		var zero [4]byte
+		if vb.VolumeUUID == zero {
+			if _, err := rand.Read(vb.VolumeUUID[:]); err != nil {
+				return fmt.Errorf("SaveState: mint VolumeUUID: %w", err)
+			}
+			vb.seqNumHighWater.Store(seqNumReservation)
+		}
+	}
 
 	walNum := vb.WAL.WallNum.Load()
 	if vb.UseShardedWAL && vb.ShardedWAL != nil {
@@ -2401,30 +2511,81 @@ func (vb *VB) SaveState() error {
 		ShardedWAL:          vb.UseShardedWAL,
 		SnapshotID:          vb.SnapshotID,
 		SourceVolumeName:    vb.SourceVolumeName,
+		EncryptionEnabled:   vb.EncryptionEnabled,
+		VolumeUUID:          vb.VolumeUUID,
+		SeqNumHighWater:     vb.seqNumHighWater.Load(),
 	}
 
-	// Save as JSON
+	if vb.EncryptionEnabled && vb.MasterKey != nil {
+		state.KeyFingerprint = vb.MasterKey.Fingerprint
+	}
+
+	state.StateSeqNum = vb.nextStateSeqNum.Add(1)
+
 	jsonData, err := json.Marshal(state)
 	if err != nil {
 		return err
 	}
 
-	// First, write to the local persistant disk
 	filename := fmt.Sprintf("%s/%s", vb.BaseDir, types.GetFilePath(types.FileTypeConfig, 0, vb.GetVolume()))
-	err = os.WriteFile(filename, jsonData, 0600)
-
-	if err != nil {
-		return err
+	if err := writeFileAtomic(filename, jsonData, 0600); err != nil {
+		return fmt.Errorf("SaveState: atomic write %s: %w", filename, err)
 	}
 
-	// Next, write to the backend
+	// Next, write to the backend.
 	headers := []byte{}
-	err = vb.Backend.Write(types.FileTypeConfig, 0, &headers, &jsonData)
-	if err != nil {
+	if err := vb.Backend.Write(types.FileTypeConfig, 0, &headers, &jsonData); err != nil {
 		return err
 	}
 
 	return nil
+}
+
+// writeFileAtomic writes data to path atomically via tmp + fsync + rename +
+// fsync(parent). On return without error, the file exists at path with the
+// new contents fully durable on disk. A crash before return may leave a
+// stale path.tmp behind (caller-tolerable: next SaveState rewrites it).
+func writeFileAtomic(path string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	tmp := path + ".tmp"
+	f, err := os.OpenFile(tmp, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, perm)
+	if err != nil {
+		return err
+	}
+	if _, err := f.Write(data); err != nil {
+		_ = f.Close()
+		_ = os.Remove(tmp)
+		return err
+	}
+	if err := f.Sync(); err != nil {
+		_ = f.Close()
+		_ = os.Remove(tmp)
+		return err
+	}
+	if err := f.Close(); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	return fsyncDir(dir)
+}
+
+// fsyncDir fsyncs a directory entry so a preceding rename is durable. POSIX:
+// without this, the rename may be lost on crash even if the file content was
+// fsynced (the directory entry change is buffered separately).
+func fsyncDir(dir string) error {
+	d, err := os.Open(dir)
+	if err != nil {
+		return err
+	}
+	if err := d.Sync(); err != nil {
+		_ = d.Close()
+		return err
+	}
+	return d.Close()
 }
 
 // Load the block tracking state from disk
@@ -2499,6 +2660,45 @@ func (vb *VB) LoadState() error {
 	vb.Version = state.Version
 	vb.VolumeConfig = state.VolumeConfig
 
+	vb.nextStateSeqNum.Store(state.StateSeqNum)
+
+	// Encryption-at-rest validation and SeqNum bootstrap.
+	//
+	// The runtime must agree with the persisted flag — supplying a key for an
+	// unencrypted volume, or omitting the key for an encrypted one, is a
+	// startup-time error rather than a silent fall-through. Key fingerprint
+	// mismatch surfaces the same way (an operator who points the daemon at
+	// the wrong key file sees a clear error rather than every read failing
+	// integrity later).
+	//
+	// On a successful Open of an existing encrypted volume, restart SeqNum at
+	// the persisted high-water and reserve the next window durably before any
+	// data write can hand out a value. This is what makes nonce uniqueness
+	// crash-safe: a kill -9 before the next SaveState loses up to one
+	// reservation window of values, but every value handed out before the
+	// crash sits below the high-water we just persisted, so none can be
+	// re-issued.
+	if vb.EncryptionEnabled != state.EncryptionEnabled {
+		return fmt.Errorf("%w: runtime EncryptionEnabled=%v, persisted=%v (volume %s)",
+			ErrEncryptionMismatch, vb.EncryptionEnabled, state.EncryptionEnabled, vb.VolumeName)
+	}
+	if vb.EncryptionEnabled {
+		if vb.MasterKey == nil {
+			return fmt.Errorf("%w: volume %s requires master key", ErrEncryptionMismatch, vb.VolumeName)
+		}
+		if state.KeyFingerprint != "" && state.KeyFingerprint != vb.MasterKey.Fingerprint {
+			return fmt.Errorf("%w: volume %s sealed under key %s, supplied key is %s",
+				ErrEncryptionMismatch, vb.VolumeName, state.KeyFingerprint, vb.MasterKey.Fingerprint)
+		}
+		vb.VolumeUUID = state.VolumeUUID
+		vb.volumeNameHash = computeVolumeNameHash(state.VolumeName)
+		vb.SeqNum.Store(state.SeqNumHighWater)
+		vb.seqNumHighWater.Store(state.SeqNumHighWater)
+		if err := vb.bumpSeqNumHighWater(); err != nil {
+			return fmt.Errorf("LoadState: reserve initial SeqNum window: %w", err)
+		}
+	}
+
 	// If this volume was created from a snapshot, load the base block map.
 	// OpenFromSnapshot sets SnapshotID and SourceVolumeName from the snapshot
 	// config, so we don't set them separately to avoid two sources of truth.
@@ -2512,6 +2712,55 @@ func (vb *VB) LoadState() error {
 	slog.Debug("Loaded state", "state", state)
 
 	return nil
+}
+
+// reserveSeqNum hands out n consecutive sequence numbers for the data path.
+// Common path is lock-free atomic.Add; the high-water is checked after the
+// fact and only when crossed do we take seqNumHighWaterMu and SaveState to
+// advance it. Stage 1 wires the helper into LoadState's startup reservation
+// only — Stage 2 plugs it into WriteWAL/createChunkFile in place of the
+// existing vb.SeqNum.Add calls. Refuses past MaxSeqNum (56-bit nonce slot).
+//
+// Unencrypted volumes fall through to plain atomic.Add — the high-water is a
+// nonce-uniqueness mechanism and is irrelevant when no nonce exists.
+func (vb *VB) reserveSeqNum(n uint64) (start uint64, err error) {
+	end := vb.SeqNum.Add(n)
+	start = end - n
+	if !vb.EncryptionEnabled {
+		return start, nil
+	}
+	if end > MaxSeqNum {
+		return 0, fmt.Errorf("viperblock: SeqNum %d exceeds 56-bit nonce limit, volume %s must be recreated", end, vb.VolumeName)
+	}
+	if end <= vb.seqNumHighWater.Load() {
+		return start, nil
+	}
+	vb.seqNumHighWaterMu.Lock()
+	defer vb.seqNumHighWaterMu.Unlock()
+	// Re-check under the mutex: another caller may have advanced past us.
+	hw := vb.seqNumHighWater.Load()
+	if end <= hw {
+		return start, nil
+	}
+	for end > hw {
+		hw += seqNumReservation
+	}
+	vb.seqNumHighWater.Store(hw)
+	if err := vb.SaveState(); err != nil {
+		return 0, fmt.Errorf("reserveSeqNum: SaveState: %w", err)
+	}
+	return start, nil
+}
+
+// bumpSeqNumHighWater advances the persisted SeqNumHighWater by
+// seqNumReservation and durably SaveStates. Called from LoadState's startup
+// path to claim a fresh reservation window before any data write can issue a
+// SeqNum that overlaps the pre-crash range.
+func (vb *VB) bumpSeqNumHighWater() error {
+	vb.seqNumHighWaterMu.Lock()
+	defer vb.seqNumHighWaterMu.Unlock()
+	vb.seqNumHighWater.Add(seqNumReservation)
+	return vb.SaveState()
 }
 
 // Query the local state from file or the backend

--- a/viperblock/viperblock.go
+++ b/viperblock/viperblock.go
@@ -2406,10 +2406,16 @@ func (vb *VB) readWALFileForRecovery(filename string) ([]Block, uint64, error) {
 		for {
 			record := make([]byte, recordSize)
 			if _, err := io.ReadFull(f, record); err != nil {
-				if err != io.EOF && err != io.ErrUnexpectedEOF {
-					slog.Warn("WAL recovery: I/O error reading record, stopping", "file", filename, "error", err, "valid_records_so_far", len(blocks))
+				// Tail tear: the last record was only partially written
+				// before a crash. Same fail-tolerant posture as the
+				// legacy CRC path — stop replay and return what we have.
+				if err == io.EOF || err == io.ErrUnexpectedEOF {
+					break
 				}
-				break
+				// Any other I/O error means we can't be sure whether
+				// the remainder is a tear or tamper; keep the WAL for
+				// retry rather than dropping records on the floor.
+				return nil, 0, fmt.Errorf("readWALFileForRecovery: %s: read record: %w", filename, err)
 			}
 
 			seqNum := binary.BigEndian.Uint64(record[0:8])
@@ -2420,8 +2426,11 @@ func (vb *VB) readWALFileForRecovery(filename string) ([]Block, uint64, error) {
 			aad := makeAAD(vb.volumeNameHash, blockNum, seqNum)
 			plain, err := vb.aead.Open(nil, nonce[:], record[24:], aad)
 			if err != nil {
-				slog.Warn("WAL recovery: aead.Open failed, stopping read", "file", filename, "block", blockNum, "seqNum", seqNum, "valid_records_so_far", len(blocks))
-				break
+				// AEAD failure on a fully-read record is tamper, not
+				// tear. Surface as ErrIntegrity so RecoverLocalWALs
+				// keeps the file (no silent truncation of recovery).
+				slog.Error("WAL recovery: aead.Open failed", "file", filename, "block", blockNum, "seqNum", seqNum, "valid_records_so_far", len(blocks))
+				return nil, 0, fmt.Errorf("readWALFileForRecovery: %w: WAL record block %d seqNum %d in %s: %v", ErrIntegrity, blockNum, seqNum, filename, err)
 			}
 
 			blocks = append(blocks, Block{

--- a/viperblock/viperblock.go
+++ b/viperblock/viperblock.go
@@ -967,6 +967,18 @@ func (vb *VB) WriteAt(offset uint64, data []byte) error {
 	endOffset := offset + dataLen
 	endBlock := (endOffset - 1) / blockSize
 
+	// Reserve a contiguous SeqNum batch up-front. reserveSeqNum may call
+	// SaveState (which takes BlocksToObject.mu), so it must run before we
+	// acquire vb.Writes.mu below to keep the lock order consistent. We issue
+	// start+1..start+n to preserve the legacy "atomic.Add(1) post-increment"
+	// semantics (issued SeqNums are >= 1; SeqNum == 0 reads as uninitialised
+	// in BlockStore).
+	start, err := vb.reserveSeqNum(endBlock - startBlock + 1)
+	if err != nil {
+		return err
+	}
+	nextSeqNum := start + 1
+
 	var writes []Block
 
 	for b := startBlock; b <= endBlock; b++ {
@@ -1008,11 +1020,12 @@ func (vb *VB) WriteAt(offset uint64, data []byte) error {
 		copy(blockData[writeStart:writeEnd], data[blockStart+writeStart-offset:blockStart+writeEnd-offset])
 
 		writes = append(writes, Block{
-			SeqNum: vb.SeqNum.Add(1),
+			SeqNum: nextSeqNum,
 			Block:  b,
 			Len:    blockSize,
 			Data:   blockData,
 		})
+		nextSeqNum++
 	}
 
 	// Thread-safe write into memory buffer
@@ -1052,6 +1065,18 @@ func (vb *VB) Write(block uint64, data []byte) (err error) {
 
 	//slog.Info("\tVBWRITE:", "blockRequests", blockRequests, "block", block, "blockLen", blockLen)
 
+	// Reserve a contiguous SeqNum batch up-front. reserveSeqNum may call
+	// SaveState (which takes BlocksToObject.mu), so it must run before we
+	// acquire vb.Writes.mu below to keep the lock order consistent. We issue
+	// start+1..start+n to preserve the legacy "atomic.Add(1) post-increment"
+	// semantics (issued SeqNums are >= 1; SeqNum == 0 reads as uninitialised
+	// in BlockStore).
+	start, err := vb.reserveSeqNum(blockRequests)
+	if err != nil {
+		return err
+	}
+	seqNum := start + 1
+
 	vb.Writes.mu.Lock()
 
 	// Loop through each block request
@@ -1066,9 +1091,6 @@ func (vb *VB) Write(block uint64, data []byte) (err error) {
 
 		//slog.Info("\t\tBLOCKWRITE:", "currentBlock", currentBlock, "start", start, "end", end, "i", i)
 
-		// Write raw data received, first to the main memory Block, which will be flushed to the WAL
-		seqNum := vb.SeqNum.Add(1)
-
 		vb.Writes.Blocks = append(vb.Writes.Blocks, Block{
 			SeqNum: seqNum,
 			Block:  currentBlock,
@@ -1081,6 +1103,8 @@ func (vb *VB) Write(block uint64, data []byte) (err error) {
 		}
 
 		//slog.Info("WRITE:", "seqNum", seqNum, "BLOCK:", currentBlock, "start", start, "end", end)
+
+		seqNum++
 	}
 
 	vb.Writes.mu.Unlock()
@@ -2908,9 +2932,10 @@ func (vb *VB) LoadState() error {
 // reserveSeqNum hands out n consecutive sequence numbers for the data path.
 // Common path is lock-free atomic.Add; the high-water is checked after the
 // fact and only when crossed do we take seqNumHighWaterMu and SaveState to
-// advance it. Stage 1 wires the helper into LoadState's startup reservation
-// only — Stage 2 plugs it into WriteWAL/createChunkFile in place of the
-// existing vb.SeqNum.Add calls. Refuses past MaxSeqNum (56-bit nonce slot).
+// advance it. Refuses past MaxSeqNum (56-bit nonce slot).
+//
+// Lock order: callers must NOT hold BlocksToObject.mu — the slow path takes
+// seqNumHighWaterMu then calls SaveState, which acquires BlocksToObject.mu.
 //
 // Unencrypted volumes fall through to plain atomic.Add — the high-water is a
 // nonce-uniqueness mechanism and is irrelevant when no nonce exists.

--- a/viperblock/viperblock.go
+++ b/viperblock/viperblock.go
@@ -260,6 +260,13 @@ type BlockLookup struct {
 	NumBlocks    uint16
 	ObjectID     uint64
 	ObjectOffset uint32
+	// SeqNum is the chunk-write generation that produced this block's
+	// ciphertext on the backend. Drives nonce + AAD reconstruction on the
+	// decrypt path: the on-disk chunk carries no nonce, so the per-block
+	// SeqNum here is the only source. Always populated from BlockEntry.SeqNum
+	// in createChunkFile (zero for blocks written by pre-encryption code paths
+	// — those volumes are unreadable post-cutover by design).
+	SeqNum uint64
 }
 
 type ConsecutiveBlock struct {
@@ -574,6 +581,18 @@ func New(config *VB, btype string, backendConfig any) (vb *VB, err error) {
 	// Calculate initial cache size based on 30% of system memory
 	//initialCacheSize := calculateCacheSize(config.BlockSize, 30)
 
+	// Magic selection: encrypted volumes use VBCE chunks and VBWE single-file
+	// WAL records (AEAD-sealed, no CRC). Unencrypted volumes keep the legacy
+	// VBCH / VBWL formats unchanged. The sharded WAL keeps VBWL because the
+	// sharded path is refused at startup under encryption (see New
+	// validation); pre-existing unencrypted shards remain readable.
+	chunkMagic := [4]byte{'V', 'B', 'C', 'H'}
+	walMagic := [4]byte{'V', 'B', 'W', 'L'}
+	if config.EncryptionEnabled {
+		chunkMagic = [4]byte{'V', 'B', 'C', 'E'}
+		walMagic = [4]byte{'V', 'B', 'W', 'E'}
+	}
+
 	vb = &VB{
 		VolumeName:       config.VolumeName,
 		VolumeSize:       config.VolumeSize,
@@ -583,7 +602,7 @@ func New(config *VB, btype string, backendConfig any) (vb *VB, err error) {
 		FlushSize:        config.FlushSize,
 		WALSyncInterval:  config.WALSyncInterval,
 		Writes:           Blocks{},
-		WAL:              WAL{BaseDir: config.BaseDir, WALMagic: [4]byte{'V', 'B', 'W', 'L'}},
+		WAL:              WAL{BaseDir: config.BaseDir, WALMagic: walMagic},
 		BlockToObjectWAL: WAL{BaseDir: config.BaseDir, WALMagic: [4]byte{'V', 'B', 'W', 'B'}},
 		Cache: Cache{
 			lru: lruCache,
@@ -595,7 +614,7 @@ func New(config *VB, btype string, backendConfig any) (vb *VB, err error) {
 		},
 		Version: 1,
 
-		ChunkMagic:     [4]byte{'V', 'B', 'C', 'H'},
+		ChunkMagic:     chunkMagic,
 		BlocksToObject: BlocksToObject{},
 		Backend:        backend,
 		BaseDir:        config.BaseDir,
@@ -1229,69 +1248,47 @@ func (vb *VB) Flush2() (err error) {
 }
 
 func (vb *VB) WriteWAL(block Block) (err error) {
-	// Pre-allocate record buffer (28 byte header + data)
-	recordSize := 28 + len(block.Data)
-	record := make([]byte, recordSize)
+	var record []byte
+
+	if vb.EncryptionEnabled {
+		// Encrypted layout (magic VBWE), per-record:
+		//   [SeqNum(8) | BlockNum(8) | BlockLen(8) | ciphertext(BlockLen) | tag(16)]
+		// CRC32 is dropped — the 16-byte GCM tag subsumes it (NIST SP 800-38D
+		// §5: AEAD provides confidentiality and integrity in one primitive).
+		// Nonce: (SeqNum, VolumeUUID, DomainWAL). AAD: (volumeNameHash,
+		// BlockNum, SeqNum). Bound together they defeat cross-volume swap,
+		// in-place rollback, and positional shuffle on WAL replay.
+		const headerLen = 24
+		record = make([]byte, headerLen, headerLen+len(block.Data)+16)
+		binary.BigEndian.PutUint64(record[0:8], block.SeqNum)
+		binary.BigEndian.PutUint64(record[8:16], block.Block)
+		binary.BigEndian.PutUint64(record[16:24], block.Len)
+		nonce := makeNonce(block.SeqNum, vb.VolumeUUID, DomainWAL)
+		aad := makeAAD(vb.volumeNameHash, block.Block, block.SeqNum)
+		record = vb.aead.Seal(record, nonce[:], block.Data, aad)
+	} else {
+		// Legacy layout (magic VBWL), per-record:
+		//   [SeqNum(8) | BlockNum(8) | BlockLen(8) | CRC32(4) | data(BlockLen)]
+		recordSize := 28 + len(block.Data)
+		record = make([]byte, recordSize)
+		binary.BigEndian.PutUint64(record[0:8], block.SeqNum)
+		binary.BigEndian.PutUint64(record[8:16], block.Block)
+		binary.BigEndian.PutUint64(record[16:24], block.Len)
+		checksum := crc32.ChecksumIEEE(record[0:24])
+		checksum = crc32.Update(checksum, crc32.IEEETable, block.Data)
+		binary.BigEndian.PutUint32(record[24:28], checksum)
+		copy(record[28:], block.Data)
+	}
 
 	vb.WAL.mu.Lock()
-
-	// Get the current WAL file
 	currentWAL := vb.WAL.DB[len(vb.WAL.DB)-1]
-
-	//slog.Info("WRITE WAL:", "currentWAL", currentWAL)
-
-	// Format for each block in the WAL
-	// [seq_number, uint64][block_number, uint64][block_length, uint64][checksum, uint32][block_data, []byte]
-	// big endian
-
-	// Write the block number as big endian
-	binary.BigEndian.PutUint64(record[0:8], block.SeqNum)
-
-	//blockSeq := make([]byte, 8)
-	//binary.BigEndian.PutUint64(blockSeq, block.SeqNum)
-	//currentWAL.Write(blockSeq)
-
-	// Write the block number as big endian
-	binary.BigEndian.PutUint64(record[8:16], block.Block)
-
-	//blockNumber := make([]byte, 8)
-	//binary.BigEndian.PutUint64(blockNumber, block.Block)
-	//slog.Info("WriteWAL > blockNumber", "original", block.Block, "converted", binary.BigEndian.Uint64(blockNumber))
-	//currentWAL.Write(blockNumber)
-
-	// TODO: Optimise
-	// Write the block length as big endian
-	binary.BigEndian.PutUint64(record[16:24], block.Len)
-
-	//blockLength := make([]byte, 8)
-	//binary.BigEndian.PutUint64(blockLength, uint64(len(block.Data)))
-	//currentWAL.Write(blockLength)
-
-	// Calculate a CRC32 checksum of the block data and headers
-	checksum := crc32.ChecksumIEEE(record[0:24])
-	checksum = crc32.Update(checksum, crc32.IEEETable, block.Data)
-
-	// Write the checksum as big endian
-	binary.BigEndian.PutUint32(record[24:28], checksum)
-
-	//checksumBytes := make([]byte, 4)
-	//binary.BigEndian.PutUint32(checksumBytes, checksum)
-	//currentWAL.Write(checksumBytes)
-
-	// Next, write the block data
-	copy(record[28:], block.Data)
-
-	// Optimistation, write a single time to reduce O_SYNC calls (slow) per finished block
 	n, err := currentWAL.Write(record)
-
-	// Mark WAL as dirty for periodic sync goroutine
 	vb.WAL.dirty.Store(true)
-
 	vb.WAL.mu.Unlock()
 
-	if n != recordSize {
-		slog.Error("ERROR WRITING BLOCK TO WAL: incomplete write", "n", n, "expected", recordSize)
-		return fmt.Errorf("incomplete write to WAL: wrote %d of %d bytes", n, recordSize)
+	if n != len(record) {
+		slog.Error("ERROR WRITING BLOCK TO WAL: incomplete write", "n", n, "expected", len(record))
+		return fmt.Errorf("incomplete write to WAL: wrote %d of %d bytes", n, len(record))
 	}
 
 	return err
@@ -1437,19 +1434,30 @@ func (vb *VB) WriteBlockWAL(blocks *[]BlockLookup) (err error) {
 	// return nil
 }
 
-func (vb *VB) writeBlockWalChunk(block *BlockLookup) (data []byte) {
-	data = make([]byte, 26)
+// blockWalChunkSize is the on-disk size of a serialized BlockLookup entry in
+// the block-to-object checkpoint. Format (big-endian):
+//
+//	[StartBlock(8) | NumBlocks(2) | ObjectID(8) | ObjectOffset(4) | SeqNum(8) | CRC32(4)]
+//
+// SeqNum was added to drive nonce + AAD reconstruction on the decrypt path
+// (Stage 3); the field is populated unconditionally so encrypted and
+// unencrypted volumes share a single checkpoint format. Pre-encryption
+// checkpoints written under the previous 26-byte layout are unreadable by
+// post-cutover binaries — volumes must be recreated. CRC32 is retained on
+// metadata because the checkpoint stays plaintext (not AEAD-sealed).
+const blockWalChunkSize = 34
 
-	// Write the start block
+func (vb *VB) writeBlockWalChunk(block *BlockLookup) (data []byte) {
+	data = make([]byte, blockWalChunkSize)
+
 	binary.BigEndian.PutUint64(data[0:8], block.StartBlock)
 	binary.BigEndian.PutUint16(data[8:10], block.NumBlocks)
 	binary.BigEndian.PutUint64(data[10:18], block.ObjectID)
 	binary.BigEndian.PutUint32(data[18:22], block.ObjectOffset)
+	binary.BigEndian.PutUint64(data[22:30], block.SeqNum)
 
-	// Calculate a CRC32 checksum of the block data and headers
-	checksum := crc32.ChecksumIEEE(data[0:22])
-
-	binary.BigEndian.PutUint32(data[22:26], checksum)
+	checksum := crc32.ChecksumIEEE(data[0:30])
+	binary.BigEndian.PutUint32(data[30:34], checksum)
 
 	return data
 }
@@ -1459,17 +1467,13 @@ func (vb *VB) readBlockWalChunk(data []byte) (block BlockLookup, err error) {
 	block.NumBlocks = binary.BigEndian.Uint16(data[8:10])
 	block.ObjectID = binary.BigEndian.Uint64(data[10:18])
 	block.ObjectOffset = binary.BigEndian.Uint32(data[18:22])
+	block.SeqNum = binary.BigEndian.Uint64(data[22:30])
 
-	checksum := binary.BigEndian.Uint32(data[22:26])
+	checksum := binary.BigEndian.Uint32(data[30:34])
 
-	// Validate checksum
-	checksum_validated := crc32.ChecksumIEEE(data[:8])
-	checksum_validated = crc32.Update(checksum_validated, crc32.IEEETable, data[8:10])
-	checksum_validated = crc32.Update(checksum_validated, crc32.IEEETable, data[10:18])
-	checksum_validated = crc32.Update(checksum_validated, crc32.IEEETable, data[18:22])
-
-	if checksum_validated != checksum {
-		slog.Error("Checksum mismatch", "checksum", checksum, "checksum_validated", checksum_validated)
+	checksumValidated := crc32.ChecksumIEEE(data[:30])
+	if checksumValidated != checksum {
+		slog.Error("Checksum mismatch", "checksum", checksum, "checksum_validated", checksumValidated)
 		return block, fmt.Errorf("checksum mismatch")
 	}
 
@@ -1977,7 +1981,29 @@ func (vb *VB) createChunkFile(currentWALNum uint64, chunkIndex uint64, chunkBuff
 
 	headers := vb.ChunkHeader()
 
-	err = vb.Backend.Write(types.FileTypeChunk, chunkIndex, &headers, chunkBuffer)
+	// On encrypted volumes the chunk body is rebuilt as a sequence of sealed
+	// blocks at stride BlockSize+16. Per-block nonce: (block.SeqNum,
+	// VolumeUUID, DomainChunk). AAD: (volumeNameHash, block.Block,
+	// block.SeqNum). The on-disk chunk carries no nonce; decrypt reconstructs
+	// it from BlockLookup.SeqNum (set below) at read time.
+	bodyBuffer := chunkBuffer
+	if vb.EncryptionEnabled {
+		bs := int(vb.BlockSize)
+		sealed := make([]byte, 0, len(*matchedBlocks)*(bs+16))
+		for i, mb := range *matchedBlocks {
+			start := i * bs
+			end := start + bs
+			if end > len(*chunkBuffer) {
+				return fmt.Errorf("createChunkFile: matchedBlocks/chunkBuffer length mismatch (block %d of %d, buffer %d bytes)", i, len(*matchedBlocks), len(*chunkBuffer))
+			}
+			nonce := makeNonce(mb.SeqNum, vb.VolumeUUID, DomainChunk)
+			aad := makeAAD(vb.volumeNameHash, mb.Block, mb.SeqNum)
+			sealed = vb.aead.Seal(sealed, nonce[:], (*chunkBuffer)[start:end], aad)
+		}
+		bodyBuffer = &sealed
+	}
+
+	err = vb.Backend.Write(types.FileTypeChunk, chunkIndex, &headers, bodyBuffer)
 	if err != nil {
 		return err
 	}
@@ -2018,6 +2044,13 @@ func (vb *VB) createChunkFile(currentWALNum uint64, chunkIndex uint64, chunkBuff
 
 	BlockObjectsToWAL := make([]BlockLookup, 0, len(*matchedBlocks))
 
+	// Per-block on-disk stride: encrypted chunks add a 16-byte GCM tag after
+	// each ciphertext block; unencrypted chunks stay at BlockSize.
+	stride := int(vb.BlockSize)
+	if vb.EncryptionEnabled {
+		stride += 16
+	}
+
 	vb.BlocksToObject.mu.Lock()
 	for k, block := range *matchedBlocks {
 		// Find out how many consecutive blocks there are
@@ -2034,7 +2067,8 @@ func (vb *VB) createChunkFile(currentWALNum uint64, chunkIndex uint64, chunkBuff
 			StartBlock:   block.Block,
 			NumBlocks:    utils.SafeIntToUint16(numBlocks),
 			ObjectID:     chunkIndex,
-			ObjectOffset: utils.SafeIntToUint32(headerLen + (i * int(vb.BlockSize))),
+			ObjectOffset: utils.SafeIntToUint32(headerLen + (i * stride)),
+			SeqNum:       block.SeqNum,
 		}
 
 		// TODO: Optimise for number of consecutive blocks to reduce the memory size
@@ -2208,12 +2242,11 @@ func (vb *VB) LoadBlockState() (err error) {
 
 	// Check the wall number
 
-	// Read each block from the checkpoint buffer (26 bytes each)
+	// Read each block from the checkpoint buffer (blockWalChunkSize bytes each).
 	offset := vb.BlockToObjectWALHeaderSize()
 
 	for offset < len(checkpoint) {
-		// TODO: Improve offset calculation, not specific to 26 bytes
-		block, err := vb.readBlockWalChunk(checkpoint[offset : offset+26])
+		block, err := vb.readBlockWalChunk(checkpoint[offset : offset+blockWalChunkSize])
 
 		if err != nil {
 			slog.Error("Error reading block", "error", err)
@@ -2224,10 +2257,10 @@ func (vb *VB) LoadBlockState() (err error) {
 
 		// Also update BlockStore if enabled
 		if vb.UseBlockStore && vb.BlockStore != nil {
-			vb.BlockStore.SetPersisted(block.StartBlock, block.ObjectID, block.ObjectOffset, 0)
+			vb.BlockStore.SetPersisted(block.StartBlock, block.ObjectID, block.ObjectOffset, block.SeqNum)
 		}
 
-		offset += 26
+		offset += blockWalChunkSize
 	}
 
 	return err

--- a/viperblock/viperblock.go
+++ b/viperblock/viperblock.go
@@ -183,13 +183,12 @@ type VB struct {
 	// VBState. SourceVolumeUUID / sourceVolumeNameHash carry the source
 	// volume's identity when this is a snapshot clone (Stage 3 populates
 	// them from SnapshotState; Stage 1 leaves them zero).
-	MasterKey         *masterkey.Key
-	EncryptionEnabled bool
-	aead              cipher.AEAD
-	volumeNameHash    [32]byte
-	VolumeUUID        [4]byte
-	SourceVolumeUUID  [4]byte
-	//nolint:unused // Stage 3 populates this from SnapshotState when reading clone base chunks.
+	MasterKey            *masterkey.Key
+	EncryptionEnabled    bool
+	aead                 cipher.AEAD
+	volumeNameHash       [32]byte
+	VolumeUUID           [4]byte
+	SourceVolumeUUID     [4]byte
 	sourceVolumeNameHash [32]byte
 
 	// SeqNumHighWater is the in-memory mirror of VBState.SeqNumHighWater —
@@ -277,6 +276,15 @@ type ConsecutiveBlock struct {
 	OffsetEnd     uint64
 	ObjectID      uint64
 	ObjectOffset  uint32
+	// SeqNum is the chunk-write generation that sealed this block's
+	// ciphertext on the backend. On pre-coalesce per-block entries it is
+	// populated from BlockLookup.SeqNum (or BlockEntry.SeqNum on the
+	// BlockStore path). After coalescing, the head block's SeqNum is left
+	// here and per-block SeqNums for the full run land in SeqNums; on the
+	// decrypt path we iterate SeqNums to reconstruct each block's nonce +
+	// AAD. Unused on unencrypted reads.
+	SeqNum  uint64
+	SeqNums []uint64
 }
 
 type ConsecutiveBlocks []ConsecutiveBlock
@@ -407,6 +415,13 @@ var ErrStateBackendUnavailable = errors.New("viperblock: state backend unavailab
 // configuration is combined with UseShardedWAL (refused for the duration of
 // the single-file-WAL-only encryption scope).
 var ErrEncryptionMismatch = errors.New("viperblock: encryption configuration mismatch")
+
+// ErrIntegrity wraps every AEAD-open failure on the read paths (WAL replay,
+// chunk read, snapshot-clone base read). A non-nil unwrap of ErrIntegrity
+// means an attacker either tampered with on-disk ciphertext / tag, swapped
+// one volume's chunk into another's prefix, or replayed an older authentic
+// ciphertext at the same offset. Callers must fail-closed on any wrap.
+var ErrIntegrity = errors.New("viperblock: integrity check failed")
 
 // classifyStateLoad maps the local and backend LoadStateRequest errors into a
 // sentinel suitable for callers. The local read is informational — its
@@ -1800,39 +1815,78 @@ func (vb *VB) WriteWALToChunk(force bool) error {
 	// Read blocks from WAL, pre-allocate the estimated number of blocks that could be in the chunk
 	blocks := make([]Block, 0, (vb.ObjBlockSize/vb.BlockSize)+1)
 
-	for {
-		data := make([]byte, 28+vb.BlockSize)
-		_, err := pendingWAL2.Read(data)
-		if err != nil {
-			if err == io.EOF {
-				break
+	if vb.EncryptionEnabled {
+		// Encrypted WAL record layout (magic VBWE):
+		//   [SeqNum(8) | BlockNum(8) | BlockLen(8) | ciphertext(BlockLen) | tag(16)]
+		// = 40 + BlockSize bytes. Nonce (SeqNum, VolumeUUID, DomainWAL),
+		// AAD (volumeNameHash, BlockNum, SeqNum). The 16-byte GCM tag
+		// subsumes the dropped CRC32; aead.Open validates confidentiality
+		// and integrity in one pass.
+		recordSize := 40 + int(vb.BlockSize)
+		for {
+			record := make([]byte, recordSize)
+			if _, err := io.ReadFull(pendingWAL2, record); err != nil {
+				if err == io.EOF {
+					break
+				}
+				return fmt.Errorf("error reading encrypted WAL data: %v", err)
 			}
-			return fmt.Errorf("error reading WAL data: %v", err)
-		}
 
-		// Validate checksum
-		checksum := binary.BigEndian.Uint32(data[24:28])
+			seqNum := binary.BigEndian.Uint64(record[0:8])
+			blockNum := binary.BigEndian.Uint64(record[8:16])
+			blockLen := binary.BigEndian.Uint64(record[16:24])
 
-		checksumValidated := crc32.ChecksumIEEE(data[:24])
-		// Skip the checksum (24:28), just the data next
-		checksumValidated = crc32.Update(checksumValidated, crc32.IEEETable, data[28:])
-
-		if checksumValidated != checksum {
-			pos, err := pendingWAL2.Seek(0, io.SeekCurrent)
+			nonce := makeNonce(seqNum, vb.VolumeUUID, DomainWAL)
+			aad := makeAAD(vb.volumeNameHash, blockNum, seqNum)
+			plain, err := vb.aead.Open(nil, nonce[:], record[24:], aad)
 			if err != nil {
-				return fmt.Errorf("error seeking in WriteWALToChunk: %v", err)
+				pos, _ := pendingWAL2.Seek(0, io.SeekCurrent)
+				slog.Error("WAL aead.Open failed", "filename", filename, "pos", pos, "block", blockNum, "seqNum", seqNum)
+				return fmt.Errorf("%w: WAL record block %d seqNum %d in %s: %w", ErrIntegrity, blockNum, seqNum, filename, err)
 			}
 
-			slog.Error("checksum mismatch in WriteWALToChunk", "filename", filename, "pos", pos, "checksum", checksum, "checksumValidated", checksumValidated)
-			return fmt.Errorf("checksum mismatch in WriteWALToChunk")
+			blocks = append(blocks, Block{
+				SeqNum: seqNum,
+				Block:  blockNum,
+				Len:    blockLen,
+				Data:   plain,
+			})
 		}
+	} else {
+		for {
+			data := make([]byte, 28+vb.BlockSize)
+			_, err := pendingWAL2.Read(data)
+			if err != nil {
+				if err == io.EOF {
+					break
+				}
+				return fmt.Errorf("error reading WAL data: %v", err)
+			}
 
-		blocks = append(blocks, Block{
-			SeqNum: binary.BigEndian.Uint64(data[:8]),
-			Block:  binary.BigEndian.Uint64(data[8:16]),
-			Len:    binary.BigEndian.Uint64(data[16:24]),
-			Data:   data[28:],
-		})
+			// Validate checksum
+			checksum := binary.BigEndian.Uint32(data[24:28])
+
+			checksumValidated := crc32.ChecksumIEEE(data[:24])
+			// Skip the checksum (24:28), just the data next
+			checksumValidated = crc32.Update(checksumValidated, crc32.IEEETable, data[28:])
+
+			if checksumValidated != checksum {
+				pos, err := pendingWAL2.Seek(0, io.SeekCurrent)
+				if err != nil {
+					return fmt.Errorf("error seeking in WriteWALToChunk: %v", err)
+				}
+
+				slog.Error("checksum mismatch in WriteWALToChunk", "filename", filename, "pos", pos, "checksum", checksum, "checksumValidated", checksumValidated)
+				return fmt.Errorf("checksum mismatch in WriteWALToChunk")
+			}
+
+			blocks = append(blocks, Block{
+				SeqNum: binary.BigEndian.Uint64(data[:8]),
+				Block:  binary.BigEndian.Uint64(data[8:16]),
+				Len:    binary.BigEndian.Uint64(data[16:24]),
+				Data:   data[28:],
+			})
+		}
 	}
 
 	// Deduplicate and sort blocks
@@ -2297,8 +2351,48 @@ func (vb *VB) readWALFileForRecovery(filename string) ([]Block, uint64, error) {
 
 	var blocks []Block
 	var maxSeqNum uint64
-	recordSize := 28 + int(vb.BlockSize)
 
+	// Encrypted WAL records are 40+BlockSize (24-byte header + ciphertext +
+	// 16-byte tag); unencrypted records are 28+BlockSize (24-byte header +
+	// CRC32 + plaintext). Both record sizes are fixed, so a tail tear shows
+	// up as ErrUnexpectedEOF and stops replay at the last fully-written
+	// record (same fail-tolerant posture as the legacy CRC path).
+	if vb.EncryptionEnabled {
+		recordSize := 40 + int(vb.BlockSize)
+		for {
+			record := make([]byte, recordSize)
+			if _, err := io.ReadFull(f, record); err != nil {
+				if err != io.EOF && err != io.ErrUnexpectedEOF {
+					slog.Warn("WAL recovery: I/O error reading record, stopping", "file", filename, "error", err, "valid_records_so_far", len(blocks))
+				}
+				break
+			}
+
+			seqNum := binary.BigEndian.Uint64(record[0:8])
+			blockNum := binary.BigEndian.Uint64(record[8:16])
+			blockLen := binary.BigEndian.Uint64(record[16:24])
+
+			nonce := makeNonce(seqNum, vb.VolumeUUID, DomainWAL)
+			aad := makeAAD(vb.volumeNameHash, blockNum, seqNum)
+			plain, err := vb.aead.Open(nil, nonce[:], record[24:], aad)
+			if err != nil {
+				slog.Warn("WAL recovery: aead.Open failed, stopping read", "file", filename, "block", blockNum, "seqNum", seqNum, "valid_records_so_far", len(blocks))
+				break
+			}
+
+			blocks = append(blocks, Block{
+				SeqNum: seqNum,
+				Block:  blockNum,
+				Len:    blockLen,
+				Data:   plain,
+			})
+
+			maxSeqNum = max(maxSeqNum, seqNum)
+		}
+		return blocks, maxSeqNum, nil
+	}
+
+	recordSize := 28 + int(vb.BlockSize)
 	for {
 		record := make([]byte, recordSize)
 		if _, err := io.ReadFull(f, record); err != nil {
@@ -2484,7 +2578,52 @@ func (vb *VB) RecoverLocalWALs() error {
 }
 
 // Lookup Block to Object
-func (vb *VB) LookupBlockToObject(block uint64) (objectID uint64, objectOffset uint32, err error) {
+// LookupBlockToObject returns the persisted location of a block plus its
+// chunk-write SeqNum. The SeqNum return drives nonce + AAD reconstruction on
+// the decrypt path; on unencrypted volumes callers ignore it. Returns
+// ErrZeroBlock when the block has never been written.
+// openChunkRun decrypts a coalesced run of N chunk blocks read from the
+// backend at stride BlockSize+16. Each block's nonce is reconstructed from
+// (cb.SeqNums[k], volumeUUID, DomainChunk) and AAD from (volumeNameHash,
+// cb.StartBlock+k, cb.SeqNums[k]). On any AEAD-open failure we wrap
+// ErrIntegrity and refuse to populate dst — fail-closed: a partial decrypt
+// would let an attacker corrupt one block while leaving the rest readable.
+// The dst slice must have length cb.NumBlocks*BlockSize; ciphertext must
+// have length cb.NumBlocks*(BlockSize+16).
+//
+// volumeUUID + volumeNameHash are passed explicitly (not read off vb) so
+// snapshot-clone reads can decrypt source-volume chunks under the source's
+// identity, not the clone's.
+func (vb *VB) openChunkRun(ciphertext []byte, cb ConsecutiveBlock, volumeUUID [4]byte, volumeNameHash [32]byte, dst []byte) error {
+	bs := int(vb.BlockSize)
+	sealedStride := bs + 16
+	expected := int(cb.NumBlocks) * sealedStride
+	if len(ciphertext) != expected {
+		return fmt.Errorf("openChunkRun: short ciphertext for object %d offset %d run %d: got %d bytes, expected %d", cb.ObjectID, cb.ObjectOffset, cb.NumBlocks, len(ciphertext), expected)
+	}
+	if len(dst) != int(cb.NumBlocks)*bs {
+		return fmt.Errorf("openChunkRun: dst length %d does not match run plaintext size %d", len(dst), int(cb.NumBlocks)*bs)
+	}
+	if len(cb.SeqNums) != int(cb.NumBlocks) {
+		return fmt.Errorf("openChunkRun: SeqNums length %d does not match NumBlocks %d", len(cb.SeqNums), cb.NumBlocks)
+	}
+	for k := 0; k < int(cb.NumBlocks); k++ {
+		seqNum := cb.SeqNums[k]
+		blockNum := cb.StartBlock + uint64(k)
+		nonce := makeNonce(seqNum, volumeUUID, DomainChunk)
+		aad := makeAAD(volumeNameHash, blockNum, seqNum)
+		sealedStart := k * sealedStride
+		sealedEnd := sealedStart + sealedStride
+		dstStart := k * bs
+		dstEnd := dstStart + bs
+		if _, err := vb.aead.Open(dst[dstStart:dstStart:dstEnd], nonce[:], ciphertext[sealedStart:sealedEnd], aad); err != nil {
+			return fmt.Errorf("%w: chunk %d block %d (seqNum %d): %w", ErrIntegrity, cb.ObjectID, blockNum, seqNum, err)
+		}
+	}
+	return nil
+}
+
+func (vb *VB) LookupBlockToObject(block uint64) (objectID uint64, objectOffset uint32, seqNum uint64, err error) {
 	slog.Debug("LookupBlockToObject", "block", block)
 
 	vb.BlocksToObject.mu.RLock()
@@ -2496,9 +2635,9 @@ func (vb *VB) LookupBlockToObject(block uint64) (objectID uint64, objectOffset u
 	slog.Debug("\tLOOKUP BLOCK TO OBJECT:", "block", block, "blockLookup", blockLookup)
 
 	if ok {
-		return blockLookup.ObjectID, blockLookup.ObjectOffset, nil
+		return blockLookup.ObjectID, blockLookup.ObjectOffset, blockLookup.SeqNum, nil
 	} else {
-		return 0, 0, ErrZeroBlock
+		return 0, 0, 0, ErrZeroBlock
 	}
 }
 
@@ -2897,14 +3036,14 @@ func (vb *VB) read(block uint64, blockLen uint64) (data []byte, err error) {
 		}
 
 		// Next, fetch which object and offset the block is within
-		objectID, objectOffset, err := vb.LookupBlockToObject(currentBlock)
+		objectID, objectOffset, seqNum, err := vb.LookupBlockToObject(currentBlock)
 		if err != nil {
 			if !errors.Is(err, ErrZeroBlock) {
 				return nil, fmt.Errorf("LookupBlockToObject block %d: %w", currentBlock, err)
 			}
 			// Block not in our own map -- check snapshot base map
 			if vb.BaseBlockMap != nil {
-				baseObjectID, baseObjectOffset, baseErr := vb.LookupBaseBlockToObject(currentBlock)
+				baseObjectID, baseObjectOffset, baseSeqNum, baseErr := vb.LookupBaseBlockToObject(currentBlock)
 				if baseErr == nil {
 					baseConsecutiveBlocks = append(baseConsecutiveBlocks, ConsecutiveBlock{
 						BlockPosition: i,
@@ -2914,6 +3053,7 @@ func (vb *VB) read(block uint64, blockLen uint64) (data []byte, err error) {
 						OffsetEnd:     end,
 						ObjectID:      baseObjectID,
 						ObjectOffset:  baseObjectOffset,
+						SeqNum:        baseSeqNum,
 					})
 					continue
 				}
@@ -2935,6 +3075,7 @@ func (vb *VB) read(block uint64, blockLen uint64) (data []byte, err error) {
 			OffsetEnd:     end,
 			ObjectID:      objectID,
 			ObjectOffset:  objectOffset,
+			SeqNum:        seqNum,
 		})
 	}
 
@@ -2965,6 +3106,17 @@ func (vb *VB) read(block uint64, blockLen uint64) (data []byte, err error) {
 			}
 		}
 
+		// Carry per-block SeqNums for the run so the encrypted decrypt loop
+		// below can reconstruct each block's nonce + AAD. Unused on
+		// unencrypted reads.
+		var seqNums []uint64
+		if vb.EncryptionEnabled {
+			seqNums = make([]uint64, numBlocks)
+			for k := 0; k < numBlocks; k++ {
+				seqNums[k] = consecutiveBlocks[i+k].SeqNum
+			}
+		}
+
 		consecutiveBlocksToRead = append(consecutiveBlocksToRead, ConsecutiveBlock{
 			BlockPosition: consecutiveBlocks[i].BlockPosition,
 			StartBlock:    consecutiveBlocks[i].StartBlock,
@@ -2973,16 +3125,23 @@ func (vb *VB) read(block uint64, blockLen uint64) (data []byte, err error) {
 			OffsetEnd:     consecutiveBlocks[i].OffsetEnd,
 			ObjectID:      consecutiveBlocks[i].ObjectID,
 			ObjectOffset:  consecutiveBlocks[i].ObjectOffset,
+			SeqNum:        consecutiveBlocks[i].SeqNum,
+			SeqNums:       seqNums,
 		})
+	}
+
+	// Per-block on-disk stride: encrypted chunks add a 16-byte GCM tag after
+	// each ciphertext block; unencrypted chunks stay at BlockSize.
+	stride := vb.BlockSize
+	if vb.EncryptionEnabled {
+		stride += 16
 	}
 
 	// Next, read our consecutive blocks from the backend
 	for _, cb := range consecutiveBlocksToRead {
 		slog.Debug("[READ] READING CONSECUTIVE BLOCK:", "startBlock", cb.StartBlock, "numBlocks", cb.NumBlocks, "offsetStart", cb.OffsetStart, "offsetEnd", cb.OffsetEnd, "objectID", cb.ObjectID, "objectOffset", cb.ObjectOffset)
 
-		// Account for our extra 10 bytes of metadata per block
-		//consecutiveBlockStart := cb.BlockPosition * uint64(vb.BlockSize)
-		consecutiveBlockOffset := (uint32(cb.NumBlocks) * vb.BlockSize)
+		consecutiveBlockOffset := uint32(cb.NumBlocks) * stride
 
 		start := cb.BlockPosition * uint64(vb.BlockSize)
 		end := start + uint64(cb.NumBlocks)*uint64(vb.BlockSize)
@@ -2993,16 +3152,21 @@ func (vb *VB) read(block uint64, blockLen uint64) (data []byte, err error) {
 		}
 
 		slog.Debug("[READ] COPYING BLOCK DATA:", "start", start, "end", end)
-		//slog.Debug("[READ] BLOCK DATA:", "blockData", blockData[:32])
 		slog.Debug("[READ] DATA:", "data len", len(data))
-		copy(data[start:end], blockData)
-		//copy(data[consecutiveBlockStart:consecutiveBlockOffset], blockData)
+
+		if vb.EncryptionEnabled {
+			if err := vb.openChunkRun(blockData, cb, vb.VolumeUUID, vb.volumeNameHash, data[start:end]); err != nil {
+				return nil, err
+			}
+		} else {
+			copy(data[start:end], blockData)
+		}
 
 		// Update the cache with the read data
 		if vb.Cache.Config.Size > 0 {
 			for i := uint64(0); i < uint64(cb.NumBlocks); i++ {
 				currentBlock := cb.StartBlock + i
-				vb.Cache.lru.Add(currentBlock, blockData[i*uint64(vb.BlockSize):(i+1)*uint64(vb.BlockSize)])
+				vb.Cache.lru.Add(currentBlock, data[start+i*uint64(vb.BlockSize):start+(i+1)*uint64(vb.BlockSize)])
 			}
 		}
 	}
@@ -3336,12 +3500,13 @@ func (vb *VB) readBlockStore(block uint64, blockLen uint64) (data []byte, err er
 				OffsetEnd:     end,
 				ObjectID:      entry.ObjectID,
 				ObjectOffset:  entry.ObjectOffset,
+				SeqNum:        entry.SeqNum,
 			})
 
 		case BlockStateEmpty:
 			// Block not in our own map -- check snapshot base map
 			if vb.BaseBlockMap != nil {
-				objectID, objectOffset, baseErr := vb.LookupBaseBlockToObject(currentBlock)
+				objectID, objectOffset, baseSeqNum, baseErr := vb.LookupBaseBlockToObject(currentBlock)
 				if baseErr == nil {
 					baseConsecutiveBlocks = append(baseConsecutiveBlocks, ConsecutiveBlock{
 						BlockPosition: i,
@@ -3351,6 +3516,7 @@ func (vb *VB) readBlockStore(block uint64, blockLen uint64) (data []byte, err er
 						OffsetEnd:     end,
 						ObjectID:      objectID,
 						ObjectOffset:  objectOffset,
+						SeqNum:        baseSeqNum,
 					})
 					continue
 				}
@@ -3402,6 +3568,14 @@ func (vb *VB) fetchConsecutiveBlocksFromBackend(consecutiveBlocks ConsecutiveBlo
 			}
 		}
 
+		var seqNums []uint64
+		if vb.EncryptionEnabled {
+			seqNums = make([]uint64, numBlocks)
+			for k := 0; k < numBlocks; k++ {
+				seqNums[k] = consecutiveBlocks[i+k].SeqNum
+			}
+		}
+
 		consecutiveBlocksToRead = append(consecutiveBlocksToRead, ConsecutiveBlock{
 			BlockPosition: consecutiveBlocks[i].BlockPosition,
 			StartBlock:    consecutiveBlocks[i].StartBlock,
@@ -3410,13 +3584,20 @@ func (vb *VB) fetchConsecutiveBlocksFromBackend(consecutiveBlocks ConsecutiveBlo
 			OffsetEnd:     consecutiveBlocks[i].OffsetEnd,
 			ObjectID:      consecutiveBlocks[i].ObjectID,
 			ObjectOffset:  consecutiveBlocks[i].ObjectOffset,
+			SeqNum:        consecutiveBlocks[i].SeqNum,
+			SeqNums:       seqNums,
 		})
+	}
+
+	stride := vb.BlockSize
+	if vb.EncryptionEnabled {
+		stride += 16
 	}
 
 	for _, cb := range consecutiveBlocksToRead {
 		slog.Debug("[READ] READING CONSECUTIVE BLOCK:", "startBlock", cb.StartBlock, "numBlocks", cb.NumBlocks)
 
-		consecutiveBlockOffset := uint32(cb.NumBlocks) * vb.BlockSize
+		consecutiveBlockOffset := uint32(cb.NumBlocks) * stride
 		start := cb.BlockPosition * uint64(vb.BlockSize)
 		end := start + uint64(cb.NumBlocks)*uint64(vb.BlockSize)
 
@@ -3425,23 +3606,31 @@ func (vb *VB) fetchConsecutiveBlocksFromBackend(consecutiveBlocks ConsecutiveBlo
 			return err
 		}
 
-		copy(data[start:end], blockData)
+		if vb.EncryptionEnabled {
+			if err := vb.openChunkRun(blockData, cb, vb.VolumeUUID, vb.volumeNameHash, data[start:end]); err != nil {
+				return err
+			}
+		} else {
+			copy(data[start:end], blockData)
+		}
 
-		// Cache blocks in BlockStore
+		// Cache blocks in BlockStore (post-decrypt plaintext)
 		if vb.UseBlockStore {
 			for i := uint64(0); i < uint64(cb.NumBlocks); i++ {
 				currentBlock := cb.StartBlock + i
-				blockStart := i * uint64(vb.BlockSize)
+				blockStart := start + i*uint64(vb.BlockSize)
 				blockEnd := blockStart + uint64(vb.BlockSize)
-				vb.BlockStore.Cache(currentBlock, blockData[blockStart:blockEnd])
+				vb.BlockStore.Cache(currentBlock, data[blockStart:blockEnd])
 			}
 		}
 
-		// Also update legacy LRU cache if enabled
+		// Also update legacy LRU cache if enabled (post-decrypt plaintext)
 		if vb.Cache.Config.Size > 0 {
 			for i := uint64(0); i < uint64(cb.NumBlocks); i++ {
 				currentBlock := cb.StartBlock + i
-				vb.Cache.lru.Add(currentBlock, blockData[i*uint64(vb.BlockSize):(i+1)*uint64(vb.BlockSize)])
+				blockStart := start + i*uint64(vb.BlockSize)
+				blockEnd := blockStart + uint64(vb.BlockSize)
+				vb.Cache.lru.Add(currentBlock, data[blockStart:blockEnd])
 			}
 		}
 	}
@@ -3451,6 +3640,12 @@ func (vb *VB) fetchConsecutiveBlocksFromBackend(consecutiveBlocks ConsecutiveBlo
 
 // fetchBaseBlocksFromBackend fetches blocks from the source volume's backend storage.
 // Used by clone volumes to read blocks that exist in the snapshot's frozen block map.
+//
+// Encrypted clones decrypt the fetched ciphertext under the SOURCE volume's
+// identity (vb.SourceVolumeUUID, vb.sourceVolumeNameHash), not the clone's
+// own identity — the chunk was sealed by the source on its original write,
+// so its nonce + AAD bind the source-volume hash and the source-side SeqNum
+// carried forward via SnapshotState.
 func (vb *VB) fetchBaseBlocksFromBackend(sourceVolume string, consecutiveBlocks ConsecutiveBlocks, data []byte) error {
 	if sourceVolume == "" {
 		return fmt.Errorf("fetchBaseBlocksFromBackend: sourceVolume is empty")
@@ -3474,6 +3669,14 @@ func (vb *VB) fetchBaseBlocksFromBackend(sourceVolume string, consecutiveBlocks 
 			}
 		}
 
+		var seqNums []uint64
+		if vb.EncryptionEnabled {
+			seqNums = make([]uint64, numBlocks)
+			for k := 0; k < numBlocks; k++ {
+				seqNums[k] = consecutiveBlocks[i+k].SeqNum
+			}
+		}
+
 		consecutiveBlocksToRead = append(consecutiveBlocksToRead, ConsecutiveBlock{
 			BlockPosition: consecutiveBlocks[i].BlockPosition,
 			StartBlock:    consecutiveBlocks[i].StartBlock,
@@ -3482,13 +3685,20 @@ func (vb *VB) fetchBaseBlocksFromBackend(sourceVolume string, consecutiveBlocks 
 			OffsetEnd:     consecutiveBlocks[i].OffsetEnd,
 			ObjectID:      consecutiveBlocks[i].ObjectID,
 			ObjectOffset:  consecutiveBlocks[i].ObjectOffset,
+			SeqNum:        consecutiveBlocks[i].SeqNum,
+			SeqNums:       seqNums,
 		})
+	}
+
+	stride := vb.BlockSize
+	if vb.EncryptionEnabled {
+		stride += 16
 	}
 
 	for _, cb := range consecutiveBlocksToRead {
 		slog.Debug("[READ] READING BASE BLOCK:", "startBlock", cb.StartBlock, "numBlocks", cb.NumBlocks, "sourceVolume", sourceVolume)
 
-		consecutiveBlockOffset := uint32(cb.NumBlocks) * vb.BlockSize
+		consecutiveBlockOffset := uint32(cb.NumBlocks) * stride
 		start := cb.BlockPosition * uint64(vb.BlockSize)
 		end := start + uint64(cb.NumBlocks)*uint64(vb.BlockSize)
 
@@ -3502,22 +3712,30 @@ func (vb *VB) fetchBaseBlocksFromBackend(sourceVolume string, consecutiveBlocks 
 			return fmt.Errorf("ReadFrom source %s object %d: short read: got %d bytes, expected %d", sourceVolume, cb.ObjectID, len(blockData), expectedLen)
 		}
 
-		copy(data[start:end], blockData)
+		if vb.EncryptionEnabled {
+			if err := vb.openChunkRun(blockData, cb, vb.SourceVolumeUUID, vb.sourceVolumeNameHash, data[start:end]); err != nil {
+				return fmt.Errorf("base chunk decrypt source %s: %w", sourceVolume, err)
+			}
+		} else {
+			copy(data[start:end], blockData)
+		}
 
-		// Cache blocks in BlockStore
+		// Cache blocks in BlockStore (post-decrypt plaintext)
 		if vb.UseBlockStore {
 			for i := uint64(0); i < uint64(cb.NumBlocks); i++ {
 				currentBlock := cb.StartBlock + i
-				blockStart := i * uint64(vb.BlockSize)
+				blockStart := start + i*uint64(vb.BlockSize)
 				blockEnd := blockStart + uint64(vb.BlockSize)
-				vb.BlockStore.Cache(currentBlock, blockData[blockStart:blockEnd])
+				vb.BlockStore.Cache(currentBlock, data[blockStart:blockEnd])
 			}
 		}
 
 		if vb.Cache.Config.Size > 0 {
 			for i := uint64(0); i < uint64(cb.NumBlocks); i++ {
 				currentBlock := cb.StartBlock + i
-				vb.Cache.lru.Add(currentBlock, blockData[i*uint64(vb.BlockSize):(i+1)*uint64(vb.BlockSize)])
+				blockStart := start + i*uint64(vb.BlockSize)
+				blockEnd := blockStart + uint64(vb.BlockSize)
+				vb.Cache.lru.Add(currentBlock, data[blockStart:blockEnd])
 			}
 		}
 	}

--- a/viperblock/viperblock.go
+++ b/viperblock/viperblock.go
@@ -287,12 +287,11 @@ type ConsecutiveBlock struct {
 	ObjectID      uint64
 	ObjectOffset  uint32
 	// SeqNum is the chunk-write generation that sealed this block's
-	// ciphertext on the backend. On pre-coalesce per-block entries it is
-	// populated from BlockLookup.SeqNum (or BlockEntry.SeqNum on the
-	// BlockStore path). After coalescing, the head block's SeqNum is left
-	// here and per-block SeqNums for the full run land in SeqNums; on the
-	// decrypt path we iterate SeqNums to reconstruct each block's nonce +
-	// AAD. Unused on unencrypted reads.
+	// ciphertext, used on pre-coalesce per-block entries (NumBlocks=1)
+	// populated from BlockLookup.SeqNum or BlockEntry.SeqNum.
+	// After coalescing, SeqNums holds the per-block SeqNums for the full
+	// run and SeqNum is left zero — openChunkRun iterates SeqNums for nonce
+	// + AAD reconstruction. Unused on unencrypted reads.
 	SeqNum  uint64
 	SeqNums []uint64
 }
@@ -1893,8 +1892,10 @@ func (vb *VB) WriteWALToChunk(force bool) error {
 		// subsumes the dropped CRC32; aead.Open validates confidentiality
 		// and integrity in one pass.
 		recordSize := 40 + int(vb.BlockSize)
+		record := make([]byte, recordSize)
+		var aad [AADLen]byte
+		initAAD(&aad, vb.volumeNameHash)
 		for {
-			record := make([]byte, recordSize)
 			if _, err := io.ReadFull(pendingWAL2, record); err != nil {
 				if err == io.EOF {
 					break
@@ -1907,8 +1908,8 @@ func (vb *VB) WriteWALToChunk(force bool) error {
 			blockLen := binary.BigEndian.Uint64(record[16:24])
 
 			nonce := makeNonce(seqNum, vb.VolumeUUID, DomainWAL)
-			aad := makeAAD(vb.volumeNameHash, blockNum, seqNum)
-			plain, err := vb.aead.Open(nil, nonce[:], record[24:], aad)
+			updateAAD(&aad, blockNum, seqNum)
+			plain, err := vb.aead.Open(nil, nonce[:], record[24:], aad[:])
 			if err != nil {
 				pos, _ := pendingWAL2.Seek(0, io.SeekCurrent)
 				slog.Error("WAL aead.Open failed", "filename", filename, "pos", pos, "block", blockNum, "seqNum", seqNum)
@@ -2114,6 +2115,8 @@ func (vb *VB) createChunkFile(currentWALNum uint64, chunkIndex uint64, chunkBuff
 	if vb.EncryptionEnabled {
 		bs := int(vb.BlockSize)
 		sealed := make([]byte, 0, len(*matchedBlocks)*(bs+16))
+		var aad [AADLen]byte
+		initAAD(&aad, vb.volumeNameHash)
 		for i, mb := range *matchedBlocks {
 			start := i * bs
 			end := start + bs
@@ -2121,8 +2124,8 @@ func (vb *VB) createChunkFile(currentWALNum uint64, chunkIndex uint64, chunkBuff
 				return fmt.Errorf("createChunkFile: matchedBlocks/chunkBuffer length mismatch (block %d of %d, buffer %d bytes)", i, len(*matchedBlocks), len(*chunkBuffer))
 			}
 			nonce := makeNonce(mb.SeqNum, vb.VolumeUUID, DomainChunk)
-			aad := makeAAD(vb.volumeNameHash, mb.Block, mb.SeqNum)
-			sealed = vb.aead.Seal(sealed, nonce[:], (*chunkBuffer)[start:end], aad)
+			updateAAD(&aad, mb.Block, mb.SeqNum)
+			sealed = vb.aead.Seal(sealed, nonce[:], (*chunkBuffer)[start:end], aad[:])
 		}
 		bodyBuffer = &sealed
 	}
@@ -2432,8 +2435,10 @@ func (vb *VB) readWALFileForRecovery(filename string) ([]Block, uint64, error) {
 	// record (same fail-tolerant posture as the legacy CRC path).
 	if vb.EncryptionEnabled {
 		recordSize := 40 + int(vb.BlockSize)
+		record := make([]byte, recordSize)
+		var aad [AADLen]byte
+		initAAD(&aad, vb.volumeNameHash)
 		for {
-			record := make([]byte, recordSize)
 			if _, err := io.ReadFull(f, record); err != nil {
 				// Tail tear: the last record was only partially written
 				// before a crash. Same fail-tolerant posture as the
@@ -2452,8 +2457,8 @@ func (vb *VB) readWALFileForRecovery(filename string) ([]Block, uint64, error) {
 			blockLen := binary.BigEndian.Uint64(record[16:24])
 
 			nonce := makeNonce(seqNum, vb.VolumeUUID, DomainWAL)
-			aad := makeAAD(vb.volumeNameHash, blockNum, seqNum)
-			plain, err := vb.aead.Open(nil, nonce[:], record[24:], aad)
+			updateAAD(&aad, blockNum, seqNum)
+			plain, err := vb.aead.Open(nil, nonce[:], record[24:], aad[:])
 			if err != nil {
 				// AEAD failure on a fully-read record is tamper, not
 				// tear. Surface as ErrIntegrity so RecoverLocalWALs
@@ -2729,16 +2734,18 @@ func (vb *VB) openChunkRun(ciphertext []byte, cb ConsecutiveBlock, volumeUUID [4
 	if len(cb.SeqNums) != int(cb.NumBlocks) {
 		return fmt.Errorf("openChunkRun: SeqNums length %d does not match NumBlocks %d", len(cb.SeqNums), cb.NumBlocks)
 	}
+	var aad [AADLen]byte
+	initAAD(&aad, volumeNameHash)
 	for k := 0; k < int(cb.NumBlocks); k++ {
 		seqNum := cb.SeqNums[k]
 		blockNum := cb.StartBlock + uint64(k)
 		nonce := makeNonce(seqNum, volumeUUID, DomainChunk)
-		aad := makeAAD(volumeNameHash, blockNum, seqNum)
+		updateAAD(&aad, blockNum, seqNum)
 		sealedStart := k * sealedStride
 		sealedEnd := sealedStart + sealedStride
 		dstStart := k * bs
 		dstEnd := dstStart + bs
-		if _, err := vb.aead.Open(dst[dstStart:dstStart:dstEnd], nonce[:], ciphertext[sealedStart:sealedEnd], aad); err != nil {
+		if _, err := vb.aead.Open(dst[dstStart:dstStart:dstEnd], nonce[:], ciphertext[sealedStart:sealedEnd], aad[:]); err != nil {
 			return fmt.Errorf("%w: chunk %d block %d (seqNum %d): %w", ErrIntegrity, cb.ObjectID, blockNum, seqNum, err)
 		}
 	}
@@ -2772,10 +2779,11 @@ func (vb *VB) LookupBlockToObject(block uint64) (objectID uint64, objectOffset u
 // metadata HMAC). The local write is atomic — tmp file + fsync + rename
 // + fsync parent dir — so a crash mid-persist cannot leave a torn config.json
 // that would let reserveSeqNum re-hand-out values on restart.
+// SaveState persists VBState with the currently-committed SeqNumHighWater.
+// Bootstraps VolumeUUID + initial high-water on first call of an encrypted
+// volume — safe because Open serializes its bootstrap SaveState before any
+// data writer can run.
 func (vb *VB) SaveState() error {
-	vb.BlocksToObject.mu.Lock()
-	defer vb.BlocksToObject.mu.Unlock()
-
 	if vb.EncryptionEnabled {
 		var zero [4]byte
 		if vb.VolumeUUID == zero {
@@ -2785,6 +2793,32 @@ func (vb *VB) SaveState() error {
 			vb.seqNumHighWater.Store(seqNumReservation)
 		}
 	}
+	return vb.saveStateWithHighWater(vb.seqNumHighWater.Load())
+}
+
+// saveStateWithHighWater persists VBState with an explicit SeqNumHighWater
+// value rather than reading vb.seqNumHighWater. reserveSeqNum needs to durably
+// commit a NEW high-water before publishing it via vb.seqNumHighWater.Store —
+// publishing first and then persisting would race the lock-free fast path:
+// concurrent writers observing the speculative in-memory value would issue
+// SeqNums above the persisted high-water, and a crash before persist
+// completion would let those values be re-issued on restart (catastrophic
+// AES-GCM nonce reuse, NIST SP 800-38D §8.3).
+func (vb *VB) saveStateWithHighWater(highWater uint64) error {
+	persisted, err := vb.persistStateLocal(highWater)
+	if err != nil {
+		return err
+	}
+	return vb.pushStateToBackend(persisted)
+}
+
+// persistStateLocal marshals VBState, seals it for encrypted volumes, and
+// fsyncs the local config.json. Returns the persisted bytes so callers can
+// hand them to pushStateToBackend without re-marshaling. Crash-safety lives
+// in this step: when it returns nil, the new state is durable on local disk.
+func (vb *VB) persistStateLocal(highWater uint64) ([]byte, error) {
+	vb.BlocksToObject.mu.Lock()
+	defer vb.BlocksToObject.mu.Unlock()
 
 	walNum := vb.WAL.WallNum.Load()
 	if vb.UseShardedWAL && vb.ShardedWAL != nil {
@@ -2807,7 +2841,7 @@ func (vb *VB) SaveState() error {
 		SourceVolumeName:    vb.SourceVolumeName,
 		EncryptionEnabled:   vb.EncryptionEnabled,
 		VolumeUUID:          vb.VolumeUUID,
-		SeqNumHighWater:     vb.seqNumHighWater.Load(),
+		SeqNumHighWater:     highWater,
 	}
 
 	if vb.EncryptionEnabled {
@@ -2818,15 +2852,14 @@ func (vb *VB) SaveState() error {
 
 	jsonData, err := json.Marshal(state)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// Encrypted volumes append a 16-byte AES-GCM tag binding the JSON bytes to
-	// (volumeNameHash, "vbstate", StateSeqNum). Closes the cross-volume
-	// metadata pivot: an attacker swapping volume A's config.json into volume
-	// B's prefix is rejected at LoadStateRequest because the AAD
-	// reconstruction uses vb.volumeNameHash (our own identity), which differs
-	// from the seal-time hash for volume A.
+	// (volumeNameHash, "vbstate", StateSeqNum). An attacker swapping volume
+	// A's config.json into volume B's prefix is rejected at LoadStateRequest
+	// because the AAD reconstruction uses vb.volumeNameHash (our own
+	// identity), which differs from the seal-time hash for volume A.
 	persisted := jsonData
 	if vb.EncryptionEnabled {
 		nonce := makeNonce(state.StateSeqNum, vb.VolumeUUID, DomainVBStateMeta)
@@ -2836,16 +2869,20 @@ func (vb *VB) SaveState() error {
 
 	filename := fmt.Sprintf("%s/%s", vb.BaseDir, types.GetFilePath(types.FileTypeConfig, 0, vb.GetVolume()))
 	if err := writeFileAtomic(filename, persisted, 0600); err != nil {
-		return fmt.Errorf("SaveState: atomic write %s: %w", filename, err)
+		return nil, fmt.Errorf("SaveState: atomic write %s: %w", filename, err)
 	}
 
-	// Next, write to the backend.
+	return persisted, nil
+}
+
+// pushStateToBackend writes pre-marshaled VBState bytes to the backend (S3
+// PUT for the S3 backend). Safe to call without seqNumHighWaterMu held —
+// LoadState reconciles local vs backend by max(SeqNum), so a stale or
+// in-flight backend write is non-fatal as long as the local fsync from
+// persistStateLocal succeeded.
+func (vb *VB) pushStateToBackend(persisted []byte) error {
 	headers := []byte{}
-	if err := vb.Backend.Write(types.FileTypeConfig, 0, &headers, &persisted); err != nil {
-		return err
-	}
-
-	return nil
+	return vb.Backend.Write(types.FileTypeConfig, 0, &headers, &persisted)
 }
 
 // writeFileAtomic writes data to path atomically via tmp + fsync + rename +
@@ -3049,18 +3086,38 @@ func (vb *VB) reserveSeqNum(n uint64) (start uint64, err error) {
 		return start, nil
 	}
 	vb.seqNumHighWaterMu.Lock()
-	defer vb.seqNumHighWaterMu.Unlock()
 	// Re-check under the mutex: another caller may have advanced past us.
 	hw := vb.seqNumHighWater.Load()
 	if end <= hw {
+		vb.seqNumHighWaterMu.Unlock()
 		return start, nil
 	}
 	for end > hw {
 		hw += seqNumReservation
 	}
+	// Persist locally BEFORE publishing the new hw to vb.seqNumHighWater.
+	// While we hold the mutex, concurrent fast-path callers checking
+	// vb.seqNumHighWater see the OLD value: below it they proceed safely
+	// within the already-persisted range; above it they take the slow path
+	// and block here. Either way, no SeqNum above the durable hw is issued.
+	// If persistStateLocal fails, hw is never published — recovery is just
+	// "retry on next reserve."
+	persisted, err := vb.persistStateLocal(hw)
+	if err != nil {
+		vb.seqNumHighWaterMu.Unlock()
+		return 0, fmt.Errorf("reserveSeqNum: persistStateLocal: %w", err)
+	}
 	vb.seqNumHighWater.Store(hw)
-	if err := vb.SaveState(); err != nil {
-		return 0, fmt.Errorf("reserveSeqNum: SaveState: %w", err)
+	vb.seqNumHighWaterMu.Unlock()
+
+	// Backend push happens outside the mutex — the S3 PUT can be tens to
+	// hundreds of ms and would otherwise gate every reservation-window
+	// crossing. Crash-safety lives in the local fsync above; LoadState picks
+	// max(local, backend) SeqNum so a lagged or failed backend write is
+	// recoverable on next SaveState.
+	if perr := vb.pushStateToBackend(persisted); perr != nil {
+		slog.Warn("reserveSeqNum: backend state push failed; local fsync is durable",
+			"volume", vb.VolumeName, "highWater", hw, "err", perr)
 	}
 	return start, nil
 }
@@ -3071,9 +3128,20 @@ func (vb *VB) reserveSeqNum(n uint64) (start uint64, err error) {
 // SeqNum that overlaps the pre-crash range.
 func (vb *VB) bumpSeqNumHighWater() error {
 	vb.seqNumHighWaterMu.Lock()
-	defer vb.seqNumHighWaterMu.Unlock()
-	vb.seqNumHighWater.Add(seqNumReservation)
-	return vb.SaveState()
+	newHW := vb.seqNumHighWater.Load() + seqNumReservation
+	persisted, err := vb.persistStateLocal(newHW)
+	if err != nil {
+		vb.seqNumHighWaterMu.Unlock()
+		return err
+	}
+	vb.seqNumHighWater.Store(newHW)
+	vb.seqNumHighWaterMu.Unlock()
+
+	if perr := vb.pushStateToBackend(persisted); perr != nil {
+		slog.Warn("bumpSeqNumHighWater: backend state push failed; local fsync is durable",
+			"volume", vb.VolumeName, "highWater", newHW, "err", perr)
+	}
+	return nil
 }
 
 // Query the local state from file or the backend
@@ -3309,7 +3377,6 @@ func (vb *VB) read(block uint64, blockLen uint64) (data []byte, err error) {
 			OffsetEnd:     consecutiveBlocks[i].OffsetEnd,
 			ObjectID:      consecutiveBlocks[i].ObjectID,
 			ObjectOffset:  consecutiveBlocks[i].ObjectOffset,
-			SeqNum:        consecutiveBlocks[i].SeqNum,
 			SeqNums:       seqNums,
 		})
 	}
@@ -3775,7 +3842,6 @@ func (vb *VB) fetchConsecutiveBlocksFromBackend(consecutiveBlocks ConsecutiveBlo
 			OffsetEnd:     consecutiveBlocks[i].OffsetEnd,
 			ObjectID:      consecutiveBlocks[i].ObjectID,
 			ObjectOffset:  consecutiveBlocks[i].ObjectOffset,
-			SeqNum:        consecutiveBlocks[i].SeqNum,
 			SeqNums:       seqNums,
 		})
 	}
@@ -3883,7 +3949,6 @@ func (vb *VB) fetchBaseBlocksFromBackend(sourceVolume string, consecutiveBlocks 
 			OffsetEnd:     consecutiveBlocks[i].OffsetEnd,
 			ObjectID:      consecutiveBlocks[i].ObjectID,
 			ObjectOffset:  consecutiveBlocks[i].ObjectOffset,
-			SeqNum:        consecutiveBlocks[i].SeqNum,
 			SeqNums:       seqNums,
 		})
 	}

--- a/viperblock/viperblock.go
+++ b/viperblock/viperblock.go
@@ -1155,8 +1155,14 @@ func (vb *VB) flushLocked() error {
 	flushBlocks := make([]Block, len(vb.Writes.Blocks))
 	copy(flushBlocks, vb.Writes.Blocks)
 
-	// Map to track successfully flushed blocks
-	flushed := make(map[uint64]uint64) // block -> seqnum
+	// flushed maps block number -> latest SeqNum that landed in the WAL,
+	// used to filter vb.Writes.Blocks and feed PendingBackendWrites. It
+	// dedupes by block number, so its cardinality CANNOT be used to detect
+	// partial flushes: when a hot block is rewritten N times in a window,
+	// N successful WriteWAL calls collapse into one map entry. successCount
+	// tracks records persisted, which is what "partial flush" actually means.
+	flushed := make(map[uint64]uint64)
+	successCount := 0
 
 	for _, block := range flushBlocks {
 		if err := vb.WriteWAL(block); err != nil {
@@ -1164,7 +1170,7 @@ func (vb *VB) flushLocked() error {
 			break
 		}
 
-		// Record successful flush
+		successCount++
 		flushed[block.Block] = block.SeqNum
 
 		// Mark block as Pending in BlockStore (Hot -> Pending transition)
@@ -1178,8 +1184,6 @@ func (vb *VB) flushLocked() error {
 		remaining := make([]Block, 0)
 		for _, b := range vb.Writes.Blocks {
 			if _, ok := flushed[b.Block]; !ok {
-				//slog.Info("REMAINING:", "block", b.Block, "seqnum", b.SeqNum)
-				// Either this block wasn't flushed, or it was rewritten after flush started
 				remaining = append(remaining, b)
 			}
 		}
@@ -1196,8 +1200,8 @@ func (vb *VB) flushLocked() error {
 	}
 	vb.PendingBackendWrites.mu.Unlock()
 
-	if len(flushed) < len(flushBlocks) {
-		return fmt.Errorf("partial flush: %d of %d blocks flushed", len(flushed), len(flushBlocks))
+	if successCount < len(flushBlocks) {
+		return fmt.Errorf("partial flush: %d of %d records flushed", successCount, len(flushBlocks))
 	}
 
 	return nil
@@ -1223,8 +1227,9 @@ func (vb *VB) flushLockedSharded() error {
 
 	// Write to each shard in parallel
 	type shardError struct {
-		err     error
-		flushed map[uint64]uint64
+		err          error
+		flushed      map[uint64]uint64
+		successCount int
 	}
 	results := make([]shardError, NumShards)
 	var wg sync.WaitGroup
@@ -1238,13 +1243,16 @@ func (vb *VB) flushLockedSharded() error {
 		go func(shardID int) {
 			defer wg.Done()
 			flushed := make(map[uint64]uint64)
+			successCount := 0
 			for _, block := range shardGroups[shardID] {
 				if err := vb.WriteShardedWAL(block); err != nil {
 					slog.Error("ERROR FLUSHING SHARD:", "shard", shardID, "block", block.Block, "error", err)
 					results[shardID].err = err
 					results[shardID].flushed = flushed
+					results[shardID].successCount = successCount
 					return
 				}
+				successCount++
 				flushed[block.Block] = block.SeqNum
 
 				if vb.UseBlockStore && vb.BlockStore != nil {
@@ -1252,15 +1260,20 @@ func (vb *VB) flushLockedSharded() error {
 				}
 			}
 			results[shardID].flushed = flushed
+			results[shardID].successCount = successCount
 		}(i)
 	}
 	wg.Wait()
 
-	// Merge flushed maps from all shards
+	// Merge flushed maps from all shards. allFlushed dedupes by block number
+	// so its cardinality CANNOT be used to detect partial flushes — see
+	// flushLocked. totalSuccess sums records persisted per shard.
 	allFlushed := make(map[uint64]uint64)
 	var firstErr error
+	totalSuccess := 0
 	for i := range NumShards {
 		maps.Copy(allFlushed, results[i].flushed)
+		totalSuccess += results[i].successCount
 		if results[i].err != nil && firstErr == nil {
 			firstErr = results[i].err
 		}
@@ -1287,7 +1300,7 @@ func (vb *VB) flushLockedSharded() error {
 	vb.PendingBackendWrites.mu.Unlock()
 
 	if firstErr != nil {
-		return fmt.Errorf("partial sharded flush: %d of %d blocks flushed: %w", len(allFlushed), len(flushBlocks), firstErr)
+		return fmt.Errorf("partial sharded flush: %d of %d records flushed: %w", totalSuccess, len(flushBlocks), firstErr)
 	}
 
 	return nil
@@ -4093,6 +4106,7 @@ func (vb *VB) FlushBlockStore() error {
 	}
 
 	flushed := make(map[uint64]uint64) // block -> seqnum
+	successCount := 0
 
 	for _, block := range hotBlocks {
 		if err := vb.WriteWAL(block); err != nil {
@@ -4100,6 +4114,7 @@ func (vb *VB) FlushBlockStore() error {
 			break
 		}
 
+		successCount++
 		flushed[block.Block] = block.SeqNum
 		// Transition to Pending in BlockStore
 		vb.BlockStore.MarkPending(block.Block)
@@ -4123,8 +4138,8 @@ func (vb *VB) FlushBlockStore() error {
 		vb.PendingBackendWrites.mu.Unlock()
 	}
 
-	if len(flushed) < len(hotBlocks) {
-		return fmt.Errorf("partial flush: %d of %d blocks flushed", len(flushed), len(hotBlocks))
+	if successCount < len(hotBlocks) {
+		return fmt.Errorf("partial flush: %d of %d records flushed", successCount, len(hotBlocks))
 	}
 
 	return nil

--- a/viperblock/viperblock.go
+++ b/viperblock/viperblock.go
@@ -1321,16 +1321,36 @@ func (vb *VB) WriteWAL(block Block) (err error) {
 
 	vb.WAL.mu.Lock()
 	currentWAL := vb.WAL.DB[len(vb.WAL.DB)-1]
+	// O_APPEND makes the file offset unreliable; Stat is the source of truth
+	// for the on-disk boundary we may need to roll back to.
+	preStat, statErr := currentWAL.Stat()
+	if statErr != nil {
+		vb.WAL.mu.Unlock()
+		return fmt.Errorf("error obtaining WAL size before write: %w", statErr)
+	}
+	preSize := preStat.Size()
 	n, err := currentWAL.Write(record)
 	vb.WAL.dirty.Store(true)
-	vb.WAL.mu.Unlock()
 
-	if n != len(record) {
-		slog.Error("ERROR WRITING BLOCK TO WAL: incomplete write", "n", n, "expected", len(record))
-		return fmt.Errorf("incomplete write to WAL: wrote %d of %d bytes", n, len(record))
+	if err != nil || n != len(record) {
+		// Torn write: roll back to the last record boundary so future appends
+		// and replay stay aligned with the record framing.
+		truncErr := currentWAL.Truncate(preSize)
+		vb.WAL.mu.Unlock()
+
+		if truncErr != nil {
+			return fmt.Errorf("incomplete WAL write (wrote %d of %d bytes) and truncate to %d failed: %w", n, len(record), preSize, truncErr)
+		}
+		if err != nil {
+			slog.Error("WAL write failed, truncated to last boundary", "n", n, "expected", len(record), "preSize", preSize, "error", err)
+			return fmt.Errorf("WAL write failed (truncated to %d): %w", preSize, err)
+		}
+		slog.Error("WAL incomplete write, truncated to last boundary", "n", n, "expected", len(record), "preSize", preSize)
+		return fmt.Errorf("incomplete write to WAL: wrote %d of %d bytes (truncated to %d)", n, len(record), preSize)
 	}
 
-	return err
+	vb.WAL.mu.Unlock()
+	return nil
 }
 
 // WriteShardedWAL writes a block to the appropriate shard based on block number.

--- a/viperblock/viperblock.go
+++ b/viperblock/viperblock.go
@@ -214,6 +214,15 @@ type VB struct {
 	// the value is bound into the VBState metadata HMAC and breaks ties when
 	// LoadState picks between local and backend copies.
 	nextStateSeqNum atomic.Uint64
+
+	// saveStateMu serialises persistStateLocal so the StateSeqNum bump,
+	// marshal, and atomic rename are observed in monotonic order on disk.
+	// Without serialisation two concurrent SaveStates could mint StateSeqNum
+	// N and N+1 then rename in either order, leaving the lower StateSeqNum
+	// as the on-disk winner. Held only across the marshal+fsync path; not
+	// shared with the read-path mutex so LookupBlockToObject and friends
+	// stay uncontended.
+	saveStateMu sync.Mutex
 }
 
 // CacheConfig holds configuration for the LRU cache
@@ -437,9 +446,10 @@ var ErrIntegrity = errors.New("viperblock: integrity check failed")
 // the pre-encryption magic — VBCH for chunks, VBWL for the single-file WAL.
 // Without this dedicated signal the chunk read path would try to AEAD-open
 // plaintext bytes and surface a generic ErrIntegrity, leaving operators with
-// no actionable migration cue. Callers must refuse to open the volume and
-// direct the operator to the migration tool before retrying.
-var ErrPreEncryptionFormat = errors.New("viperblock: chunk has pre-encryption format (VBCH) but volume opened with EncryptionEnabled=true; migrate via the viperblock migration tool before re-opening")
+// no actionable migration cue. The supported migration path is a hard cutover:
+// create a new encrypted volume and copy data across via guest-side tooling
+// (dd, filesystem-level copy). Callers must refuse to open the volume.
+var ErrPreEncryptionFormat = errors.New("viperblock: chunk has pre-encryption format (VBCH) but volume opened with EncryptionEnabled=true; create a new encrypted volume and copy data across via guest-side tooling")
 
 // classifyStateLoad maps the local and backend LoadStateRequest errors into a
 // sentinel suitable for callers. The local read is informational — its
@@ -1321,8 +1331,10 @@ func (vb *VB) WriteWAL(block Block) (err error) {
 		binary.BigEndian.PutUint64(record[8:16], block.Block)
 		binary.BigEndian.PutUint64(record[16:24], block.Len)
 		nonce := makeNonce(block.SeqNum, vb.VolumeUUID, DomainWAL)
-		aad := makeAAD(vb.volumeNameHash, block.Block, block.SeqNum)
-		record = vb.aead.Seal(record, nonce[:], block.Data, aad)
+		var aad [AADLen]byte
+		initAAD(&aad, vb.volumeNameHash)
+		updateAAD(&aad, block.Block, block.SeqNum)
+		record = vb.aead.Seal(record, nonce[:], block.Data, aad[:])
 	} else {
 		// Legacy layout (magic VBWL), per-record:
 		//   [SeqNum(8) | BlockNum(8) | BlockLen(8) | CRC32(4) | data(BlockLen)]
@@ -2558,6 +2570,14 @@ func (vb *VB) RecoverLocalWALs() error {
 		fullPath := filepath.Join(walDir, fname)
 		blocks, fileMaxSeq, err := vb.readWALFileForRecovery(fullPath)
 		if err != nil {
+			// An integrity failure on a recovered WAL is fail-closed: the
+			// tampered or torn file may hold the only durable copy of writes
+			// that never made it to a chunk, and silently skipping it would
+			// surface as data loss. Abort so the caller can refuse to bring
+			// the volume up; the file stays on disk for forensics + retry.
+			if errors.Is(err, ErrIntegrity) {
+				return fmt.Errorf("WAL recovery: integrity failure in %s: %w", fname, err)
+			}
 			slog.Error("WAL recovery: failed to read WAL file, keeping for retry", "file", fname, "error", err)
 			continue
 		}
@@ -2704,11 +2724,6 @@ func (vb *VB) checkChunkMagic(volumeName string, objectID uint64, read func(offs
 	return nil
 }
 
-// Lookup Block to Object
-// LookupBlockToObject returns the persisted location of a block plus its
-// chunk-write SeqNum. The SeqNum return drives nonce + AAD reconstruction on
-// the decrypt path; on unencrypted volumes callers ignore it. Returns
-// ErrZeroBlock when the block has never been written.
 // openChunkRun decrypts a coalesced run of N chunk blocks read from the
 // backend at stride BlockSize+16. Each block's nonce is reconstructed from
 // (cb.SeqNums[k], volumeUUID, DomainChunk) and AAD from (volumeNameHash,
@@ -2752,6 +2767,10 @@ func (vb *VB) openChunkRun(ciphertext []byte, cb ConsecutiveBlock, volumeUUID [4
 	return nil
 }
 
+// LookupBlockToObject returns the persisted location of a block plus its
+// chunk-write SeqNum. The SeqNum return drives nonce + AAD reconstruction on
+// the decrypt path; on unencrypted volumes callers ignore it. Returns
+// ErrZeroBlock when the block has never been written.
 func (vb *VB) LookupBlockToObject(block uint64) (objectID uint64, objectOffset uint32, seqNum uint64, err error) {
 	slog.Debug("LookupBlockToObject", "block", block)
 
@@ -2770,19 +2789,15 @@ func (vb *VB) LookupBlockToObject(block uint64) (objectID uint64, objectOffset u
 	}
 }
 
-// Save the block tracking state to disk.
+// SaveState persists VBState to disk and to the backend.
 //
-// For encrypted volumes, SaveState bootstraps the per-volume nonce subspace
-// on first call: if VolumeUUID is zero we mint it via crypto/rand and seed
+// For encrypted volumes, the first call bootstraps the per-volume nonce
+// subspace: if VolumeUUID is zero we mint it via crypto/rand and seed
 // SeqNumHighWater = seqNumReservation. Subsequent calls preserve the existing
 // UUID and advance StateSeqNum monotonically (the value is bound into the
-// metadata HMAC). The local write is atomic — tmp file + fsync + rename
-// + fsync parent dir — so a crash mid-persist cannot leave a torn config.json
+// metadata HMAC). The local write is atomic — tmp file + fsync + rename +
+// fsync parent dir — so a crash mid-persist cannot leave a torn config.json
 // that would let reserveSeqNum re-hand-out values on restart.
-// SaveState persists VBState with the currently-committed SeqNumHighWater.
-// Bootstraps VolumeUUID + initial high-water on first call of an encrypted
-// volume — safe because Open serializes its bootstrap SaveState before any
-// data writer can run.
 func (vb *VB) SaveState() error {
 	if vb.EncryptionEnabled {
 		var zero [4]byte
@@ -2817,8 +2832,8 @@ func (vb *VB) saveStateWithHighWater(highWater uint64) error {
 // hand them to pushStateToBackend without re-marshaling. Crash-safety lives
 // in this step: when it returns nil, the new state is durable on local disk.
 func (vb *VB) persistStateLocal(highWater uint64) ([]byte, error) {
-	vb.BlocksToObject.mu.Lock()
-	defer vb.BlocksToObject.mu.Unlock()
+	vb.saveStateMu.Lock()
+	defer vb.saveStateMu.Unlock()
 
 	walNum := vb.WAL.WallNum.Load()
 	if vb.UseShardedWAL && vb.ShardedWAL != nil {
@@ -2966,11 +2981,35 @@ func (vb *VB) LoadState() error {
 		return classified
 	}
 
-	// Step 3. Compare the two states, the state with the highest SeqNum is the correct state.
-	// When local state failed to load (e.g. no local file for a newly created volume),
-	// always prefer the backend state regardless of SeqNum.
-	if localErr != nil || stateBackend.SeqNum > state.SeqNum {
+	// Step 3. Compare the two states and select the authoritative copy.
+	// StateSeqNum is the SaveState generation counter — bumped on every
+	// persist whether or not data writes occurred — so it is the
+	// strictly-monotonic tiebreak the rollback defense rests on (an attacker
+	// who rolls the backend back to v1 loses to local v2 because v2's
+	// StateSeqNum is strictly higher). When local failed to load (e.g. no
+	// local file for a newly created volume), always prefer the backend
+	// state regardless.
+	if localErr != nil || stateBackend.StateSeqNum > state.StateSeqNum {
 		state = stateBackend
+	}
+
+	// Step 4. Validate encryption invariants against the selected state
+	// BEFORE mutating any vb.* field. A wrong-key open, a flag XOR mismatch,
+	// or a key-fingerprint mismatch must leave the VB untouched so callers
+	// that log the error and continue cannot operate on partially-loaded
+	// state derived from the rejected blob.
+	if vb.EncryptionEnabled != state.EncryptionEnabled {
+		return fmt.Errorf("%w: runtime EncryptionEnabled=%v, persisted=%v (volume %s)",
+			ErrEncryptionMismatch, vb.EncryptionEnabled, state.EncryptionEnabled, vb.VolumeName)
+	}
+	if vb.EncryptionEnabled {
+		if vb.MasterKey == nil {
+			return fmt.Errorf("%w: volume %s requires master key", ErrEncryptionMismatch, vb.VolumeName)
+		}
+		if state.KeyFingerprint != vb.MasterKey.Fingerprint {
+			return fmt.Errorf("%w: volume %s sealed under key %s, supplied key is %s",
+				ErrEncryptionMismatch, vb.VolumeName, state.KeyFingerprint, vb.MasterKey.Fingerprint)
+		}
 	}
 
 	// Reconcile VolumeSize with VolumeConfig.SizeGiB (safety net for resize).
@@ -2986,8 +3025,6 @@ func (vb *VB) LoadState() error {
 		slog.Warn("LoadState: VolumeConfig.SizeGiB < VBState.VolumeSize (shrink not supported, keeping current size)",
 			"configSize", configSizeBytes, "stateSize", state.VolumeSize)
 	}
-
-	// TODO: Add improved test cases for state.json corruption and edge cases
 
 	vb.VolumeName = state.VolumeName
 	vb.VolumeSize = state.VolumeSize
@@ -3012,34 +3049,14 @@ func (vb *VB) LoadState() error {
 
 	vb.nextStateSeqNum.Store(state.StateSeqNum)
 
-	// Encryption-at-rest validation and SeqNum bootstrap.
-	//
-	// The runtime must agree with the persisted flag — supplying a key for an
-	// unencrypted volume, or omitting the key for an encrypted one, is a
-	// startup-time error rather than a silent fall-through. Key fingerprint
-	// mismatch surfaces the same way (an operator who points the daemon at
-	// the wrong key file sees a clear error rather than every read failing
-	// integrity later).
-	//
-	// On a successful Open of an existing encrypted volume, restart SeqNum at
-	// the persisted high-water and reserve the next window durably before any
-	// data write can hand out a value. This is what makes nonce uniqueness
-	// crash-safe: a kill -9 before the next SaveState loses up to one
-	// reservation window of values, but every value handed out before the
-	// crash sits below the high-water we just persisted, so none can be
-	// re-issued.
-	if vb.EncryptionEnabled != state.EncryptionEnabled {
-		return fmt.Errorf("%w: runtime EncryptionEnabled=%v, persisted=%v (volume %s)",
-			ErrEncryptionMismatch, vb.EncryptionEnabled, state.EncryptionEnabled, vb.VolumeName)
-	}
+	// Encryption SeqNum bootstrap. On a successful Open of an existing
+	// encrypted volume, restart SeqNum at the persisted high-water and
+	// reserve the next window durably before any data write can hand out a
+	// value. This is what makes nonce uniqueness crash-safe: a kill -9
+	// before the next SaveState loses up to one reservation window of
+	// values, but every value handed out before the crash sits below the
+	// high-water we just persisted, so none can be re-issued.
 	if vb.EncryptionEnabled {
-		if vb.MasterKey == nil {
-			return fmt.Errorf("%w: volume %s requires master key", ErrEncryptionMismatch, vb.VolumeName)
-		}
-		if state.KeyFingerprint != vb.MasterKey.Fingerprint {
-			return fmt.Errorf("%w: volume %s sealed under key %s, supplied key is %s",
-				ErrEncryptionMismatch, vb.VolumeName, state.KeyFingerprint, vb.MasterKey.Fingerprint)
-		}
 		vb.VolumeUUID = state.VolumeUUID
 		vb.SeqNum.Store(state.SeqNumHighWater)
 		vb.seqNumHighWater.Store(state.SeqNumHighWater)
@@ -3068,8 +3085,9 @@ func (vb *VB) LoadState() error {
 // fact and only when crossed do we take seqNumHighWaterMu and SaveState to
 // advance it. Refuses past MaxSeqNum (56-bit nonce slot).
 //
-// Lock order: callers must NOT hold BlocksToObject.mu — the slow path takes
-// seqNumHighWaterMu then calls SaveState, which acquires BlocksToObject.mu.
+// Lock order: the slow path takes seqNumHighWaterMu then calls
+// persistStateLocal, which acquires saveStateMu. saveStateMu must not be
+// held when calling reserveSeqNum.
 //
 // Unencrypted volumes fall through to plain atomic.Add — the high-water is a
 // nonce-uniqueness mechanism and is irrelevant when no nonce exists.

--- a/viperblock/viperblock_test.go
+++ b/viperblock/viperblock_test.go
@@ -1803,13 +1803,12 @@ func TestPendingBackendWritesDeduplication(t *testing.T) {
 				assert.NoError(t, err)
 			}
 
-			// Flush() returns "partial flush" error when duplicate block numbers exist
-			// because the flushed map deduplicates by block number.
-			// 9 writes (5 to block 700, 4 to 701-704) result in 5 unique blocks.
-			// This is expected behavior - we just need the data to be persisted.
-			_ = vb.Flush()
+			// All 9 records (5 to block 700, 4 to 701-704) land in the WAL.
+			// Flush must succeed regardless of duplicate block numbers.
+			err := vb.Flush()
+			assert.NoError(t, err)
 
-			err := vb.WriteWALToChunk(true)
+			err = vb.WriteWALToChunk(true)
 			assert.NoError(t, err)
 
 			// All pending should be cleared after chunk creation

--- a/viperblock/viperblock_test.go
+++ b/viperblock/viperblock_test.go
@@ -1037,7 +1037,7 @@ func TestBlockLookup(t *testing.T) {
 			// Test LookupBlockToObject
 
 			for _, block := range []uint64{0, 1, 2} {
-				objectID, objectOffset, err := vb.LookupBlockToObject(block)
+				objectID, objectOffset, _, err := vb.LookupBlockToObject(block)
 				assert.Error(t, err)
 				assert.Equal(t, uint64(0), objectID)
 				assert.Equal(t, uint32(0), objectOffset)
@@ -1053,7 +1053,7 @@ func TestBlockLookup(t *testing.T) {
 
 			// Test LookupBlockToObject
 			for _, block := range []uint64{0, 1, 2} {
-				objectID, objectOffset, err := vb.LookupBlockToObject(block)
+				objectID, objectOffset, _, err := vb.LookupBlockToObject(block)
 				assert.NoError(t, err)
 				assert.Equal(t, objectID, uint64(0))
 				offset := vb.BlockSize*uint32(block) + uint32(headersLen)
@@ -1074,7 +1074,7 @@ func TestBlockLookup(t *testing.T) {
 			assert.NoError(t, err)
 
 			// Confirm the block does not exist in the object/chunk file (since not flushed/Write to WAL)
-			objectID, objectOffset, err := vb.LookupBlockToObject(3)
+			objectID, objectOffset, _, err := vb.LookupBlockToObject(3)
 			assert.Error(t, err)
 			assert.Equal(t, uint64(0), objectID)
 			assert.Equal(t, uint32(0), objectOffset)
@@ -1086,7 +1086,7 @@ func TestBlockLookup(t *testing.T) {
 			assert.NoError(t, err)
 
 			// Lookup the block in the WAL, should be the 2nd chunk
-			objectID, objectOffset, err = vb.LookupBlockToObject(3)
+			objectID, objectOffset, _, err = vb.LookupBlockToObject(3)
 			assert.NoError(t, err)
 			assert.Equal(t, uint64(1), objectID)
 			offset := vb.BlockSize*uint32(0) + uint32(headersLen)
@@ -1189,7 +1189,7 @@ func TestInvalidS3Host(t *testing.T) {
 			assert.NoError(t, err)
 
 			// Confirm the block does not exist in the object/chunk file (since not flushed/Write to WAL)
-			objectID, objectOffset, err := vb.LookupBlockToObject(5)
+			objectID, objectOffset, _, err := vb.LookupBlockToObject(5)
 			assert.Error(t, err)
 			assert.Equal(t, uint64(0), objectID)
 			assert.Equal(t, uint32(0), objectOffset)
@@ -1201,7 +1201,7 @@ func TestInvalidS3Host(t *testing.T) {
 			assert.Error(t, err)
 
 			// Confirm the block does not exist in the object/chunk file (since not flushed/Write to WAL)
-			objectID, objectOffset, err = vb.LookupBlockToObject(4)
+			objectID, objectOffset, _, err = vb.LookupBlockToObject(4)
 			assert.Error(t, err)
 			assert.Equal(t, uint64(0), objectID)
 			assert.Equal(t, uint32(0), objectOffset)
@@ -1242,7 +1242,7 @@ func TestInvalidS3Bucket(t *testing.T) {
 			assert.NoError(t, err)
 
 			// Confirm the block does not exist in the object/chunk file (since not flushed/Write to WAL)
-			objectID, objectOffset, err := vb.LookupBlockToObject(5)
+			objectID, objectOffset, _, err := vb.LookupBlockToObject(5)
 			assert.Error(t, err)
 			assert.Equal(t, uint64(0), objectID)
 			assert.Equal(t, uint32(0), objectOffset)
@@ -1254,7 +1254,7 @@ func TestInvalidS3Bucket(t *testing.T) {
 			assert.Error(t, err)
 
 			// Confirm the block does not exist in the object/chunk file (since not flushed/Write to WAL)
-			objectID, objectOffset, err = vb.LookupBlockToObject(4)
+			objectID, objectOffset, _, err = vb.LookupBlockToObject(4)
 			assert.Error(t, err)
 			assert.Equal(t, uint64(0), objectID)
 			assert.Equal(t, uint32(0), objectOffset)
@@ -1292,7 +1292,7 @@ func TestInvalidS3Auth(t *testing.T) {
 			assert.NoError(t, err)
 
 			// Confirm the block does not exist in the object/chunk file (since not flushed/Write to WAL)
-			objectID, objectOffset, err := vb.LookupBlockToObject(4)
+			objectID, objectOffset, _, err := vb.LookupBlockToObject(4)
 			assert.Error(t, err)
 			assert.Equal(t, uint64(0), objectID)
 			assert.Equal(t, uint32(0), objectOffset)
@@ -1304,7 +1304,7 @@ func TestInvalidS3Auth(t *testing.T) {
 			assert.Error(t, err)
 
 			// Confirm the block does not exist in the object/chunk file (since not flushed/Write to WAL)
-			objectID, objectOffset, err = vb.LookupBlockToObject(4)
+			objectID, objectOffset, _, err = vb.LookupBlockToObject(4)
 			assert.Error(t, err)
 			assert.Equal(t, uint64(0), objectID)
 			assert.Equal(t, uint32(0), objectOffset)
@@ -1801,7 +1801,7 @@ func TestRecoverLocalWALs(t *testing.T) {
 
 			// Verify blocks are now in BlocksToObject (persisted to backend)
 			for i := range 3 {
-				_, _, err := vb.LookupBlockToObject(uint64(i))
+				_, _, _, err := vb.LookupBlockToObject(uint64(i))
 				assert.NoError(t, err, "Block %d should be in BlocksToObject after recovery", i)
 			}
 
@@ -1889,7 +1889,7 @@ func TestRecoverLocalWALsPartialRecord(t *testing.T) {
 
 			// Verify both blocks are recovered
 			for i := range 2 {
-				_, _, err := vb.LookupBlockToObject(uint64(i))
+				_, _, _, err := vb.LookupBlockToObject(uint64(i))
 				assert.NoError(t, err, "Block %d should be recovered despite trailing corruption", i)
 			}
 
@@ -2066,7 +2066,7 @@ func TestRecoverLocalWALsChecksumCorruption(t *testing.T) {
 			}
 
 			// Block 2 (the 3rd block) should NOT be recovered
-			_, _, err = vb.LookupBlockToObject(2)
+			_, _, _, err = vb.LookupBlockToObject(2)
 			assert.Error(t, err, "Block 2 should not be recovered due to checksum corruption")
 		})
 	})

--- a/viperblock/viperblock_test.go
+++ b/viperblock/viperblock_test.go
@@ -753,6 +753,137 @@ func TestWALOperations(t *testing.T) {
 	})
 }
 
+// TestWriteWALTruncatesOnShortWrite verifies two related properties of the
+// truncate-on-failed-write path in WriteWAL:
+//
+//  1. Boundary preservation under torn-write conditions. If a previous
+//     WriteWAL leaves partial bytes past the last record boundary (the bug's
+//     blast radius), replay misaligns. Truncating back to the boundary
+//     restores a WAL whose replay round-trips. This is the actual invariant
+//     the fix defends.
+//
+//  2. Write-error path. When WriteWAL's underlying Write returns an error,
+//     WriteWAL returns an error and does NOT grow the WAL past the last
+//     record boundary. We induce a deterministic error by closing the
+//     *os.File handle before calling WriteWAL.
+func TestWriteWALTruncatesOnShortWrite(t *testing.T) {
+	t.Run("BoundaryPreservation_TornBytesBreakReplay_TruncateRestoresIt", func(t *testing.T) {
+		vb, walPath := setupWALTruncateTestVB(t, "boundary")
+
+		dataA := make([]byte, DefaultBlockSize)
+		copy(dataA, "record A")
+		require.NoError(t, vb.WriteWAL(Block{SeqNum: 10, Block: 10, Len: uint64(len(dataA)), Data: dataA}))
+
+		dataB := make([]byte, DefaultBlockSize)
+		copy(dataB, "record B")
+		require.NoError(t, vb.WriteWAL(Block{SeqNum: 11, Block: 11, Len: uint64(len(dataB)), Data: dataB}))
+
+		boundary, err := os.Stat(walPath)
+		require.NoError(t, err)
+		boundarySize := boundary.Size()
+		recordSize := int64(28 + vb.BlockSize)
+		require.Equal(t, int64(vb.WALHeaderSize())+2*recordSize, boundarySize, "boundary size sanity")
+
+		// Inject a partial-record tail — exactly what a torn write would
+		// leave on disk without the fix. 7 bytes is partial-but-nonzero.
+		f, err := os.OpenFile(walPath, os.O_WRONLY|os.O_APPEND, 0600)
+		require.NoError(t, err)
+		_, err = f.Write([]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07})
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
+
+		// Replay over the misaligned tail must surface as an error.
+		currentWAL := vb.WAL.DB[len(vb.WAL.DB)-1]
+		_, err = currentWAL.Seek(int64(vb.WALHeaderSize()), 0)
+		require.NoError(t, err)
+		replayErr := vb.ReadWAL()
+		require.Error(t, replayErr, "replay must fail when WAL has unaligned trailing bytes")
+
+		// Apply the fix: truncate back to the last good boundary.
+		require.NoError(t, os.Truncate(walPath, boundarySize))
+
+		_, err = currentWAL.Seek(int64(vb.WALHeaderSize()), 0)
+		require.NoError(t, err)
+		require.NoError(t, vb.ReadWAL(), "replay must succeed after truncating back to the record boundary")
+
+		st, err := os.Stat(walPath)
+		require.NoError(t, err)
+		require.Equal(t, boundarySize, st.Size(), "truncate must restore the WAL to exactly the boundary size")
+	})
+
+	t.Run("WriteErrorPath_ClosedHandle_NoGrowthPastBoundary", func(t *testing.T) {
+		vb, walPath := setupWALTruncateTestVB(t, "writeerr")
+
+		data1 := make([]byte, DefaultBlockSize)
+		copy(data1, "first valid record")
+		require.NoError(t, vb.WriteWAL(Block{SeqNum: 1, Block: 1, Len: uint64(len(data1)), Data: data1}))
+
+		st, err := os.Stat(walPath)
+		require.NoError(t, err)
+		boundarySize := st.Size()
+		require.Greater(t, boundarySize, int64(0))
+
+		// Close the active WAL handle to deterministically trigger an error
+		// on the next Write. WriteWAL must surface that error and must NOT
+		// leave the WAL file grown past the boundary.
+		vb.WAL.mu.Lock()
+		require.NoError(t, vb.WAL.DB[len(vb.WAL.DB)-1].Close())
+		vb.WAL.mu.Unlock()
+
+		data2 := make([]byte, DefaultBlockSize)
+		copy(data2, "this write must fail")
+		err = vb.WriteWAL(Block{SeqNum: 2, Block: 2, Len: uint64(len(data2)), Data: data2})
+		require.Error(t, err, "WriteWAL on a closed handle must return an error")
+
+		st2, err := os.Stat(walPath)
+		require.NoError(t, err)
+		require.LessOrEqual(t, st2.Size(), boundarySize,
+			"WAL must not have grown past the boundary after a failed write (pre=%d, post=%d)",
+			boundarySize, st2.Size())
+	})
+}
+
+// setupWALTruncateTestVB spins up a minimal file-backed VB with legacy WAL
+// and an opened WAL file. Returns the VB and the WAL file path. Cleanup is
+// registered with t.Cleanup.
+func setupWALTruncateTestVB(t *testing.T, tag string) (*VB, string) {
+	t.Helper()
+	tmpDir := os.TempDir()
+	testVol := fmt.Sprintf("test_wal_truncate_%s_%d", tag, time.Now().UnixNano())
+
+	backendConfig := file.FileConfig{
+		VolumeName: testVol,
+		VolumeSize: volumeSize,
+		BaseDir:    tmpDir,
+	}
+
+	vbconfig := VB{
+		VolumeName:      testVol,
+		VolumeSize:      volumeSize,
+		BaseDir:         fmt.Sprintf("%s/%s", tmpDir, "viperblock"),
+		WALSyncInterval: -1,
+	}
+
+	vb, err := New(&vbconfig, FileBackend, backendConfig)
+	require.NoError(t, err)
+	require.NotNil(t, vb)
+	vb.UseShardedWAL = false
+	vb.ShardedWAL = nil
+
+	t.Cleanup(func() {
+		vb.StopWALSyncer()
+		os.RemoveAll(filepath.Join(vb.BaseDir, testVol))
+	})
+
+	require.NoError(t, vb.Backend.Init())
+
+	walPath := fmt.Sprintf("%s/%s/wal/chunks/wal.%08d.bin",
+		vb.BaseDir, vb.GetVolume(), vb.WAL.WallNum.Load())
+	require.NoError(t, vb.OpenWAL(&vb.WAL, walPath))
+
+	return vb, walPath
+}
+
 // TestWALPeriodicSync tests the periodic WAL fsync functionality
 // following patterns from PostgreSQL (wal_writer_delay), BadgerDB, and MongoDB
 func TestWALPeriodicSync(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds AES-256-GCM encryption at rest for WAL records, chunk blocks, and VBState/snapshot metadata. Mode (encrypted vs plaintext) is locked at volume creation via magic bytes (`VBCE`/`VBWE` vs `VBCH`/`VBWL`); cross-mode reads are rejected.

- Per-record nonce `[BE(SeqNum_56) | VolumeUUID_4 | domain_1]` with a crash-safe SeqNum high-water reservation pattern
- AAD binds ciphertext to `SHA256(VolumeName)`, block number, and SeqNum; tamper/replay/cross-volume splice all fail with `ErrIntegrity`
- VBState and snapshot manifests sealed via `sealMeta`/`openMeta` (AES-GCM with empty plaintext, JSON in AAD)
- Snapshots persist source `VolumeUUID` + `volumeNameHash` so clones can decrypt base chunks under source identity
- Master key wired through `-encryption-key-file` on `vblock`, `sfs`, and the NBD entry point
- `DESIGN.md` §18 documents formats, threat model, and migration

## Test plan

- [x] `go test ./... -race` (80.3% diff coverage)
- [x] `make preflight` clean (lint, govulncheck, race)
- [x] New tamper/snapshot/meta suites: ciphertext flip, tag flip, AAD flip, cross-volume splice, in-place replay, rollback-vs-fsync
- [x] `TestMakeNonce_UniquenessSweep` — 10^6 random triples (gated by `-short`)