### PR TITLE
fix: read cache pins full request buffers (encryption-at-rest leak)

### DIFF
--- a/scripts/nbd-loadgen.sh
+++ b/scripts/nbd-loadgen.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+#
+# nbd-loadgen.sh — drive viperblock NBD I/O load on ONE instance while watching
+# host memory, to observe nbdkit/qemu RSS growth (e.g. the read-cache slice-
+# aliasing leak). Read-only load by default.
+#
+# SAFETY — this tool exists because an earlier, unguarded run drove the node
+# into OOM (all four instances at once, direct-I/O streaming reads, no host
+# memory guard; see docs/development/bugs/nbd-read-cache-slice-aliasing-leak.md
+# "Field validation"). Guards here:
+#   * single target only (no "all instances")
+#   * aborts when host MemAvailable drops below FLOOR (default 2048 MiB)
+#   * bounded duration (default 120 s) + in-guest hard-timer backstop
+#   * stop-sentinel for prompt teardown; teardown on any exit
+#   * write churn is opt-in (--write); reads target the RO second volume
+#
+# NOTE: the leaked cache memory is pinned in the LRU — it stops growing when
+# I/O stops but does NOT shrink. Only a volume detach / process teardown frees
+# it. Keep FLOOR well above the largest single nbdkit you expect.
+#
+# Usage:
+#   ./nbd-loadgen.sh <instance-ip> [-d sec] [-f floor_mb] [-r read_dev]
+#                    [--write] [-k keyfile] [-u user]
+# Env: SPINIFEX_KEY overrides the default key path.
+set -euo pipefail
+
+usage() {
+	echo "usage: $0 <instance-ip> [-d sec] [-f floor_mb] [-r read_dev] [--write] [-k keyfile] [-u user]" >&2
+	exit 2
+}
+
+[ $# -ge 1 ] || usage
+IP=$1
+shift
+
+DUR=120
+FLOOR=2048
+RDEV=/dev/vdb
+WRITE=0
+KEY="${SPINIFEX_KEY:-$HOME/.ssh/spinifex-key}"
+SSH_USER=ec2-user
+
+while [ $# -gt 0 ]; do
+	case "$1" in
+	-d) DUR=$2; shift 2 ;;
+	-f) FLOOR=$2; shift 2 ;;
+	-r) RDEV=$2; shift 2 ;;
+	--write) WRITE=1; shift ;;
+	-k) KEY=$2; shift 2 ;;
+	-u) SSH_USER=$2; shift 2 ;;
+	*) usage ;;
+	esac
+done
+
+SSH=(ssh -i "$KEY" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=6 "$SSH_USER@$IP")
+
+mem_avail_mb() { awk '/^MemAvailable:/ {print int($2/1024)}' /proc/meminfo; }
+rss_mb() { ps -eo rss,comm | awk -v p="$1" '$2 ~ p {s+=$1} END {printf "%d", s/1024}'; }
+
+teardown() {
+	echo ">> teardown: stopping in-guest load on $IP"
+	"${SSH[@]}" 'touch /tmp/nbd-loadgen.stop 2>/dev/null;
+		sudo pkill -9 -f nbd-guest-load 2>/dev/null;
+		sudo pkill -9 dd 2>/dev/null;
+		sudo pkill -9 openssl 2>/dev/null;
+		sudo pkill -9 python3 2>/dev/null;
+		sudo rm -f /root/nbd-loadgen.bin /tmp/nbd-loadgen.stop 2>/dev/null' 2>/dev/null || true
+}
+trap teardown EXIT INT TERM
+
+echo ">> target=$IP dur=${DUR}s floor=${FLOOR}MiB read=$RDEV write=$WRITE"
+echo ">> host MemAvailable=$(mem_avail_mb)MiB"
+[ "$(mem_avail_mb)" -gt "$FLOOR" ] || { echo "!! host already below floor — refusing to start" >&2; exit 1; }
+
+# Stage the in-guest load. It has its own hard timer and watches a stop-sentinel
+# so the host can tear it down promptly.
+"${SSH[@]}" "cat > /tmp/nbd-guest-load.sh" <<GUEST
+#!/bin/bash
+DUR=$DUR; RDEV=$RDEV; WRITE=$WRITE
+rm -f /tmp/nbd-loadgen.stop
+end=\$((SECONDS + DUR))
+stop() { [ -f /tmp/nbd-loadgen.stop ] || [ \$SECONDS -ge \$end ]; }
+
+# ~150 MiB guest RAM balloon (drives qemu host RSS), released on stop.
+python3 - <<'PY' &
+import time
+b = bytearray(150 * 1024 * 1024)
+for i in range(0, len(b), 4096):
+    b[i] = 1
+while True:
+    time.sleep(1)
+PY
+MEM=\$!
+
+# Sequential read churn over the RO volume — the read-cache leak trigger.
+( while ! stop; do dd if=\$RDEV of=/dev/null bs=64k iflag=direct 2>/dev/null; done ) &
+R=\$!
+
+W=
+if [ "\$WRITE" = "1" ]; then
+	( while ! stop; do
+		openssl enc -aes-256-ctr -nosalt -pass pass:loadx -in /dev/zero 2>/dev/null \
+			| dd of=/root/nbd-loadgen.bin bs=1M count=256 iflag=fullblock oflag=direct 2>/dev/null
+		sync; rm -f /root/nbd-loadgen.bin
+	  done ) &
+	W=\$!
+fi
+
+while ! stop; do sleep 1; done
+kill \$MEM \$R \$W 2>/dev/null
+rm -f /root/nbd-loadgen.bin
+GUEST
+
+"${SSH[@]}" 'chmod +x /tmp/nbd-guest-load.sh; sudo nohup /tmp/nbd-guest-load.sh >/tmp/nbd-guest-load.log 2>&1 & echo ">> in-guest load started"'
+
+# Host watch loop: report RSS, abort on memory floor or timeout.
+t0=$SECONDS
+while [ $((SECONDS - t0)) -lt "$DUR" ]; do
+	A=$(mem_avail_mb)
+	printf ">> t=%3ds  host avail=%6dMiB  qemu=%5dMiB  nbdkit=%5dMiB\n" \
+		$((SECONDS - t0)) "$A" "$(rss_mb qemu-system)" "$(rss_mb nbdkit)"
+	if [ "$A" -lt "$FLOOR" ]; then
+		echo "!! host avail ${A}MiB < floor ${FLOOR}MiB — ABORTING"
+		break
+	fi
+	sleep 2
+done
+echo ">> run complete"

--- a/viperblock/cachebench/cachebench_test.go
+++ b/viperblock/cachebench/cachebench_test.go
@@ -1,169 +1,155 @@
-// Package cachebench isolates the read-cache retention behaviour of the
-// viperblock NBD plugin. It models the exact construct at
-// viperblock/viperblock.go:3925 & :4036 — the read cache stores a 4 KiB
-// subslice of the (large) per-NBD-request read buffer:
+// Package cachebench drives the REAL viperblock read path (file backend,
+// UseBlockStore=true — the production NBD default) to guard against the
+// read-cache buffer-aliasing leak fixed at viperblock.go:3925 & :4036.
 //
-//	data := make([]byte, blockLen)               // viperblock.go:3254/3753
-//	...
-//	vb.Cache.lru.Add(block, data[blockStart:blockEnd])   // subslice -> pins data
+// The bug: readBlockStore allocates one large per-request buffer
 //
-// In Go a subslice retains its whole backing array, so a single live 4 KiB
-// entry pins the entire request buffer. This benchmark drives the SAME LRU
-// dependency (hashicorp/golang-lru/v2, viperblock.go:31/615) and measures
-// retained heap for the current code (subslice) vs the proposed fix (clone),
-// across three access patterns:
+//	data := make([]byte, blockLen)                       // viperblock.go:3753
 //
-//   - clustered:  large reads at well-separated aligned offsets. Each buffer's
-//     blocks enter and leave the LRU together, so aliasing barely bites — best
-//     case for the current code.
-//   - random:     overlapping unaligned reads over a hot region. Older buffers
-//     are partially overwritten; modest retention overhead — typical case.
-//   - streaming:  a sliding read window advancing one block at a time (e.g.
-//     sequential I/O with overlapping prefetch). Each read overwrites all but
-//     one of the previous buffer's block-entries, so EVERY cached entry ends up
-//     aliasing its own distinct backing buffer. With the subslice Add this pins
-//     bufLen/blockSize (24x here) the intended bytes — the worst case, and the
-//     mechanism behind the observed nbdkit RSS blowup / host OOM.
+// and previously cached each 4 KiB block as a SUBSLICE of it
+//
+//	vb.Cache.lru.Add(block, data[blockStart:blockEnd])   // pins all of data
+//
+// In Go a subslice retains its whole backing array, so a single live cache
+// entry pins the entire request buffer. Under streaming/prefetch I/O (a read
+// window sliding one block at a time) every surviving LRU entry ends up
+// aliasing its own distinct request buffer, so retained heap balloons to
+// roughly cacheSize*requestBytes instead of cacheSize*blockSize — the nbdkit
+// RSS blowup / host OOM. The fix wraps each insert in clone() so the LRU owns
+// an independent BlockSize buffer.
+//
+// Unlike a synthetic model, this test exercises vb.ReadAt -> read ->
+// readBlockStore against a real persisted volume, so it FAILS if the clone()
+// fix is reverted: it asserts the post-streaming retained heap stays within a
+// multiple of the intended cache footprint, a bound the subslice variant
+// (~16x larger here) cannot satisfy.
 //
 // Lives in its own package so it does not inherit the viperblock package's
-// TestMain (predastore server); avoids the WAL/backend path so it is fast and
-// deterministic.
+// TestMain (predastore server); the file backend keeps it hermetic.
 package cachebench
 
 import (
-	"math/rand"
+	"errors"
+	"fmt"
+	"path/filepath"
 	"runtime"
 	"testing"
+	"time"
 
-	lru "github.com/hashicorp/golang-lru/v2"
+	"github.com/mulgadc/viperblock/types"
+	vblib "github.com/mulgadc/viperblock/viperblock"
+	"github.com/mulgadc/viperblock/viperblock/backends/file"
 )
 
 const (
-	cacheSize = 8192 // 1/4 of production nbd cache_size (32768)
 	blockSize = 4096 // viperblock DefaultBlockSize
-	largeReq  = 24   // 96 KiB read buffer (bounds worst-case retention < 1 GiB)
-	prodScale = 4    // cacheSize * prodScale == production 32768
+	cacheSize = 4096 // LRU entry cap -> intended ceiling = cacheSize*blockSize = 16 MiB
+	largeReq  = 32   // blocks per ReadAt -> 128 KiB request buffer (the thing a subslice pins)
+	numReads  = cacheSize + 512
+	allBlocks = numReads + largeReq // distinct blocks written/persisted
+
+	// retainFactor bounds legitimate retained heap (clone LRU + never-evicted
+	// BlockStore Cached copies) as a multiple of (cacheSize+allBlocks) blocks.
+	// The reverted subslice variant retains ~cacheSize*largeReq*blockSize
+	// (512 MiB here), far beyond this bound.
+	retainFactor = 2.5
 )
 
-func TestCacheRetentionMemory(t *testing.T) {
-	intended := float64(cacheSize*blockSize) / (1024 * 1024)
+// TestReadCacheDoesNotPinRequestBuffers persists a volume, then issues a
+// sliding-window stream of multi-block ReadAt calls and checks that the read
+// cache did not pin the per-request buffers. Guards viperblock.go:3925 (and the
+// identical pattern at :3455 legacy / :4036 snapshot-base).
+func TestReadCacheDoesNotPinRequestBuffers(t *testing.T) {
+	vb := setupVB(t)
 
-	var streamBefore, streamAfter float64
-	for _, w := range []struct {
-		name string
-		fn   func(useClone bool) float64
-	}{
-		{"clustered (aligned, separated)", runClustered},
-		{"random    (unaligned overlap) ", runRandom},
-		{"streaming (sliding prefetch)  ", runStreaming},
-	} {
-		before := w.fn(false)
-		after := w.fn(true)
-		t.Logf("=== %s ===", w.name)
-		t.Logf("  intended ceiling : %7.1f MiB", intended)
-		t.Logf("  BEFORE (subslice): %7.1f MiB  (%5.1fx intended)", before, before/intended)
-		t.Logf("  AFTER  (clone)   : %7.1f MiB  (%5.1fx intended)", after, after/intended)
-		t.Logf("  reduction        : %7.1f MiB  (%5.1fx smaller)", before-after, before/after)
-		t.Logf("  @prod 32768 (x%d) : BEFORE %.0f MiB -> AFTER %.0f MiB", prodScale, before*prodScale, after*prodScale)
-		if w.name[:9] == "streaming" {
-			streamBefore, streamAfter = before, after
+	// Write every block once and force it out to the backend so reads come back
+	// as BlockStatePersisted (BlockStore data freed) and populate the cache.
+	buf := make([]byte, blockSize)
+	for b := range allBlocks {
+		bn := uint64(b)
+		buf[0], buf[blockSize-1] = byte(bn), byte(bn>>8)
+		if err := vb.WriteAt(bn*blockSize, buf); err != nil {
+			t.Fatalf("WriteAt block %d: %v", bn, err)
 		}
 	}
-
-	// Headline guard: under the streaming worst case the subslice Add must pin
-	// dramatically more than the clone fix (each entry pins a whole buffer).
-	if streamBefore < streamAfter*5 {
-		t.Fatalf("streaming worst case did not show the leak: before=%.1f after=%.1f (want before >= 5x after)",
-			streamBefore, streamAfter)
+	if err := vb.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
 	}
-}
+	if err := vb.WriteWALToChunk(true); err != nil {
+		t.Fatalf("WriteWALToChunk: %v", err)
+	}
 
-// runClustered: large reads at block-aligned offsets over a keyspace 4x the
-// cache. A request's blocks share recency and evict together, so buffers stay
-// fully resident while cached — aliasing has little to pin. Best case.
-func runClustered(useClone bool) float64 {
-	const (
-		keyspace = cacheSize * 4
-		numReads = 12000
-	)
-	rng := rand.New(rand.NewSource(42))
-	maxStart := (keyspace - largeReq) / largeReq
-	return drive(useClone, numReads, func() uint64 {
-		return uint64(rng.Intn(maxStart) * largeReq) // aligned, well-separated
-	})
-}
-
-// runRandom: overlapping unaligned reads over a hot region ~3x the cache.
-// Successive reads share blocks with earlier ones and overwrite those entries,
-// eroding older buffers. Modest overhead — typical case.
-func runRandom(useClone bool) float64 {
-	const (
-		region   = cacheSize * 3
-		numReads = 30000
-	)
-	rng := rand.New(rand.NewSource(42))
-	maxStart := region - largeReq
-	return drive(useClone, numReads, func() uint64 {
-		return uint64(rng.Intn(maxStart)) // unaligned -> overlap
-	})
-}
-
-// runStreaming: a read window advancing one block per read. Read s caches keys
-// [s, s+largeReq); the next read overwrites keys [s+1, s+largeReq), leaving
-// buffer s referenced only by key s. Every live cache entry therefore aliases a
-// distinct backing buffer — maximal pinning. Worst case.
-func runStreaming(useClone bool) float64 {
-	const numReads = 40000
-	var s uint64
-	return drive(useClone, numReads, func() uint64 {
-		cur := s
-		s++ // slide by one block each read
-		return cur
-	})
-}
-
-// drive runs numReads large reads, each allocating a fresh backing buffer and
-// caching its blocks at the offset returned by start(). Returns retained heap.
-func drive(useClone bool, numReads int, start func() uint64) float64 {
+	// Baseline after persist: LRU empty, BlockStore entries Persisted (no data).
 	base := heapInuseMiB()
-	cache, _ := lru.New[uint64, []byte](cacheSize)
-	for range numReads {
-		buf := newBuf(largeReq * blockSize)
-		s := start()
-		for b := range largeReq {
-			addBlock(cache, s+uint64(b), buf, b, useClone)
+
+	// Streaming read: window slides one block per read. Each read pulls exactly
+	// one new leading block from the backend (the rest are already Cached), so
+	// each surviving LRU entry maps to a distinct request buffer — maximal
+	// pinning if the cache stored subslices.
+	for s := range numReads {
+		sn := uint64(s)
+		if _, err := vb.ReadAt(sn*blockSize, largeReq*blockSize); err != nil && !errors.Is(err, vblib.ErrZeroBlock) {
+			t.Fatalf("ReadAt offset-block %d: %v", sn, err)
 		}
 	}
+
 	retained := heapInuseMiB() - base
-	runtime.KeepAlive(cache)
-	return retained
-}
+	runtime.KeepAlive(vb)
 
-// addBlock mirrors viperblock.go:3925/4036: store the b-th 4 KiB block of buf.
-// useClone=false stores a subslice (aliases buf); true stores an independent copy.
-func addBlock(cache *lru.Cache[uint64, []byte], key uint64, buf []byte, b int, useClone bool) {
-	val := buf[b*blockSize : (b+1)*blockSize]
-	if useClone {
-		val = clone(val)
+	intended := float64(cacheSize*blockSize) / (1024 * 1024)
+	// Legitimate footprint with the clone fix: the bounded LRU plus the
+	// (currently never-evicted) BlockStore Cached copies of every block read.
+	legit := float64((cacheSize+allBlocks)*blockSize) / (1024 * 1024)
+	threshold := legit * retainFactor
+	subsliceWorst := float64(cacheSize*largeReq*blockSize) / (1024 * 1024)
+
+	t.Logf("intended LRU ceiling : %7.1f MiB (cacheSize=%d x %d B)", intended, cacheSize, blockSize)
+	t.Logf("retained after stream: %7.1f MiB", retained)
+	t.Logf("clone threshold      : %7.1f MiB (legit %.1f x %.1f)", threshold, legit, retainFactor)
+	t.Logf("subslice worst case  : %7.1f MiB (what a revert would retain)", subsliceWorst)
+
+	if retained > threshold {
+		t.Fatalf("read cache retained %.1f MiB > %.1f MiB threshold: entries are pinning whole "+
+			"request buffers — the clone() fix at viperblock.go:3925/4036 is missing or reverted",
+			retained, threshold)
 	}
-	cache.Add(key, val)
 }
 
-// newBuf allocates a per-request read buffer and faults both ends in, matching
-// read()'s data = make([]byte, blockLen).
-func newBuf(n int) []byte {
-	buf := make([]byte, n)
-	buf[0] = 1
-	buf[n-1] = 1
-	return buf
-}
+func setupVB(t *testing.T) *vblib.VB {
+	t.Helper()
+	dir := t.TempDir()
+	vol := fmt.Sprintf("cbench_%d", time.Now().UnixNano())
+	volBytes := uint64(allBlocks+largeReq) * blockSize
 
-// clone matches viperblock's clone() helper (viperblock.go:3703): a fresh copy
-// that does not alias the source's backing array.
-func clone(in []byte) []byte {
-	out := make([]byte, len(in))
-	copy(out, in)
-	return out
+	bcfg := file.FileConfig{VolumeName: vol, VolumeSize: volBytes, BaseDir: dir}
+	cfg := &vblib.VB{
+		VolumeName:      vol,
+		VolumeSize:      volBytes,
+		BaseDir:         filepath.Join(dir, "viperblock"),
+		WALSyncInterval: -1, // standalone recipe: no background syncer
+		Cache:           vblib.Cache{Config: vblib.CacheConfig{Size: cacheSize}},
+	}
+	vb, err := vblib.New(cfg, "file", bcfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	vb.UseShardedWAL = false
+	vb.ShardedWAL = nil
+
+	if err := vb.Backend.Init(); err != nil {
+		t.Fatal(err)
+	}
+	walPath := fmt.Sprintf("%s/%s", vb.WAL.BaseDir,
+		types.GetFilePath(types.FileTypeWALChunk, vb.WAL.WallNum.Load(), vb.GetVolume()))
+	if err := vb.OpenWAL(&vb.WAL, walPath); err != nil {
+		t.Fatal(err)
+	}
+	blkPath := fmt.Sprintf("%s/%s", vb.BlockToObjectWAL.BaseDir,
+		types.GetFilePath(types.FileTypeWALBlock, vb.BlockToObjectWAL.WallNum.Load(), vb.GetVolume()))
+	if err := vb.OpenWAL(&vb.BlockToObjectWAL, blkPath); err != nil {
+		t.Fatal(err)
+	}
+	return vb
 }
 
 func heapInuseMiB() float64 {

--- a/viperblock/cachebench/cachebench_test.go
+++ b/viperblock/cachebench/cachebench_test.go
@@ -1,0 +1,175 @@
+// Package cachebench isolates the read-cache retention behaviour of the
+// viperblock NBD plugin. It models the exact construct at
+// viperblock/viperblock.go:3925 & :4036 — the read cache stores a 4 KiB
+// subslice of the (large) per-NBD-request read buffer:
+//
+//	data := make([]byte, blockLen)               // viperblock.go:3254/3753
+//	...
+//	vb.Cache.lru.Add(block, data[blockStart:blockEnd])   // subslice -> pins data
+//
+// In Go a subslice retains its whole backing array, so a single live 4 KiB
+// entry pins the entire request buffer. This benchmark drives the SAME LRU
+// dependency (hashicorp/golang-lru/v2, viperblock.go:31/615) and measures
+// retained heap for the current code (subslice) vs the proposed fix (clone),
+// across three access patterns:
+//
+//   - clustered:  large reads at well-separated aligned offsets. Each buffer's
+//     blocks enter and leave the LRU together, so aliasing barely bites — best
+//     case for the current code.
+//   - random:     overlapping unaligned reads over a hot region. Older buffers
+//     are partially overwritten; modest retention overhead — typical case.
+//   - streaming:  a sliding read window advancing one block at a time (e.g.
+//     sequential I/O with overlapping prefetch). Each read overwrites all but
+//     one of the previous buffer's block-entries, so EVERY cached entry ends up
+//     aliasing its own distinct backing buffer. With the subslice Add this pins
+//     bufLen/blockSize (24x here) the intended bytes — the worst case, and the
+//     mechanism behind the observed nbdkit RSS blowup / host OOM.
+//
+// Lives in its own package so it does not inherit the viperblock package's
+// TestMain (predastore server); avoids the WAL/backend path so it is fast and
+// deterministic.
+package cachebench
+
+import (
+	"math/rand"
+	"runtime"
+	"testing"
+
+	lru "github.com/hashicorp/golang-lru/v2"
+)
+
+const (
+	cacheSize = 8192 // 1/4 of production nbd cache_size (32768)
+	blockSize = 4096 // viperblock DefaultBlockSize
+	largeReq  = 24   // 96 KiB read buffer (bounds worst-case retention < 1 GiB)
+	prodScale = 4    // cacheSize * prodScale == production 32768
+)
+
+func TestCacheRetentionMemory(t *testing.T) {
+	intended := float64(cacheSize*blockSize) / (1024 * 1024)
+
+	var streamBefore, streamAfter float64
+	for _, w := range []struct {
+		name string
+		fn   func(useClone bool) float64
+	}{
+		{"clustered (aligned, separated)", runClustered},
+		{"random    (unaligned overlap) ", runRandom},
+		{"streaming (sliding prefetch)  ", runStreaming},
+	} {
+		before := w.fn(false)
+		after := w.fn(true)
+		t.Logf("=== %s ===", w.name)
+		t.Logf("  intended ceiling : %7.1f MiB", intended)
+		t.Logf("  BEFORE (subslice): %7.1f MiB  (%5.1fx intended)", before, before/intended)
+		t.Logf("  AFTER  (clone)   : %7.1f MiB  (%5.1fx intended)", after, after/intended)
+		t.Logf("  reduction        : %7.1f MiB  (%5.1fx smaller)", before-after, before/after)
+		t.Logf("  @prod 32768 (x%d) : BEFORE %.0f MiB -> AFTER %.0f MiB", prodScale, before*prodScale, after*prodScale)
+		if w.name[:9] == "streaming" {
+			streamBefore, streamAfter = before, after
+		}
+	}
+
+	// Headline guard: under the streaming worst case the subslice Add must pin
+	// dramatically more than the clone fix (each entry pins a whole buffer).
+	if streamBefore < streamAfter*5 {
+		t.Fatalf("streaming worst case did not show the leak: before=%.1f after=%.1f (want before >= 5x after)",
+			streamBefore, streamAfter)
+	}
+}
+
+// runClustered: large reads at block-aligned offsets over a keyspace 4x the
+// cache. A request's blocks share recency and evict together, so buffers stay
+// fully resident while cached — aliasing has little to pin. Best case.
+func runClustered(useClone bool) float64 {
+	const (
+		keyspace = cacheSize * 4
+		numReads = 12000
+	)
+	rng := rand.New(rand.NewSource(42))
+	maxStart := (keyspace - largeReq) / largeReq
+	return drive(useClone, numReads, func() uint64 {
+		return uint64(rng.Intn(maxStart) * largeReq) // aligned, well-separated
+	})
+}
+
+// runRandom: overlapping unaligned reads over a hot region ~3x the cache.
+// Successive reads share blocks with earlier ones and overwrite those entries,
+// eroding older buffers. Modest overhead — typical case.
+func runRandom(useClone bool) float64 {
+	const (
+		region   = cacheSize * 3
+		numReads = 30000
+	)
+	rng := rand.New(rand.NewSource(42))
+	maxStart := region - largeReq
+	return drive(useClone, numReads, func() uint64 {
+		return uint64(rng.Intn(maxStart)) // unaligned -> overlap
+	})
+}
+
+// runStreaming: a read window advancing one block per read. Read s caches keys
+// [s, s+largeReq); the next read overwrites keys [s+1, s+largeReq), leaving
+// buffer s referenced only by key s. Every live cache entry therefore aliases a
+// distinct backing buffer — maximal pinning. Worst case.
+func runStreaming(useClone bool) float64 {
+	const numReads = 40000
+	var s uint64
+	return drive(useClone, numReads, func() uint64 {
+		cur := s
+		s++ // slide by one block each read
+		return cur
+	})
+}
+
+// drive runs numReads large reads, each allocating a fresh backing buffer and
+// caching its blocks at the offset returned by start(). Returns retained heap.
+func drive(useClone bool, numReads int, start func() uint64) float64 {
+	base := heapInuseMiB()
+	cache, _ := lru.New[uint64, []byte](cacheSize)
+	for range numReads {
+		buf := newBuf(largeReq * blockSize)
+		s := start()
+		for b := range largeReq {
+			addBlock(cache, s+uint64(b), buf, b, useClone)
+		}
+	}
+	retained := heapInuseMiB() - base
+	runtime.KeepAlive(cache)
+	return retained
+}
+
+// addBlock mirrors viperblock.go:3925/4036: store the b-th 4 KiB block of buf.
+// useClone=false stores a subslice (aliases buf); true stores an independent copy.
+func addBlock(cache *lru.Cache[uint64, []byte], key uint64, buf []byte, b int, useClone bool) {
+	val := buf[b*blockSize : (b+1)*blockSize]
+	if useClone {
+		val = clone(val)
+	}
+	cache.Add(key, val)
+}
+
+// newBuf allocates a per-request read buffer and faults both ends in, matching
+// read()'s data = make([]byte, blockLen).
+func newBuf(n int) []byte {
+	buf := make([]byte, n)
+	buf[0] = 1
+	buf[n-1] = 1
+	return buf
+}
+
+// clone matches viperblock's clone() helper (viperblock.go:3703): a fresh copy
+// that does not alias the source's backing array.
+func clone(in []byte) []byte {
+	out := make([]byte, len(in))
+	copy(out, in)
+	return out
+}
+
+func heapInuseMiB() float64 {
+	runtime.GC()
+	runtime.GC() // second pass: finish sweep so freed buffers are not counted
+	var m runtime.MemStats
+	runtime.ReadMemStats(&m)
+	return float64(m.HeapInuse) / (1024 * 1024)
+}

--- a/viperblock/viperblock.go
+++ b/viperblock/viperblock.go
@@ -3452,7 +3452,7 @@ func (vb *VB) read(block uint64, blockLen uint64) (data []byte, err error) {
 		if vb.Cache.Config.Size > 0 {
 			for i := uint64(0); i < uint64(cb.NumBlocks); i++ {
 				currentBlock := cb.StartBlock + i
-				vb.Cache.lru.Add(currentBlock, data[start+i*uint64(vb.BlockSize):start+(i+1)*uint64(vb.BlockSize)])
+				vb.Cache.lru.Add(currentBlock, clone(data[start+i*uint64(vb.BlockSize):start+(i+1)*uint64(vb.BlockSize)]))
 			}
 		}
 	}
@@ -3922,7 +3922,7 @@ func (vb *VB) fetchConsecutiveBlocksFromBackend(consecutiveBlocks ConsecutiveBlo
 				currentBlock := cb.StartBlock + i
 				blockStart := start + i*uint64(vb.BlockSize)
 				blockEnd := blockStart + uint64(vb.BlockSize)
-				vb.Cache.lru.Add(currentBlock, data[blockStart:blockEnd])
+				vb.Cache.lru.Add(currentBlock, clone(data[blockStart:blockEnd]))
 			}
 		}
 	}
@@ -4033,7 +4033,7 @@ func (vb *VB) fetchBaseBlocksFromBackend(sourceVolume string, consecutiveBlocks 
 				currentBlock := cb.StartBlock + i
 				blockStart := start + i*uint64(vb.BlockSize)
 				blockEnd := blockStart + uint64(vb.BlockSize)
-				vb.Cache.lru.Add(currentBlock, data[blockStart:blockEnd])
+				vb.Cache.lru.Add(currentBlock, clone(data[blockStart:blockEnd]))
 			}
 		}
 	}

--- a/viperblock/writebench/writebench_test.go
+++ b/viperblock/writebench/writebench_test.go
@@ -1,0 +1,294 @@
+// Package writebench drives the REAL viperblock write/flush path (file
+// backend, legacy single-file WAL) to quantify heavy-write latency and the
+// flush-path memory growth described in
+// docs/development/bugs/nbd-write-latency-and-flush-oom.md, and to compare the
+// proposed fixes:
+//
+//	#1 demote hot-path INFO logging to Debug
+//	#2 move chunk consolidation/upload off the guest-fsync path (async drain)
+//	#3 bound the in-flight write buffer with backpressure
+//
+// It models the NBD plugin's per-op logging (one slog.Info per write, like
+// PREAD/PWRITE at nbd/viperblock.go:258/277) and a slow object backend
+// (S3/predastore RTT) so the synchronous-drain stall is visible. Lives in its
+// own package so it does not inherit the viperblock package's predastore
+// TestMain, and uses the legacy WAL (UseShardedWAL=false, WALSyncInterval=-1)
+// which is the deadlock-free standalone recipe.
+package writebench
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/mulgadc/viperblock/types"
+	vblib "github.com/mulgadc/viperblock/viperblock"
+	"github.com/mulgadc/viperblock/viperblock/backends/file"
+)
+
+const (
+	blockSize       = 4096
+	volBytes        = 256 * 1024 * 1024 // 256 MiB volume
+	numWrites       = 12000             // 12000 x 4 KiB = ~47 MiB written
+	guestFlushEvery = 3000              // RARE guest fsync -> buffer grows (OOM regime)
+	capBytes        = 4 * 1024 * 1024   // #3 backpressure threshold (4 MiB)
+	backendDelayMs  = 3                 // simulated object-backend (S3) write RTT
+)
+
+type variant struct {
+	name        string
+	demoteLogs  bool // #1
+	asyncDrain  bool // #2
+	boundBuffer bool // #3
+}
+
+type result struct {
+	totalMs     float64
+	flushP50    float64
+	flushP99    float64
+	peakHeapMiB float64 // heap growth above post-setup baseline
+	drains      int
+}
+
+func TestWritePathLatencyMemory(t *testing.T) {
+	variants := []variant{
+		{"baseline (current code)      ", false, false, false},
+		{"#1 logs demoted              ", true, false, false},
+		{"#2 async drain               ", false, true, false},
+		{"#3 bounded buffer            ", false, false, true},
+		{"#2+#3 async + bounded        ", false, true, true},
+		{"#1+#2+#3 all fixes           ", true, true, true},
+	}
+	t.Logf("workload: %d x 4KiB writes, guest fsync every %d ops, backend RTT %dms, cap %dMiB",
+		numWrites, guestFlushEvery, backendDelayMs, capBytes/(1024*1024))
+	measureLoggingTax(t)
+	for _, v := range variants {
+		r := runVariant(t, v)
+		t.Logf("%s total=%7.0fms  flush p50=%6.2f p99=%7.2fms  peakHeap=%6.1fMiB  drains=%d",
+			v.name, r.totalMs, r.flushP50, r.flushP99, r.peakHeapMiB, r.drains)
+	}
+}
+
+// measureLoggingTax isolates fix #1: the cost of one structured log per I/O op
+// at INFO (current) vs Error (demoted). Logs to a temp file (real write
+// syscalls); journald is slower still, so this understates the production win.
+func measureLoggingTax(t *testing.T) {
+	const n = 200000
+	run := func(level slog.Level) time.Duration {
+		lf, err := os.Create(filepath.Join(t.TempDir(), "tax.log"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer lf.Close()
+		slog.SetDefault(slog.New(slog.NewTextHandler(lf, &slog.HandlerOptions{Level: level})))
+		start := time.Now()
+		for i := range n {
+			slog.Info("PWRITE", "offset", uint64(i)*blockSize, "len", blockSize)
+		}
+		return time.Since(start)
+	}
+	info := run(slog.LevelInfo)
+	errl := run(slog.LevelError) // calls become no-ops below the handler level
+	t.Logf("logging tax (#1): %d ops  INFO=%6.1fms (%4.0f ns/op)  Error=%5.1fms (%3.0f ns/op)  -> %.0fx cheaper",
+		n, float64(info.Microseconds())/1000, float64(info.Nanoseconds())/n,
+		float64(errl.Microseconds())/1000, float64(errl.Nanoseconds())/n,
+		float64(info.Nanoseconds())/float64(errl.Nanoseconds()))
+}
+
+func runVariant(t *testing.T, v variant) result {
+	// #1: per-op logging level. Logs go to a temp file (real write syscalls,
+	// approximating journald) so the cost is realistic.
+	lf, err := os.Create(filepath.Join(t.TempDir(), "vb.log"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer lf.Close()
+	level := slog.LevelInfo
+	if v.demoteLogs {
+		level = slog.LevelError // fix: hot-path logs become no-ops
+	}
+	slog.SetDefault(slog.New(slog.NewTextHandler(lf, &slog.HandlerOptions{Level: level})))
+
+	vb := setupVB(t)
+	defer vb.StopWALSyncer()
+
+	// baseline heap after setup, before the workload
+	base := heapInuse()
+
+	// #2: background drainer. Foreground Flush only does the (fast, local) WAL
+	// write; chunk consolidation/upload runs here, off the fsync path.
+	drainCh := make(chan struct{}, 4096)
+	var drainWG sync.WaitGroup
+	if v.asyncDrain {
+		drainWG.Go(func() {
+			for range drainCh {
+				_ = vb.WriteWALToChunk(false)
+			}
+		})
+	}
+
+	// peak-heap sampler
+	stop := make(chan struct{})
+	var peak uint64
+	var sampleWG sync.WaitGroup
+	sampleWG.Go(func() {
+		tk := time.NewTicker(5 * time.Millisecond)
+		defer tk.Stop()
+		var m runtime.MemStats
+		for {
+			select {
+			case <-stop:
+				return
+			case <-tk.C:
+				runtime.ReadMemStats(&m)
+				if m.HeapInuse > peak {
+					peak = m.HeapInuse
+				}
+			}
+		}
+	})
+
+	var flushLat []float64
+	pending := 0
+	drains := 0
+	doFlush := func() {
+		start := time.Now()
+		_ = vb.Flush() // drains write buffer -> local WAL (fast)
+		if v.asyncDrain {
+			select {
+			case drainCh <- struct{}{}: // hand chunk drain to background
+			default:
+			}
+		} else {
+			_ = vb.WriteWALToChunk(false) // synchronous: blocks the fsync
+		}
+		flushLat = append(flushLat, float64(time.Since(start).Microseconds())/1000)
+		drains++
+		pending = 0
+	}
+
+	t0 := time.Now()
+	off := uint64(0)
+	buf := make([]byte, blockSize)
+	for i := range numWrites {
+		buf[0] = byte(i)
+		buf[blockSize-1] = byte(i)
+		if err := vb.WriteAt(off, buf); err != nil {
+			t.Fatal(err)
+		}
+		// models the NBD plugin's per-op INFO log (nbd/viperblock.go:258/277)
+		slog.Info("PWRITE", "offset", off, "len", blockSize)
+		pending += blockSize
+		off += blockSize
+		if off+blockSize > volBytes {
+			off = 0
+		}
+		if (i+1)%guestFlushEvery == 0 {
+			doFlush()
+		}
+		if v.boundBuffer && pending >= capBytes { // #3 backpressure
+			doFlush()
+		}
+	}
+	doFlush()
+
+	if v.asyncDrain {
+		close(drainCh)
+		drainWG.Wait()
+	}
+	_ = vb.WriteWALToChunk(true) // persist remainder
+
+	total := time.Since(t0)
+	close(stop)
+	sampleWG.Wait()
+
+	sort.Float64s(flushLat)
+	return result{
+		totalMs:     float64(total.Microseconds()) / 1000,
+		flushP50:    pct(flushLat, 50),
+		flushP99:    pct(flushLat, 99),
+		peakHeapMiB: float64(peak-base) / (1024 * 1024),
+		drains:      drains,
+	}
+}
+
+func setupVB(t *testing.T) *vblib.VB {
+	dir := t.TempDir()
+	vol := fmt.Sprintf("wbench_%d", time.Now().UnixNano())
+
+	bcfg := file.FileConfig{VolumeName: vol, VolumeSize: volBytes, BaseDir: dir}
+	cfg := &vblib.VB{
+		VolumeName:      vol,
+		VolumeSize:      volBytes,
+		BaseDir:         filepath.Join(dir, "viperblock"),
+		WALSyncInterval: -1, // legacy recipe: no background syncer deadlock
+	}
+	vb, err := vblib.New(cfg, "file", bcfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	vb.UseShardedWAL = false
+	vb.ShardedWAL = nil
+
+	if err := vb.Backend.Init(); err != nil {
+		t.Fatal(err)
+	}
+	// Wrap the backend to simulate object-store (S3/predastore) write latency
+	// on the chunk-persist path. WAL writes go straight to the local file and
+	// are unaffected.
+	vb.Backend = &slowBackend{Backend: vb.Backend, delay: backendDelayMs * time.Millisecond}
+
+	walPath := fmt.Sprintf("%s/%s", vb.WAL.BaseDir,
+		types.GetFilePath(types.FileTypeWALChunk, vb.WAL.WallNum.Load(), vb.GetVolume()))
+	if err := vb.OpenWAL(&vb.WAL, walPath); err != nil {
+		t.Fatal(err)
+	}
+	blkPath := fmt.Sprintf("%s/%s", vb.BlockToObjectWAL.BaseDir,
+		types.GetFilePath(types.FileTypeWALBlock, vb.BlockToObjectWAL.WallNum.Load(), vb.GetVolume()))
+	if err := vb.OpenWAL(&vb.BlockToObjectWAL, blkPath); err != nil {
+		t.Fatal(err)
+	}
+	return vb
+}
+
+// slowBackend wraps a real backend and adds a fixed delay to object writes,
+// modelling S3/predastore round-trip latency on the chunk-persist path.
+type slowBackend struct {
+	types.Backend
+
+	delay time.Duration
+}
+
+func (s *slowBackend) Write(ft types.FileType, id uint64, headers *[]byte, data *[]byte) error {
+	time.Sleep(s.delay)
+	return s.Backend.Write(ft, id, headers, data)
+}
+
+func (s *slowBackend) WriteTo(vol string, ft types.FileType, id uint64, headers *[]byte, data *[]byte) error {
+	time.Sleep(s.delay)
+	return s.Backend.WriteTo(vol, ft, id, headers, data)
+}
+
+func pct(sorted []float64, p int) float64 {
+	if len(sorted) == 0 {
+		return 0
+	}
+	idx := p * len(sorted) / 100
+	if idx >= len(sorted) {
+		idx = len(sorted) - 1
+	}
+	return sorted[idx]
+}
+
+func heapInuse() uint64 {
+	runtime.GC()
+	var m runtime.MemStats
+	runtime.ReadMemStats(&m)
+	return m.HeapInuse
+}


### PR DESCRIPTION
## Summary

Fixes a memory leak introduced by the encryption-at-rest work (commit `c498310`, "decrypt on read"). Under streaming/prefetch I/O the read cache retained **~16x** its configured size, driving nbdkit RSS blowup / host OOM.

## Root cause

`readBlockStore` allocates one large per-request buffer and previously cached each 4 KiB block as a **subslice** of it:

```go
data := make([]byte, blockLen)                       // viperblock.go:3753
...
vb.Cache.lru.Add(currentBlock, data[blockStart:blockEnd])   // subslice -> pins all of data
```

In Go a subslice retains its whole backing array, so a single live LRU entry pins the entire request buffer. Under a sliding-window read (sequential I/O with overlapping prefetch) every surviving entry aliases its own distinct request buffer, so retained heap grows to ~`cacheSize * requestBytes` instead of `cacheSize * blockSize`.

The decrypt-on-read change had to switch the cache source from the per-run plaintext `blockData` to the whole-request `data` buffer (the decrypted plaintext only lives there), which is correct — but it cached a subslice instead of a copy. The adjacent `BlockStore.Cache` calls were already safe because they copy.

## Fix

Wrap each insert in the existing `clone()` helper so the LRU owns an independent `BlockSize` buffer, matching `BlockStore.Cache`'s copy discipline. Applied to all three sites: `viperblock.go:3455` (legacy read), `:3925` (BlockStore read), `:4036` (snapshot base read).

## Validation

New `cachebench` guard drives the **real** `ReadAt -> read -> readBlockStore` path against a file-backed volume and asserts post-stream retained heap stays within a bound the subslice variant can't meet:

| Build | Retained heap | Result |
|---|---|---|
| With `clone()` fix | 8.2 MiB | PASS (threshold 85 MiB) |
| Subslice reverted | 510.8 MiB | FAIL (names viperblock.go:3925/4036) |

Also cherry-picks the NBD read/write benchmarks + load generator from `feat/nbd-io-benchmarks`.

`make preflight` passes (lint, govulncheck, tests, race).

## Notes

- The cachebench guard exercises the production `readBlockStore` site (3925); the legacy (3455) and snapshot-base (4036) sites carry the identical fix but aren't directly driven.
- A separate, milder issue surfaced during analysis: the BlockStore `Cached` state has no eviction wiring, so it grows with distinct blocks read. Out of scope here; flagging for follow-up.