### PR TITLE
fix: wrap at-rest metadata in a valid-JSON envelope

### DIFF
--- a/viperblock/crypto.go
+++ b/viperblock/crypto.go
@@ -20,7 +20,9 @@ package viperblock
 import (
 	"crypto/cipher"
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/binary"
+	"encoding/json"
 	"fmt"
 )
 
@@ -111,12 +113,33 @@ func computeVolumeNameHash(name string) [32]byte {
 	return sha256.Sum256([]byte(name))
 }
 
-// sealMeta authenticates VBState/SnapshotState JSON with AES-GCM-as-MAC: the
-// JSON bytes stay plaintext-readable so operators can still `cat config.json`,
-// while a 16-byte trailing tag binds the bytes to the structured metadata AAD
-// (volumeNameHash || domain || stateSeqNum) and to the nonce. Returns
-// jsonBytes || tag. The full AAD covered by the tag is aad || jsonBytes — the
-// JSON content is authenticated even though it ships in the clear.
+// envelopeVersion is the schema tag written into the metadata envelope so a
+// future format change is self-describing on read.
+const envelopeVersion = 1
+
+// metaEnvelope is the on-disk wrapper for authenticated VBState/SnapshotState
+// metadata: {"v":1,"payload":<json>,"authtag":"<base64 tag>"}. The whole file
+// stays valid JSON — `jq .payload config.json` works, and non-crypto consumers
+// (e.g. the AWS gateway enumerating AMIs) parse it with a plain json.Unmarshal
+// after StateBody strips the wrapper. Payload is the verbatim metadata JSON;
+// authtag is the base64 AES-GCM tag binding the payload to the structured AAD.
+type metaEnvelope struct {
+	Version int             `json:"v"`
+	Payload json.RawMessage `json:"payload"`
+	AuthTag string          `json:"authtag"`
+}
+
+// sealMeta authenticates VBState/SnapshotState JSON with AES-GCM-as-MAC and
+// wraps it in the valid-JSON metaEnvelope. The JSON body ships in the clear
+// (authenticated, not encrypted); the tag covers aad || jsonBytes and binds
+// the bytes to the structured metadata AAD (volumeNameHash || domain ||
+// stateSeqNum) and to the nonce.
+//
+// The envelope is assembled by concatenation so the payload is spliced in
+// verbatim — splitEnvelope recovers those exact bytes via json.RawMessage with
+// no re-serialization, which is what keeps verification robust against JSON
+// canonicalization drift (e.g. time.Time marshal round-trips are not byte-
+// identical, so a re-marshal-to-verify scheme would corrupt the tag input).
 //
 // Caller is responsible for (key, nonce) uniqueness: callers must allocate a
 // fresh stateSeqNum (via VB.nextStateSeqNum.Add(1)) for every seal, since
@@ -127,29 +150,71 @@ func sealMeta(aead cipher.AEAD, jsonBytes, aad []byte, nonce [12]byte) []byte {
 	fullAAD = append(fullAAD, aad...)
 	fullAAD = append(fullAAD, jsonBytes...)
 	tag := aead.Seal(nil, nonce[:], nil, fullAAD)
-	out := make([]byte, 0, len(jsonBytes)+len(tag))
+
+	prefix := fmt.Sprintf(`{"v":%d,"payload":`, envelopeVersion)
+	suffix := `,"authtag":"` + base64.StdEncoding.EncodeToString(tag) + `"}`
+	out := make([]byte, 0, len(prefix)+len(jsonBytes)+len(suffix))
+	out = append(out, prefix...)
 	out = append(out, jsonBytes...)
-	out = append(out, tag...)
+	out = append(out, suffix...)
 	return out
 }
 
-// openMeta verifies the trailing AES-GCM tag on a sealMeta blob and returns
-// the leading JSON bytes on success. Any tampering with the JSON, the tag,
-// the structured AAD, or the nonce inputs surfaces as a non-nil error;
-// callers must wrap with ErrIntegrity and fail-closed.
-func openMeta(aead cipher.AEAD, blob, aad []byte, nonce [12]byte) ([]byte, error) {
-	tagLen := aead.Overhead()
-	if len(blob) < tagLen {
-		return nil, fmt.Errorf("metadata blob %d bytes shorter than %d-byte tag", len(blob), tagLen)
+// splitEnvelope parses a metaEnvelope and returns the verbatim payload JSON
+// bytes and the decoded AES-GCM tag. It performs NO cryptographic
+// verification — callers that need authentication pass the result to
+// verifyMeta. Returns an error if the blob is not a well-formed envelope.
+func splitEnvelope(blob []byte) (payload []byte, tag []byte, err error) {
+	var env metaEnvelope
+	if err := json.Unmarshal(blob, &env); err != nil {
+		return nil, nil, fmt.Errorf("metadata envelope parse: %w", err)
 	}
-	split := len(blob) - tagLen
-	jsonBytes := blob[:split]
-	tag := blob[split:]
-	fullAAD := make([]byte, 0, len(aad)+len(jsonBytes))
+	if len(env.Payload) == 0 || env.AuthTag == "" {
+		return nil, nil, fmt.Errorf("metadata envelope missing payload or authtag")
+	}
+	tag, err = base64.StdEncoding.DecodeString(env.AuthTag)
+	if err != nil {
+		return nil, nil, fmt.Errorf("metadata envelope authtag decode: %w", err)
+	}
+	return env.Payload, tag, nil
+}
+
+// verifyMeta checks the AES-GCM tag over aad || payload (payload + tag come
+// from splitEnvelope). Any tampering with the payload, the tag, the structured
+// AAD, or the nonce inputs surfaces as a non-nil error; callers must wrap with
+// ErrIntegrity and fail-closed.
+func verifyMeta(aead cipher.AEAD, payload, tag, aad []byte, nonce [12]byte) error {
+	if len(tag) != aead.Overhead() {
+		return fmt.Errorf("metadata tag %d bytes, want %d", len(tag), aead.Overhead())
+	}
+	fullAAD := make([]byte, 0, len(aad)+len(payload))
 	fullAAD = append(fullAAD, aad...)
-	fullAAD = append(fullAAD, jsonBytes...)
+	fullAAD = append(fullAAD, payload...)
 	if _, err := aead.Open(nil, nonce[:], tag, fullAAD); err != nil {
-		return nil, err
+		return err
 	}
-	return jsonBytes, nil
+	return nil
+}
+
+// StateBody returns the inner VBState/SnapshotState JSON from a config.json
+// blob, transparently unwrapping the encrypted metadata envelope when present.
+// It does NOT verify the authentication tag and needs no master key — it is
+// for read-only metadata consumers (e.g. the AWS gateway enumerating AMIs and
+// volumes) that read fields but do not authenticate them. Callers that must
+// authenticate the bytes use VB.LoadStateRequest / VB.LoadSnapshotBlockMap.
+//
+// Plain (unencrypted) config.json is returned unchanged, so a single call site
+// transparently handles both encrypted and legacy-cleartext volumes.
+func StateBody(raw []byte) []byte {
+	var probe struct {
+		Payload json.RawMessage `json:"payload"`
+		AuthTag string          `json:"authtag"`
+	}
+	if err := json.Unmarshal(raw, &probe); err != nil {
+		return raw
+	}
+	if len(probe.Payload) > 0 && probe.AuthTag != "" {
+		return probe.Payload
+	}
+	return raw
 }

--- a/viperblock/crypto_test.go
+++ b/viperblock/crypto_test.go
@@ -16,6 +16,7 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/binary"
+	"encoding/json"
 	"testing"
 
 	"github.com/mulgadc/predastore/pkg/masterkey"
@@ -240,11 +241,26 @@ func TestAEAD_DomainSeparationAtCiphertext(t *testing.T) {
 	assert.Error(t, err, "WAL ciphertext must not verify under chunk nonce")
 }
 
-// TestSealMeta_RoundTrip exercises the metadata HMAC primitive: seal a
-// JSON blob with structured AAD + nonce, recover the JSON via openMeta.
-// jsonBytes ship in the clear (operators can `cat config.json`) — the tag
-// binds them to (volumeNameHash, domainTag, stateSeqNum) so cross-volume
-// substitution and bit-flip are detectable.
+// openMetaTest mirrors the production read path (splitEnvelope + verifyMeta):
+// parse the envelope, verify the tag over the verbatim payload, return the
+// payload. Keeps the tamper assertions below readable as a single call.
+func openMetaTest(aead cipher.AEAD, blob, aad []byte, nonce [12]byte) ([]byte, error) {
+	payload, tag, err := splitEnvelope(blob)
+	if err != nil {
+		return nil, err
+	}
+	if err := verifyMeta(aead, payload, tag, aad, nonce); err != nil {
+		return nil, err
+	}
+	return payload, nil
+}
+
+// TestSealMeta_RoundTrip exercises the metadata HMAC primitive: seal a JSON
+// blob with structured AAD + nonce into the valid-JSON envelope, recover the
+// payload via splitEnvelope + verifyMeta. The payload ships in the clear
+// (operators can `jq .payload config.json`) — the tag binds it to
+// (volumeNameHash, domainTag, stateSeqNum) so cross-volume substitution and
+// bit-flip are detectable.
 func TestSealMeta_RoundTrip(t *testing.T) {
 	aead := freshAEAD(t)
 	hash := sha256.Sum256([]byte("vol-meta"))
@@ -253,19 +269,25 @@ func TestSealMeta_RoundTrip(t *testing.T) {
 	aad := makeMetaAAD(hash, "vbstate", 7)
 
 	blob := sealMeta(aead, jsonBytes, aad, nonce)
-	require.Len(t, blob, len(jsonBytes)+aead.Overhead())
-	assert.Equal(t, jsonBytes, blob[:len(jsonBytes)], "jsonBytes ship plaintext in the prefix")
+	assert.True(t, json.Valid(blob), "sealed envelope must be valid JSON")
 
-	recovered, err := openMeta(aead, blob, aad, nonce)
+	payload, _, err := splitEnvelope(blob)
+	require.NoError(t, err)
+	assert.Equal(t, jsonBytes, payload, "payload recovered verbatim from the envelope")
+
+	recovered, err := openMetaTest(aead, blob, aad, nonce)
 	require.NoError(t, err)
 	assert.Equal(t, jsonBytes, recovered)
+
+	// StateBody strips the wrapper without a key (the unverified consumer path).
+	assert.Equal(t, jsonBytes, StateBody(blob))
 }
 
-// TestSealMeta_TamperFails — bit-flip in the JSON, the tag, or the
-// structured AAD inputs (domainTag / stateSeqNum / volumeNameHash) all
-// surface as openMeta errors. This is the cross-volume metadata pivot
-// closer: an attacker swapping volume A's tagged config.json into volume
-// B's prefix is rejected because the AAD's volumeNameHash differs.
+// TestSealMeta_TamperFails — bit-flip in the payload, the tag, or the
+// structured AAD inputs (domainTag / stateSeqNum / volumeNameHash) all surface
+// as errors on the read path. This is the cross-volume metadata pivot closer:
+// an attacker swapping volume A's envelope into volume B's prefix is rejected
+// because the AAD's volumeNameHash differs.
 func TestSealMeta_TamperFails(t *testing.T) {
 	aead := freshAEAD(t)
 	hash := sha256.Sum256([]byte("vol-meta-tamper"))
@@ -274,40 +296,45 @@ func TestSealMeta_TamperFails(t *testing.T) {
 	aad := makeMetaAAD(hash, "vbstate", 99)
 	blob := sealMeta(aead, jsonBytes, aad, nonce)
 
-	t.Run("json byte flip", func(t *testing.T) {
+	// payloadOffset points inside the verbatim payload (after the
+	// `{"v":1,"payload":` prefix) so the flip exercises tag verification on
+	// the payload, not envelope JSON well-formedness.
+	payloadOffset := len(`{"v":1,"payload":`) + 5
+
+	t.Run("payload byte flip", func(t *testing.T) {
 		tampered := append([]byte(nil), blob...)
-		tampered[3] ^= 0x01
-		_, err := openMeta(aead, tampered, aad, nonce)
+		tampered[payloadOffset] ^= 0x01
+		_, err := openMetaTest(aead, tampered, aad, nonce)
 		assert.Error(t, err)
 	})
 
 	t.Run("tag byte flip", func(t *testing.T) {
 		tampered := append([]byte(nil), blob...)
-		tampered[len(tampered)-1] ^= 0x01
-		_, err := openMeta(aead, tampered, aad, nonce)
+		// Flip a base64 char of the authtag (before the closing `"}`).
+		tampered[len(tampered)-3] ^= 0x01
+		_, err := openMetaTest(aead, tampered, aad, nonce)
 		assert.Error(t, err)
 	})
 
 	t.Run("wrong volumeNameHash", func(t *testing.T) {
 		other := sha256.Sum256([]byte("vol-meta-OTHER"))
-		_, err := openMeta(aead, blob, makeMetaAAD(other, "vbstate", 99), nonce)
+		_, err := openMetaTest(aead, blob, makeMetaAAD(other, "vbstate", 99), nonce)
 		assert.Error(t, err, "cross-volume AAD must fail verify")
 	})
 
 	t.Run("wrong domain tag", func(t *testing.T) {
-		_, err := openMeta(aead, blob, makeMetaAAD(hash, "snap:foo", 99), nonce)
+		_, err := openMetaTest(aead, blob, makeMetaAAD(hash, "snap:foo", 99), nonce)
 		assert.Error(t, err, "vbstate blob must not verify under snapshot AAD")
 	})
 
 	t.Run("wrong stateSeqNum", func(t *testing.T) {
-		_, err := openMeta(aead, blob, makeMetaAAD(hash, "vbstate", 100), nonce)
+		_, err := openMetaTest(aead, blob, makeMetaAAD(hash, "vbstate", 100), nonce)
 		assert.Error(t, err)
 	})
 
-	t.Run("blob shorter than tag", func(t *testing.T) {
-		short := blob[:aead.Overhead()-1]
-		_, err := openMeta(aead, short, aad, nonce)
-		assert.Error(t, err, "undersized blob must surface a clear error")
+	t.Run("not an envelope", func(t *testing.T) {
+		_, err := openMetaTest(aead, []byte(`{"VolumeName":"x"}`), aad, nonce)
+		assert.Error(t, err, "plain JSON without payload/authtag must fail split")
 	})
 }
 

--- a/viperblock/encryption_meta_test.go
+++ b/viperblock/encryption_meta_test.go
@@ -22,11 +22,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// metaPayloadOffset is a byte index that lands inside the envelope's verbatim
+// payload (past the `{"v":1,"payload":` prefix), so a flip there exercises tag
+// verification on the payload rather than envelope JSON well-formedness.
+var metaPayloadOffset = len(`{"v":1,"payload":`) + 5
+
 // TestVBStateMeta_BitFlipFailsLoad — a one-byte flip in the persisted
-// config.json after the HMAC seal must surface as ErrIntegrity at
-// LoadStateRequest. This is the literal byte-tamper check: the JSON
-// ships plaintext, the trailing 16-byte tag binds the bytes to the
-// AAD via sealMeta, so any modification fails openMeta.
+// config.json payload after the HMAC seal must surface as ErrIntegrity at
+// LoadStateRequest. The payload ships plaintext inside the envelope; the
+// authtag binds it to the AAD via sealMeta, so any modification fails verify.
 func TestVBStateMeta_BitFlipFailsLoad(t *testing.T) {
 	key := testKey(t, 0x42)
 	vb := newFileBackedVB(t, "vol-meta-bitflip", key)
@@ -36,8 +40,8 @@ func TestVBStateMeta_BitFlipFailsLoad(t *testing.T) {
 	configPath := filepath.Join(vb.BaseDir, types.GetFilePath(types.FileTypeConfig, 0, vb.GetVolume()))
 	raw, err := os.ReadFile(configPath)
 	require.NoError(t, err)
-	require.Greater(t, len(raw), 20)
-	raw[5] ^= 0x01 // flip a JSON byte
+	require.Greater(t, len(raw), metaPayloadOffset)
+	raw[metaPayloadOffset] ^= 0x01 // flip a payload byte
 	require.NoError(t, os.WriteFile(configPath, raw, 0600))
 
 	_, err = vb.LoadStateRequest(configPath)
@@ -45,10 +49,10 @@ func TestVBStateMeta_BitFlipFailsLoad(t *testing.T) {
 	assert.ErrorIs(t, err, ErrIntegrity)
 }
 
-// TestVBStateMeta_TagFlipFailsLoad — flipping a byte in the trailing
-// 16-byte tag must also fail. Distinct from the body flip: tag bytes
-// are not parsed as JSON, so a regression that verifies the tag length
-// but not its contents would pass the body-flip test and fail here.
+// TestVBStateMeta_TagFlipFailsLoad — flipping a byte in the base64 authtag
+// must also fail. Distinct from the payload flip: a regression that parses
+// the envelope but skips tag verification would pass the payload-flip test
+// (if it re-derived a tag) and fail here.
 func TestVBStateMeta_TagFlipFailsLoad(t *testing.T) {
 	key := testKey(t, 0x42)
 	vb := newFileBackedVB(t, "vol-meta-tag", key)
@@ -58,7 +62,9 @@ func TestVBStateMeta_TagFlipFailsLoad(t *testing.T) {
 	configPath := filepath.Join(vb.BaseDir, types.GetFilePath(types.FileTypeConfig, 0, vb.GetVolume()))
 	raw, err := os.ReadFile(configPath)
 	require.NoError(t, err)
-	raw[len(raw)-1] ^= 0x01 // flip last byte of tag
+	// Flip a base64 char of the authtag (the tail is `…<base64>=="}`; index
+	// -5 is a real base64 char, clear of the `=="}` suffix).
+	raw[len(raw)-5] ^= 0x01
 	require.NoError(t, os.WriteFile(configPath, raw, 0600))
 
 	_, err = vb.LoadStateRequest(configPath)
@@ -242,7 +248,8 @@ func TestSnapshotMeta_BitFlipFailsLoad(t *testing.T) {
 	configPath := filepath.Join(env.dir, types.GetFilePath(types.FileTypeConfig, 0, snapshotID))
 	raw, err := os.ReadFile(configPath)
 	require.NoError(t, err)
-	raw[10] ^= 0x01
+	require.Greater(t, len(raw), metaPayloadOffset)
+	raw[metaPayloadOffset] ^= 0x01 // flip a payload byte
 	require.NoError(t, os.WriteFile(configPath, raw, 0600))
 
 	_, _, err = env.source.LoadSnapshotBlockMap(snapshotID)
@@ -296,11 +303,10 @@ func TestBlockStoreReadEncrypted(t *testing.T) {
 	assert.ErrorIs(t, err, ErrIntegrity)
 }
 
-// TestVBStateMeta_TruncatedBlobFails — a backend-side truncation of
-// the VBState blob below the 16-byte tag boundary must surface a
-// clear error rather than panic on the slice arithmetic in
-// LoadStateRequest. Defensive: an external operator who half-uploads
-// a backend object should see a refused open, not a runtime panic.
+// TestVBStateMeta_TruncatedBlobFails — a backend-side truncation/corruption
+// of the VBState blob into a non-envelope must surface a clear error rather
+// than panic in LoadStateRequest. Defensive: an external operator who
+// half-uploads a backend object should see a refused open, not a panic.
 func TestVBStateMeta_TruncatedBlobFails(t *testing.T) {
 	key := testKey(t, 0x42)
 	dir := t.TempDir()
@@ -318,13 +324,13 @@ func TestVBStateMeta_TruncatedBlobFails(t *testing.T) {
 	require.NoError(t, vb.SaveState())
 
 	configPath := filepath.Join(dir, types.GetFilePath(types.FileTypeConfig, 0, vb.GetVolume()))
-	// Truncate to fewer bytes than the tag length — must fail with a
-	// clear "shorter than tag" message, not a slice-bounds panic.
+	// Overwrite with bytes that are not a valid envelope — must fail with a
+	// clear error, not a slice-bounds panic.
 	require.NoError(t, os.WriteFile(configPath, []byte{0x01, 0x02, 0x03}, 0600))
 
 	_, err = vb.LoadStateRequest(configPath)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrIntegrity)
 	// Make sure the error message is informative.
-	assert.Contains(t, err.Error(), "shorter")
+	assert.Contains(t, err.Error(), "envelope")
 }

--- a/viperblock/encryption_snapshot_test.go
+++ b/viperblock/encryption_snapshot_test.go
@@ -14,6 +14,7 @@ package viperblock
 import (
 	"bytes"
 	"crypto/rand"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -181,12 +182,13 @@ func TestSnapshotEncrypted_CrossVolumeSubstitutionFailsHMAC(t *testing.T) {
 	configPath := filepath.Join(env.dir, types.GetFilePath(types.FileTypeConfig, 0, snapshotID))
 	raw, err := os.ReadFile(configPath)
 	require.NoError(t, err)
-	// Decode the JSON (without the trailing tag) so we can find the
-	// SourceVolumeUUID field and flip a byte in the hex string.
-	tagLen := env.source.aead.Overhead()
-	jsonBytes := raw[:len(raw)-tagLen]
+	// Split the envelope so we can rewrite the SourceVolumeUUID field in the
+	// payload, then re-wrap with the ORIGINAL tag — verify must fail because
+	// the payload bytes (bound into the AAD via sealMeta) have changed.
+	payload, tag, err := splitEnvelope(raw)
+	require.NoError(t, err)
 	var snap SnapshotState
-	require.NoError(t, json.Unmarshal(jsonBytes, &snap))
+	require.NoError(t, json.Unmarshal(payload, &snap))
 	require.NotEmpty(t, snap.SourceVolumeUUID)
 	// Flip the first hex char.
 	tampered := []byte(snap.SourceVolumeUUID)
@@ -198,9 +200,8 @@ func TestSnapshotEncrypted_CrossVolumeSubstitutionFailsHMAC(t *testing.T) {
 	snap.SourceVolumeUUID = string(tampered)
 	tamperedJSON, err := json.Marshal(snap)
 	require.NoError(t, err)
-	// Append the original tag — verify must fail because the JSON bytes
-	// (which are part of the AAD via sealMeta) have changed.
-	newBlob := append(tamperedJSON, raw[len(raw)-tagLen:]...)
+	newBlob := fmt.Appendf(nil, `{"v":1,"payload":%s,"authtag":"%s"}`,
+		tamperedJSON, base64.StdEncoding.EncodeToString(tag))
 	require.NoError(t, os.WriteFile(configPath, newBlob, 0600))
 
 	_, _, err = env.source.LoadSnapshotBlockMap(snapshotID)

--- a/viperblock/snapshot.go
+++ b/viperblock/snapshot.go
@@ -166,25 +166,24 @@ func (vb *VB) LoadSnapshotBlockMap(snapshotID string) (*BlocksToObject, Snapshot
 		return nil, ident, fmt.Errorf("failed to read snapshot config %s: %w", snapshotID, err)
 	}
 
-	// Encrypted snapshots carry a trailing 16-byte AES-GCM tag. Two-stage
-	// parse: peek the pre-tag bytes for SourceVolumeUUID +
+	// Encrypted snapshots wrap the JSON in a metaEnvelope. Two-stage parse:
+	// split the envelope, peek the verbatim payload for SourceVolumeUUID +
 	// SourceVolumeNameHash + StateSeqNum (needed to reconstruct nonce + AAD),
 	// verify, then unmarshal the verified bytes into the full struct. The
 	// snapshotID parameter is the trusted external identity bound into the
 	// AAD — splicing in another snapshot's blob fails because the literal
 	// "snap:"||snapshotID differs from the seal-time value.
 	if vb.EncryptionEnabled {
-		tagLen := vb.aead.Overhead()
-		if len(configData) < tagLen {
-			return nil, ident, fmt.Errorf("%w: snapshot %s config %d bytes shorter than %d-byte tag", ErrIntegrity, snapshotID, len(configData), tagLen)
+		payload, tag, splitErr := splitEnvelope(configData)
+		if splitErr != nil {
+			return nil, ident, fmt.Errorf("%w: snapshot %s envelope: %w", ErrIntegrity, snapshotID, splitErr)
 		}
 		var peek struct {
 			SourceVolumeUUID     string `json:"SourceVolumeUUID"`
 			SourceVolumeNameHash string `json:"SourceVolumeNameHash"`
 			StateSeqNum          uint64 `json:"StateSeqNum"`
 		}
-		peekJSON := configData[:len(configData)-tagLen]
-		if err := json.Unmarshal(peekJSON, &peek); err != nil {
+		if err := json.Unmarshal(payload, &peek); err != nil {
 			return nil, ident, fmt.Errorf("%w: snapshot %s peek parse: %w", ErrIntegrity, snapshotID, err)
 		}
 		uuid, uuidErr := hex.DecodeString(peek.SourceVolumeUUID)
@@ -201,11 +200,10 @@ func (vb *VB) LoadSnapshotBlockMap(snapshotID string) (*BlocksToObject, Snapshot
 		copy(aadNameHash[:], nameHash)
 		nonce := makeNonce(peek.StateSeqNum, nonceUUID, DomainSnapshotMeta)
 		aad := makeMetaAAD(aadNameHash, "snap:"+snapshotID, peek.StateSeqNum)
-		verified, openErr := openMeta(vb.aead, configData, aad, nonce)
-		if openErr != nil {
-			return nil, ident, fmt.Errorf("%w: snapshot %s tag verify: %w", ErrIntegrity, snapshotID, openErr)
+		if err := verifyMeta(vb.aead, payload, tag, aad, nonce); err != nil {
+			return nil, ident, fmt.Errorf("%w: snapshot %s tag verify: %w", ErrIntegrity, snapshotID, err)
 		}
-		configData = verified
+		configData = payload
 	}
 
 	var snap SnapshotState

--- a/viperblock/viperblock.go
+++ b/viperblock/viperblock.go
@@ -3189,30 +3189,29 @@ func (vb *VB) LoadStateRequest(filename string) (state VBState, err error) {
 		}
 	}
 
-	// Encrypted volumes carry a trailing 16-byte AES-GCM tag binding the JSON
-	// to (volumeNameHash, "vbstate", StateSeqNum). The nonce + structured AAD
-	// reconstruction needs StateSeqNum + VolumeUUID, both of which live in
-	// the JSON — extract them via a minimal peek struct over the pre-tag
-	// bytes, then verify before unmarshalling the full state. The peek's
-	// VolumeUUID is the nonce subspace identifier (binds the seal-time
-	// nonce); vb.volumeNameHash is the trusted volume identity (caller-
-	// supplied at New, untouched by the parsed JSON) — splicing in another
-	// volume's blob is rejected because the AAD's volumeNameHash differs.
-	// KeyFingerprint is checked pre-verify so a wrong-key open surfaces as
-	// ErrEncryptionMismatch (with both fingerprints in the error) rather
-	// than the generic "tag verify failed" that AEAD would otherwise return.
+	// Encrypted volumes wrap the JSON in a metaEnvelope whose authtag binds
+	// the payload to (volumeNameHash, "vbstate", StateSeqNum). The nonce +
+	// structured AAD reconstruction needs StateSeqNum + VolumeUUID, both of
+	// which live in the payload — split the envelope, extract them via a
+	// minimal peek struct over the verbatim payload, then verify before
+	// unmarshalling the full state. The peek's VolumeUUID is the nonce
+	// subspace identifier (binds the seal-time nonce); vb.volumeNameHash is
+	// the trusted volume identity (caller-supplied at New, untouched by the
+	// parsed JSON) — splicing in another volume's blob is rejected because
+	// the AAD's volumeNameHash differs. KeyFingerprint is checked pre-verify
+	// so a wrong-key open surfaces as ErrEncryptionMismatch (with both
+	// fingerprints in the error) rather than the generic "tag verify failed".
 	if vb.EncryptionEnabled {
-		tagLen := vb.aead.Overhead()
-		if len(jsonData) < tagLen {
-			return state, fmt.Errorf("%w: VBState blob %d bytes shorter than %d-byte tag", ErrIntegrity, len(jsonData), tagLen)
+		payload, tag, splitErr := splitEnvelope(jsonData)
+		if splitErr != nil {
+			return state, fmt.Errorf("%w: VBState envelope: %w", ErrIntegrity, splitErr)
 		}
 		var peek struct {
 			VolumeUUID     [4]byte `json:"VolumeUUID"`
 			StateSeqNum    uint64  `json:"StateSeqNum"`
 			KeyFingerprint string  `json:"KeyFingerprint"`
 		}
-		peekJSON := jsonData[:len(jsonData)-tagLen]
-		if err := json.Unmarshal(peekJSON, &peek); err != nil {
+		if err := json.Unmarshal(payload, &peek); err != nil {
 			return state, fmt.Errorf("%w: VBState peek parse: %w", ErrIntegrity, err)
 		}
 		if peek.KeyFingerprint != vb.MasterKey.Fingerprint {
@@ -3221,19 +3220,19 @@ func (vb *VB) LoadStateRequest(filename string) (state VBState, err error) {
 		}
 		nonce := makeNonce(peek.StateSeqNum, peek.VolumeUUID, DomainVBStateMeta)
 		aad := makeMetaAAD(vb.volumeNameHash, "vbstate", peek.StateSeqNum)
-		verified, openErr := openMeta(vb.aead, jsonData, aad, nonce)
-		if openErr != nil {
-			return state, fmt.Errorf("%w: VBState tag verify: %w", ErrIntegrity, openErr)
+		if err := verifyMeta(vb.aead, payload, tag, aad, nonce); err != nil {
+			return state, fmt.Errorf("%w: VBState tag verify: %w", ErrIntegrity, err)
 		}
-		jsonData = verified
+		jsonData = payload
 	}
 
-	// Use a Decoder rather than Unmarshal so a plain-mode runtime reading a
-	// sealed blob does not error on the trailing 16-byte tag. The Decoder
-	// reads one JSON value and stops; LoadState's existing
-	// EncryptionEnabled mismatch check then surfaces the misconfig as
-	// ErrEncryptionMismatch instead of swallowing it as parse failure.
-	err = json.NewDecoder(bytes.NewReader(jsonData)).Decode(&state)
+	// StateBody strips the envelope so a plain-mode runtime reading an
+	// encrypted blob still decodes the inner payload (which carries
+	// EncryptionEnabled=true) — LoadState's flag-mismatch check then surfaces
+	// the misconfig as ErrEncryptionMismatch rather than silently decoding the
+	// envelope wrapper into a zero-valued state. For the encrypted path
+	// jsonData is already the verified payload, so StateBody is a no-op.
+	err = json.NewDecoder(bytes.NewReader(StateBody(jsonData))).Decode(&state)
 
 	return state, err
 }


### PR DESCRIPTION
VBState/SnapshotState config.json was sealed as `<json>||<16-byte tag>`, which is not valid JSON — every external consumer (the AWS gateway listing AMIs and volumes) parses it with json.Unmarshal and silently fails on the trailing tag, so encrypted AMIs/volumes became invisible.

Wrap the authenticated metadata in a valid-JSON envelope instead:

  {"v":1,"payload":<json>,"authtag":"<base64 tag>"}

The payload is spliced in verbatim and recovered byte-for-byte via json.RawMessage, so tag verification stays robust against JSON canonicalization drift (time.Time round-trips are not byte-identical, so a re-marshal-to-verify scheme would corrupt the tag input). sealMeta builds the envelope; splitEnvelope
+ verifyMeta replace openMeta on the read paths. New exported StateBody unwraps the envelope for read-only consumers that hold no key.

Tamper coverage (bit-flip, tag-flip, cross-volume splice, malformed blob) is preserved against the new layout; the security properties are unchanged.