### PR TITLE
fix: encrypted volume seal/open correctness (AMI snapshot, fresh-volume UUID, snapshot-link)

### DIFF
--- a/viperblock/encryption_snapshot_test.go
+++ b/viperblock/encryption_snapshot_test.go
@@ -174,6 +174,80 @@ func TestSnapshotEncrypted_SnapshotBeforeSaveStateMintsConsistentUUID(t *testing
 	assert.Equal(t, vb.VolumeUUID, ident.SourceVolumeUUID)
 }
 
+// TestSnapshotEncrypted_ReopenPreservesSnapshotLink gates the LoadState
+// ordering for encrypted snapshot clones. The encrypted SeqNum bootstrap
+// (bumpSeqNumHighWater) durably rewrites config.json during LoadState; it must
+// run AFTER OpenFromSnapshot restores SnapshotID, or the rewritten config
+// records an empty SnapshotID. The next open then loads no base map and serves
+// an all-zeros disk — the exact "guest drops to UEFI shell, no FS0:" failure on
+// every encrypted AMI launch. In-memory SnapshotID is restored either way
+// (OpenFromSnapshot runs at the end), so this asserts the PERSISTED config and
+// a fresh-open base read, which is what the runtime nbdkit plugin process sees.
+func TestSnapshotEncrypted_ReopenPreservesSnapshotLink(t *testing.T) {
+	env := newSnapshotEnv(t, "src-reopen", testKey(t, 0x42))
+
+	blockCount := uint64(4)
+	plaintext := make([]byte, uint64(env.source.BlockSize)*blockCount)
+	_, err := rand.Read(plaintext)
+	require.NoError(t, err)
+	require.NoError(t, env.source.Write(0, plaintext))
+	require.NoError(t, env.source.Flush())
+	require.NoError(t, env.source.WriteWALToChunk(true))
+
+	snapshotID := "snap-reopen"
+	_, err = env.source.CreateSnapshot(snapshotID)
+	require.NoError(t, err)
+
+	// Open an encrypted clone and persist its state — config.json now records
+	// SnapshotID, exactly as RunInstances' cloneAMIToVolume does.
+	clone := env.openEncryptedClone(t, "clone-reopen", snapshotID)
+	require.NoError(t, clone.SaveState())
+	require.Equal(t, snapshotID, clone.SnapshotID)
+
+	// Reopen the clone. Pre-fix, LoadState's bumpSeqNumHighWater persists
+	// config.json before OpenFromSnapshot restores the link, clobbering
+	// SnapshotID on disk.
+	reopened := newCloneReopen(t, env.dir, "clone-reopen", env.key)
+	require.NoError(t, reopened.LoadState())
+
+	// Decisive gate 1: the persisted config must still carry the snapshot link.
+	configPath := filepath.Join(env.dir, types.GetFilePath(types.FileTypeConfig, 0, "clone-reopen"))
+	persistedState, err := reopened.LoadStateRequest(configPath)
+	require.NoError(t, err)
+	require.Equal(t, snapshotID, persistedState.SnapshotID,
+		"LoadState must not persist an empty SnapshotID — that bricks base-map reads on the next open")
+
+	// Decisive gate 2: a brand-new open (mirrors the nbdkit plugin process)
+	// must load the base map from disk and decrypt source blocks, not zeros.
+	fresh := newCloneReopen(t, env.dir, "clone-reopen", env.key)
+	require.NoError(t, fresh.LoadState())
+	require.Equal(t, snapshotID, fresh.SnapshotID, "fresh open must recover SnapshotID from disk")
+	got, err := fresh.ReadAt(0, uint64(fresh.BlockSize))
+	require.NoError(t, err, "fresh open of an encrypted clone must read base blocks, not an all-zeros disk")
+	assert.True(t, bytes.Equal(plaintext[:fresh.BlockSize], got), "base block 0 must decrypt to source plaintext")
+}
+
+// newCloneReopen constructs a fresh encrypted VB over an existing on-disk
+// volume in dir WITHOUT a pre-write SaveState, so LoadState reads the persisted
+// config exactly as a cold reopen (or the out-of-process nbdkit plugin) would.
+func newCloneReopen(t *testing.T, dir, volumeName string, key *masterkey.Key) *VB {
+	t.Helper()
+	cfg := file.FileConfig{BaseDir: dir, VolumeName: volumeName}
+	vb, err := New(&VB{
+		VolumeName:        volumeName,
+		VolumeSize:        64 * 1024 * 1024,
+		BaseDir:           dir,
+		MasterKey:         key,
+		EncryptionEnabled: key != nil,
+		WALSyncInterval:   -1,
+	}, "file", cfg)
+	require.NoError(t, err)
+	require.NoError(t, vb.Backend.Init())
+	vb.BlockSize = DefaultBlockSize
+	vb.ObjBlockSize = 16 * DefaultBlockSize
+	return vb
+}
+
 // TestSnapshotEncrypted_CloneReadsBaseChunks — the clone opens the
 // snapshot and reads blocks 0-3 through the base-chunk path. Each read
 // must decrypt the source's chunks under the source's identity (the

--- a/viperblock/encryption_snapshot_test.go
+++ b/viperblock/encryption_snapshot_test.go
@@ -117,6 +117,63 @@ func TestSnapshotEncrypted_PersistsSourceIdentity(t *testing.T) {
 	assert.Equal(t, env.source.volumeNameHash, ident.SourceVolumeNameHash)
 }
 
+// TestSnapshotEncrypted_SnapshotBeforeSaveStateMintsConsistentUUID gates the
+// AMI-import ordering. ImportDiskImage writes blocks and snapshots WITHOUT a
+// prior SaveState, so VolumeUUID is still zero entering CreateSnapshot, where
+// SaveState mints it. CreateSnapshot must record the SAME (minted) UUID it
+// seals the metadata nonce under — recording the pre-mint zero while sealing
+// under the minted value makes LoadSnapshotBlockMap reconstruct the wrong
+// nonce and fail tag verify. This is the exact "snapshot ... tag verify:
+// message authentication failed" seen on every encrypted AMI launch.
+func TestSnapshotEncrypted_SnapshotBeforeSaveStateMintsConsistentUUID(t *testing.T) {
+	dir := t.TempDir()
+	key := testKey(t, 0x42)
+	cfg := file.FileConfig{BaseDir: dir, VolumeName: "src-import-order"}
+	vb, err := New(&VB{
+		VolumeName:        "src-import-order",
+		VolumeSize:        64 * 1024 * 1024,
+		BaseDir:           dir,
+		MasterKey:         key,
+		EncryptionEnabled: true,
+		WALSyncInterval:   -1,
+	}, "file", cfg)
+	require.NoError(t, err)
+	require.NoError(t, vb.Backend.Init())
+	vb.BlockSize = DefaultBlockSize
+	vb.ObjBlockSize = 16 * DefaultBlockSize
+	// Deliberately NO SaveState here — mirrors ImportDiskImage, which leaves
+	// VolumeUUID unminted entering CreateSnapshot.
+	require.NoError(t, vb.OpenWAL(&vb.WAL,
+		fmt.Sprintf("%s/%s", vb.WAL.BaseDir, types.GetFilePath(types.FileTypeWALChunk, vb.WAL.WallNum.Load(), vb.GetVolume()))))
+	require.NoError(t, vb.OpenWAL(&vb.BlockToObjectWAL,
+		fmt.Sprintf("%s/%s", vb.BlockToObjectWAL.BaseDir, types.GetFilePath(types.FileTypeWALBlock, vb.BlockToObjectWAL.WallNum.Load(), vb.GetVolume()))))
+
+	var zero [4]byte
+	require.Equal(t, zero, vb.VolumeUUID, "precondition: VolumeUUID must be unminted entering the snapshot")
+
+	data := make([]byte, vb.BlockSize*4)
+	_, err = rand.Read(data)
+	require.NoError(t, err)
+	require.NoError(t, vb.Write(0, data))
+	require.NoError(t, vb.Flush())
+	require.NoError(t, vb.WriteWALToChunk(true))
+
+	snapshotID := "snap-import-order"
+	snap, err := vb.CreateSnapshot(snapshotID)
+	require.NoError(t, err)
+	require.NotNil(t, snap)
+
+	require.NotEqual(t, zero, vb.VolumeUUID, "CreateSnapshot must mint VolumeUUID")
+	assert.Equal(t, hex.EncodeToString(vb.VolumeUUID[:]), snap.SourceVolumeUUID,
+		"snapshot must record the minted UUID it sealed the nonce under, not the pre-mint zero")
+
+	// Decisive gate: the metadata envelope must verify. Pre-fix this returns
+	// ErrIntegrity — sealed under the minted UUID, recorded (and reopened) as zero.
+	_, ident, err := vb.LoadSnapshotBlockMap(snapshotID)
+	require.NoError(t, err, "snapshot metadata must verify when VolumeUUID is minted during CreateSnapshot")
+	assert.Equal(t, vb.VolumeUUID, ident.SourceVolumeUUID)
+}
+
 // TestSnapshotEncrypted_CloneReadsBaseChunks — the clone opens the
 // snapshot and reads blocks 0-3 through the base-chunk path. Each read
 // must decrypt the source's chunks under the source's identity (the

--- a/viperblock/encryption_tamper_test.go
+++ b/viperblock/encryption_tamper_test.go
@@ -558,3 +558,62 @@ func TestEncryptedWAL_RecoveryAEADTamperSurfacesErrIntegrity(t *testing.T) {
 	_, statErr = os.Stat(walPath)
 	assert.NoError(t, statErr, "tampered WAL must NOT be deleted by RecoverLocalWALs — kept on disk for forensics + retry")
 }
+
+// TestReserveSeqNum_MintsVolumeUUIDBeforeFirstSeal gates the fresh-seeded
+// volume path (EFI varstore seed, raw AMI import): a volume written and chunked
+// WITHOUT a prior SaveState must still round-trip after a later SaveState.
+// reserveSeqNum mints VolumeUUID on the first encrypted write and persists it
+// before any block is sealed, so the chunk and config.json agree on the nonce
+// subspace. Without that mint, the chunk seals under the zero UUID while the
+// deferred SaveState (Close) mints a random one, and read-back fails tag verify
+// — the exact "integrity check failed: chunk 0 block 0 (seqNum 1): cipher:
+// message authentication failed" seen on the EFI pflash drive at instance launch.
+func TestReserveSeqNum_MintsVolumeUUIDBeforeFirstSeal(t *testing.T) {
+	dir := t.TempDir()
+	key := testKey(t, 0x42)
+	cfg := file.FileConfig{BaseDir: dir, VolumeName: "vol-efi-seed"}
+	vb, err := New(&VB{
+		VolumeName:        "vol-efi-seed",
+		VolumeSize:        64 * 1024 * 1024,
+		BaseDir:           dir,
+		MasterKey:         key,
+		EncryptionEnabled: true,
+		WALSyncInterval:   -1,
+	}, "file", cfg)
+	require.NoError(t, err)
+	require.NoError(t, vb.Backend.Init())
+	vb.BlockSize = DefaultBlockSize
+	vb.ObjBlockSize = 16 * DefaultBlockSize
+	// Deliberately NO SaveState before writing — mirrors prepareEFIVolume,
+	// which seeds the varstore via WriteAt -> Flush -> Close with no prior mint.
+	require.NoError(t, vb.OpenWAL(&vb.WAL,
+		fmt.Sprintf("%s/%s", vb.WAL.BaseDir, types.GetFilePath(types.FileTypeWALChunk, vb.WAL.WallNum.Load(), vb.GetVolume()))))
+	require.NoError(t, vb.OpenWAL(&vb.BlockToObjectWAL,
+		fmt.Sprintf("%s/%s", vb.BlockToObjectWAL.BaseDir, types.GetFilePath(types.FileTypeWALBlock, vb.BlockToObjectWAL.WallNum.Load(), vb.GetVolume()))))
+
+	var zero [4]byte
+	require.Equal(t, zero, vb.VolumeUUID, "precondition: VolumeUUID unminted before first write")
+
+	plaintext := make([]byte, vb.BlockSize*4)
+	_, err = rand.Read(plaintext)
+	require.NoError(t, err)
+	require.NoError(t, vb.Write(0, plaintext))
+	require.NoError(t, vb.Flush())
+	require.NoError(t, vb.WriteWALToChunk(true))
+
+	// The first encrypted write must have minted the UUID via reserveSeqNum, so
+	// the chunk just sealed is bound to a non-zero, persisted nonce subspace.
+	minted := vb.VolumeUUID
+	require.NotEqual(t, zero, minted, "reserveSeqNum must mint VolumeUUID on the first encrypted write")
+
+	// A deferred SaveState (Close calls this after sealing) must PRESERVE the
+	// write-minted UUID, not overwrite it with a fresh random value.
+	require.NoError(t, vb.SaveState())
+	require.Equal(t, minted, vb.VolumeUUID, "deferred SaveState must preserve the write-minted UUID")
+
+	// Decisive gate: read block 0 back through the chunk decrypt path. Pre-fix
+	// this fails ErrIntegrity (chunk sealed under zero, reopened under random).
+	got, err := vb.ReadAt(0, uint64(vb.BlockSize))
+	require.NoError(t, err, "fresh-seeded encrypted volume must round-trip after a deferred SaveState")
+	assert.True(t, bytes.Equal(plaintext[:vb.BlockSize], got), "block 0 plaintext mismatch after decrypt")
+}

--- a/viperblock/snapshot.go
+++ b/viperblock/snapshot.go
@@ -102,7 +102,6 @@ func (vb *VB) CreateSnapshot(snapshotID string) (*SnapshotState, error) {
 	}
 
 	if vb.EncryptionEnabled {
-		snap.SourceVolumeUUID = hex.EncodeToString(vb.VolumeUUID[:])
 		snap.SourceVolumeNameHash = hex.EncodeToString(vb.volumeNameHash[:])
 		snap.StateSeqNum = vb.nextStateSeqNum.Add(1)
 		// Persist the bumped counter before sealing under it: a crash
@@ -116,6 +115,12 @@ func (vb *VB) CreateSnapshot(snapshotID string) (*SnapshotState, error) {
 		if err := vb.SaveState(); err != nil {
 			return nil, fmt.Errorf("snapshot StateSeqNum persist: %w", err)
 		}
+		// Capture VolumeUUID AFTER SaveState: SaveState mints it on first
+		// use for an encrypted volume, and the meta nonce below seals under
+		// the minted value. Recording it earlier persists the pre-mint zero
+		// UUID, so open-time nonce reconstruction diverges from the seal
+		// nonce and every read fails tag verify.
+		snap.SourceVolumeUUID = hex.EncodeToString(vb.VolumeUUID[:])
 	}
 
 	snapJSON, err := json.Marshal(snap)

--- a/viperblock/v_utils/v_utils.go
+++ b/viperblock/v_utils/v_utils.go
@@ -140,6 +140,18 @@ func ImportDiskImage(s3Config *s3.S3Config, vbConfig *viperblock.VB, filename st
 		return fmt.Errorf("failed to load block WAL: %v", err)
 	}
 
+	// Encrypted volumes derive the AES-GCM nonce from VolumeUUID, which
+	// SaveState mints on first use. Mint it now, before the first chunk is
+	// sealed in the write loop, so every chunk and the AMI snapshot share one
+	// stable UUID. Deferring the mint to CreateSnapshot would seal the chunks
+	// under the zero UUID while the snapshot records the minted one, breaking
+	// clone reads with a tag-verify failure.
+	if vb.EncryptionEnabled {
+		if err := vb.SaveState(); err != nil {
+			return fmt.Errorf("failed to persist initial state: %w", err)
+		}
+	}
+
 	var block uint64 = 0
 
 	totalBytes := fileInfo.Size()

--- a/viperblock/viperblock.go
+++ b/viperblock/viperblock.go
@@ -3076,6 +3076,21 @@ func (vb *VB) LoadState() error {
 
 	vb.nextStateSeqNum.Store(state.StateSeqNum)
 
+	// If this volume was created from a snapshot, restore the base block map
+	// BEFORE the encrypted SeqNum bootstrap below. OpenFromSnapshot sets
+	// SnapshotID/SourceVolumeName, and the encrypted bumpSeqNumHighWater
+	// durably persists VBState. Restoring the snapshot link after that persist
+	// would write a config.json with an empty SnapshotID, so the next open
+	// loads no base map and serves an all-zeros disk. OpenFromSnapshot verifies
+	// the snapshot under the source identity, independent of this volume's
+	// VolumeUUID, so it is safe to run first.
+	if state.SnapshotID != "" {
+		if err := vb.OpenFromSnapshot(state.SnapshotID); err != nil {
+			slog.Error("Failed to load snapshot base map", "snapshotID", state.SnapshotID, "error", err)
+			return fmt.Errorf("failed to load snapshot %s: %w", state.SnapshotID, err)
+		}
+	}
+
 	// Encryption SeqNum bootstrap. On a successful Open of an existing
 	// encrypted volume, restart SeqNum at the persisted high-water and
 	// reserve the next window durably before any data write can hand out a
@@ -3089,16 +3104,6 @@ func (vb *VB) LoadState() error {
 		vb.seqNumHighWater.Store(state.SeqNumHighWater)
 		if err := vb.bumpSeqNumHighWater(); err != nil {
 			return fmt.Errorf("LoadState: reserve initial SeqNum window: %w", err)
-		}
-	}
-
-	// If this volume was created from a snapshot, load the base block map.
-	// OpenFromSnapshot sets SnapshotID and SourceVolumeName from the snapshot
-	// config, so we don't set them separately to avoid two sources of truth.
-	if state.SnapshotID != "" {
-		if err := vb.OpenFromSnapshot(state.SnapshotID); err != nil {
-			slog.Error("Failed to load snapshot base map", "snapshotID", state.SnapshotID, "error", err)
-			return fmt.Errorf("failed to load snapshot %s: %w", state.SnapshotID, err)
 		}
 	}
 

--- a/viperblock/viperblock.go
+++ b/viperblock/viperblock.go
@@ -2810,15 +2810,32 @@ func (vb *VB) LookupBlockToObject(block uint64) (objectID uint64, objectOffset u
 // that would let reserveSeqNum re-hand-out values on restart.
 func (vb *VB) SaveState() error {
 	if vb.EncryptionEnabled {
-		var zero [4]byte
-		if vb.VolumeUUID == zero {
-			if _, err := rand.Read(vb.VolumeUUID[:]); err != nil {
-				return fmt.Errorf("SaveState: mint VolumeUUID: %w", err)
-			}
+		minted, err := vb.mintVolumeUUID()
+		if err != nil {
+			return fmt.Errorf("SaveState: %w", err)
+		}
+		if minted {
 			vb.seqNumHighWater.Store(seqNumReservation)
 		}
 	}
 	return vb.saveStateWithHighWater(vb.seqNumHighWater.Load())
+}
+
+// mintVolumeUUID seeds the per-volume nonce subspace via crypto/rand when it is
+// still zero, returning true if it minted. VolumeUUID seeds every chunk/WAL
+// AES-GCM nonce, so it must be non-zero before any block is sealed; minting it
+// lazily and persisting a different value later makes read-back reconstruct a
+// divergent nonce and fail tag verify. Callers persist the result durably in
+// the same critical section. No-op (false) once VolumeUUID is set.
+func (vb *VB) mintVolumeUUID() (bool, error) {
+	var zero [4]byte
+	if vb.VolumeUUID != zero {
+		return false, nil
+	}
+	if _, err := rand.Read(vb.VolumeUUID[:]); err != nil {
+		return false, fmt.Errorf("mint VolumeUUID: %w", err)
+	}
+	return true, nil
 }
 
 // saveStateWithHighWater persists VBState with an explicit SeqNumHighWater
@@ -3119,6 +3136,17 @@ func (vb *VB) reserveSeqNum(n uint64) (start uint64, err error) {
 	if end <= hw {
 		vb.seqNumHighWaterMu.Unlock()
 		return start, nil
+	}
+	// Mint the per-volume nonce subspace before the first durable persist or
+	// seal. The first encrypted write always reaches here (seqNumHighWater
+	// starts at zero), so minting under this mutex guarantees VolumeUUID is
+	// non-zero and persisted by persistStateLocal below before any block is
+	// sealed under it. Without this, freshly-seeded volumes (EFI varstore, raw
+	// imports) seal chunk 0 under the zero UUID while a later SaveState mints a
+	// random one, breaking read-back with a tag-verify failure.
+	if _, err := vb.mintVolumeUUID(); err != nil {
+		vb.seqNumHighWaterMu.Unlock()
+		return 0, fmt.Errorf("reserveSeqNum: %w", err)
 	}
 	for end > hw {
 		hw += seqNumReservation


### PR DESCRIPTION
## Summary

Three at-rest-encryption seal/open correctness fixes uncovered while bringing
encrypted volume launch + lifecycle green in spinifex E2E. Each fixes a distinct
AES-GCM nonce / VolumeUUID / StateSeqNum hazard. Pairs with spinifex PR #361.

## Changes

- **Seal encrypted AMI snapshot under minted VolumeUUID** (`1044c2a`):
  `CreateSnapshot` recorded `SourceVolumeUUID` before `SaveState` minted it but
  sealed the meta nonce after; `ImportDiskImage` snapshots without a prior
  `SaveState`, so `VolumeUUID=0000` was recorded while the seal used the minted
  random UUID → open reconstructed the nonce from `0000` → `cipher: message
  authentication failed` on every encrypted AMI launch.
- **Mint VolumeUUID before first seal on fresh encrypted volumes** (`bf7c9bd`):
  `reserveSeqNum` now mints the per-volume nonce subspace before the first
  durable persist/seal (EFI varstore / raw imports reach the seal before any
  `SaveState`), clearing the EFI pflash `integrity check failed: chunk 0 block 0`.
- **Restore snapshot link before encrypted persist in LoadState** (`b09d25e`):
  reordered `LoadState` so `OpenFromSnapshot` runs before
  `bumpSeqNumHighWater` (which durably persists VBState) — otherwise the
  snapshot link was persisted empty → all-zeros boot disk / UEFI shell.

## Testing

- `make preflight` green (tests, race, vet, lint).
- Regression tests: `TestReserveSeqNum_MintsVolumeUUIDBeforeFirstSeal`,
  `TestSnapshotEncrypted_ReopenPreservesSnapshotLink` (both proven to fail
  pre-fix).
- E2E (via spinifex): encrypted guests boot both single + multi-node; confirmed
  CI run 27537503220 (0/33 UEFI-shell, was 33/33 bricked).