### PR TITLE
fix: create per-volume dir on atomic state write for remount

### DIFF
--- a/viperblock/encryption_test.go
+++ b/viperblock/encryption_test.go
@@ -130,6 +130,20 @@ func TestWriteFileAtomic_RoundTrip(t *testing.T) {
 	assert.True(t, errors.Is(err, os.ErrNotExist), "tmp file should not remain after rename")
 }
 
+// A remount on a node that never held the volume locally has no per-volume
+// dir; LoadState pulls backend state then persists it, so writeFileAtomic must
+// create the missing parent rather than fail opening the tmp file with ENOENT.
+func TestWriteFileAtomic_CreatesMissingParentDir(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "vol-remount", "config.json")
+	payload := []byte("state from backend")
+
+	require.NoError(t, writeFileAtomic(path, payload, 0600))
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, payload, got)
+}
+
 func TestSaveState_BootstrapsVolumeUUIDAndHighWater(t *testing.T) {
 	key := testKey(t, 0x42)
 	vb := newFileBackedVB(t, "vol-bootstrap", key)
@@ -284,11 +298,12 @@ func TestReserveSeqNum_FailedSaveStateDoesNotPublishHighWater(t *testing.T) {
 
 	hwBefore := vb.seqNumHighWater.Load()
 
-	// Wedge both writeFileAtomic (local) and Backend.Write (file backend) by
-	// removing the directory both target. The next SaveState's tmp-file
-	// OpenFile fails immediately.
+	// Wedge writeFileAtomic by parking a directory at the tmp path: the next
+	// SaveState's OpenFile(O_CREATE|O_WRONLY) fails with EISDIR. Removing the
+	// per-volume dir no longer wedges since writeFileAtomic recreates it.
 	configDir := filepath.Join(vb.BaseDir, vb.GetVolume())
-	require.NoError(t, os.RemoveAll(configDir))
+	tmpPath := filepath.Join(configDir, "config.json.tmp")
+	require.NoError(t, os.MkdirAll(tmpPath, 0700))
 
 	vb.SeqNum.Store(hwBefore + 5)
 	_, err := vb.reserveSeqNum(1)
@@ -299,7 +314,7 @@ func TestReserveSeqNum_FailedSaveStateDoesNotPublishHighWater(t *testing.T) {
 
 	// And after the failure is cleared, a successor reservation must persist
 	// and publish the same target hw — no skipped window, no double-count.
-	require.NoError(t, os.MkdirAll(configDir, 0700))
+	require.NoError(t, os.RemoveAll(tmpPath))
 	_, err = vb.reserveSeqNum(1)
 	require.NoError(t, err)
 	assert.Greater(t, vb.seqNumHighWater.Load(), hwBefore,

--- a/viperblock/viperblock.go
+++ b/viperblock/viperblock.go
@@ -2931,8 +2931,15 @@ func (vb *VB) pushStateToBackend(persisted []byte) error {
 // fsync(parent). On return without error, the file exists at path with the
 // new contents fully durable on disk. A crash before return may leave a
 // stale path.tmp behind (caller-tolerable: next SaveState rewrites it).
+//
+// The parent dir is created if absent so a remount on a node that never held
+// the volume locally (LoadState pulls authoritative state from the backend,
+// then persists it locally) does not fail opening the tmp file with ENOENT.
 func writeFileAtomic(path string, data []byte, perm os.FileMode) error {
 	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0750); err != nil {
+		return err
+	}
 	tmp := path + ".tmp"
 	f, err := os.OpenFile(tmp, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, perm)
 	if err != nil {


### PR DESCRIPTION
## Problem

On a remount where the node never held the volume locally (stopped EKS worker restarted, CSI volumes), `vmMgr.Run` failed:

```
failed to mount volume: LoadState: reserve initial SeqNum window: SaveState: atomic write /var/lib/spinifex/viperblock//vol-XXXX/config.json: open .../config.json.tmp: no such file or directory
```

`LoadState` correctly pulls authoritative state from the backend (predastore/S3) when the local copy is absent, then the encrypted SeqNum bootstrap (`bumpSeqNumHighWater`) calls `SaveState`. `persistStateLocal` → `writeFileAtomic` opened the `.tmp` file in a per-volume dir that did not exist on this node, yielding ENOENT and wedging `StartStoppedInstance`.

## Fix

`writeFileAtomic` now `MkdirAll`s the parent dir (0750, matching repo convention) before opening the tmp file, honouring its own contract that the file exists at `path` on return regardless of caller. The double-slash in the path is harmless (POSIX collapses it).

## Tests

- New `TestWriteFileAtomic_CreatesMissingParentDir` — missing parent is created.
- `TestReserveSeqNum_FailedSaveStateDoesNotPublishHighWater` re-wedged via an un-openable tmp path (directory at `config.json.tmp` → EISDIR) since removing the dir no longer fails the write. The guarded security property (failed SaveState must not publish speculative high-water) is unchanged.
- `make preflight` passes (race + lint + cover).

## Out of scope

The bead also notes a cross-node start forwarding to `lastNode` with `nats: timeout`; that is spinifex-side forwarding logic, tracked separately.