### PR TITLE
chore: remove bead and plan-doc references from code comments

### DIFF
--- a/viperblock/backends/s3/s3_test.go
+++ b/viperblock/backends/s3/s3_test.go
@@ -17,7 +17,7 @@ import (
 
 // TestWrapNotFound pins the AWS-error → os.ErrNotExist mapping that callers
 // (e.g. viperblock.LoadState) rely on to tell "object missing" apart from
-// "backend unreachable". Required by mulga-siv-25 medium-term fix.
+// "backend unreachable". Required by the medium-term fix.
 func TestWrapNotFound(t *testing.T) {
 	cases := []struct {
 		name         string

--- a/viperblock/viperblock_test.go
+++ b/viperblock/viperblock_test.go
@@ -2424,7 +2424,7 @@ func TestVolumeConfig_ModificationJSONRoundTrip(t *testing.T) {
 }
 
 // TestClassifyStateLoad pins the local/backend error → sentinel mapping for
-// recovery callers (mulga-siv-25). The classification decides whether the
+// recovery callers. The classification decides whether the
 // caller should retry (transient backend) or fail (genuine missing state).
 func TestClassifyStateLoad(t *testing.T) {
 	transient := fmt.Errorf("connection refused: tls handshake timeout")

--- a/viperblock/writebench/writebench_test.go
+++ b/viperblock/writebench/writebench_test.go
@@ -1,8 +1,6 @@
 // Package writebench drives the REAL viperblock write/flush path (file
 // backend, legacy single-file WAL) to quantify heavy-write latency and the
-// flush-path memory growth described in
-// docs/development/bugs/nbd-write-latency-and-flush-oom.md, and to compare the
-// proposed fixes:
+// flush-path memory growth, and to compare the proposed fixes:
 //
 //	#1 demote hot-path INFO logging to Debug
 //	#2 move chunk consolidation/upload off the guest-fsync path (async drain)


### PR DESCRIPTION
Strip mulga-* bead IDs and a docs/development plan-doc path from Go source comments. Comment text only; no logic changed.

## Summary

<!-- What does this PR do, and why? -->

## Changes

<!-- The notable changes, as bullets. -->
