### PR TITLE
fix(viperblock): close seqNum/checkpoint ordering window and add goroutine lifecycle tests

### DIFF
--- a/viperblock/encryption_snapshot_test.go
+++ b/viperblock/encryption_snapshot_test.go
@@ -382,3 +382,57 @@ func TestSnapshotEncrypted_CloneWriteUsesCloneIdentity(t *testing.T) {
 	assert.True(t, bytes.Equal(srcData, got),
 		"clone read of source-snapshot block must still decrypt under source identity")
 }
+
+// TestEncryptedChunk_LiveCheckpointSeqNumConsistency gates the ordering fix in
+// createChunkFile (mulga-be2ev): after a chunk is sealed, SaveLiveCheckpoint is
+// called immediately so the recorded BlockLookup.SeqNum matches the seal-time
+// SeqNum. A stale SeqNum causes the nonce reconstructed on ReadAt to diverge
+// from the seal nonce, making AES-GCM tag verification fail with ErrIntegrity.
+//
+// This mirrors the crash/remount scenario: a VB drains to a chunk, then a
+// "remounted" VB loads the live checkpoint and reads the same blocks back via
+// the backend. If the checkpoint SeqNum is stale (pre-fix: 30s async timer;
+// runtime: leaked goroutine overwriting with clone-point data), ReadAt fails.
+func TestEncryptedChunk_LiveCheckpointSeqNumConsistency(t *testing.T) {
+	dir := t.TempDir()
+	key := testKey(t, 0x77)
+
+	// Writer: seal blocks into a chunk. Our fix has createChunkFile call
+	// SaveLiveCheckpoint immediately after updating BlockLookup.
+	writer := openEncryptedVBInDir(t, dir, "seqnum-consistency", key)
+	defer writer.StopChunkUploader()
+
+	data := make([]byte, writer.BlockSize*4)
+	_, err := rand.Read(data)
+	require.NoError(t, err)
+	require.NoError(t, writer.Write(0, data))
+	require.NoError(t, writer.Flush())
+	// WriteWALToChunk → createChunkFile → SaveLiveCheckpoint (ordering fix).
+	require.NoError(t, writer.WriteWALToChunk(true))
+
+	// Remount: fresh VB over the same backend loading only from the live
+	// checkpoint — no in-memory write buffer. This is what happens on remount
+	// after a crash or after a leaked goroutine overwrites the checkpoint.
+	remounted := newCloneReopen(t, dir, "seqnum-consistency", key)
+	require.NoError(t, remounted.LoadState())
+	require.NoError(t, remounted.LoadLiveCheckpoint())
+
+	// Every BlockLookup entry in the live checkpoint must carry the exact
+	// SeqNum that was used to seal the corresponding chunk ciphertext.
+	writer.BlocksToObject.mu.RLock()
+	defer writer.BlocksToObject.mu.RUnlock()
+	for blockNum, want := range writer.BlocksToObject.BlockLookup {
+		got, ok := remounted.BlocksToObject.BlockLookup[blockNum]
+		require.True(t, ok, "block %d missing from live checkpoint after createChunkFile", blockNum)
+		assert.Equal(t, want.SeqNum, got.SeqNum,
+			"block %d: live checkpoint SeqNum must match seal-time SeqNum (AEAD nonce component)", blockNum)
+	}
+
+	// ReadAt on the remounted VB must decrypt using the checkpoint SeqNum.
+	// Pre-fix, a stale SeqNum here returns ErrIntegrity (cipher: message
+	// authentication failed) — the exact error logged by nbdkit on env19.
+	got, err := remounted.ReadAt(0, uint64(remounted.BlockSize))
+	require.NoError(t, err, "ReadAt on remounted encrypted VB must not fail with AEAD auth error")
+	assert.True(t, bytes.Equal(data[:remounted.BlockSize], got),
+		"remounted read must decrypt to original plaintext")
+}

--- a/viperblock/goroutine_lifecycle_test.go
+++ b/viperblock/goroutine_lifecycle_test.go
@@ -1,0 +1,60 @@
+// Tests for the chunk-uploader and WAL-syncer goroutine lifecycle, covering
+// the fix for the goroutine leak (mulga-0zzci): spinifex creates short-lived
+// VBs that must stop background goroutines without calling Close().
+
+package viperblock
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestChunkUploaderStopWithoutClose verifies the cleanup pattern used in
+// spinifex for short-lived VBs: calling StopChunkUploader + StopWALSyncer
+// without Close(). Stop must complete (goroutine exits via done channel) and
+// be safe to call a second time (matches the defer-then-explicit-stop pattern).
+func TestChunkUploaderStopWithoutClose(t *testing.T) {
+	dir := t.TempDir()
+	vb := openEncryptedVBInDir(t, dir, "goroutine-lifecycle", nil)
+
+	// Chunk uploader is started unconditionally by New(); the stop channel
+	// must be non-nil before we stop it.
+	require.NotNil(t, vb.chunkUploadStop, "chunk uploader must be running after New()")
+
+	// Stop without Close — this is the spinifex pattern for short-lived VBs
+	// (prepareRootVolume, snapshotVolume, CreateVolume, etc.). Each Stop call
+	// waits on its done channel, so when it returns the goroutine has exited.
+	vb.StopChunkUploader()
+	vb.StopWALSyncer()
+
+	assert.Nil(t, vb.chunkUploadStop, "chunkUploadStop must be nil after Stop (goroutine exited)")
+	assert.Nil(t, vb.chunkUploadDone, "chunkUploadDone must be nil after Stop")
+
+	// Second call must not panic or deadlock — matches the defer + explicit
+	// stop pattern where both may fire for the same VB.
+	assert.NotPanics(t, func() {
+		vb.StopChunkUploader()
+		vb.StopWALSyncer()
+	}, "double-Stop must be idempotent")
+}
+
+// TestChunkUploaderStopEncrypted runs the same lifecycle check for an encrypted
+// VB, since encrypted VBs go through the same uploader path.
+func TestChunkUploaderStopEncrypted(t *testing.T) {
+	dir := t.TempDir()
+	key := testKey(t, 0x33)
+	vb := openEncryptedVBInDir(t, dir, "goroutine-lifecycle-enc", key)
+
+	require.NotNil(t, vb.chunkUploadStop, "chunk uploader must be running for encrypted VB")
+
+	vb.StopChunkUploader()
+	vb.StopWALSyncer()
+
+	assert.Nil(t, vb.chunkUploadStop, "chunkUploadStop must be nil after Stop")
+	assert.NotPanics(t, func() {
+		vb.StopChunkUploader()
+		vb.StopWALSyncer()
+	}, "double-Stop must be idempotent for encrypted VB")
+}

--- a/viperblock/viperblock.go
+++ b/viperblock/viperblock.go
@@ -2285,11 +2285,6 @@ func (vb *VB) createChunkFile(currentWALNum uint64, chunkIndex uint64, chunkBuff
 
 	headerLen := len(headers)
 
-	// Loop through the chunk buffer, and write each block to the file
-	i := 0
-
-	BlockObjectsToWAL := make([]BlockLookup, 0, len(*matchedBlocks))
-
 	// Per-block on-disk stride: encrypted chunks add a 16-byte GCM tag after
 	// each ciphertext block; unencrypted chunks stay at BlockSize.
 	stride := int(vb.BlockSize)
@@ -2313,31 +2308,30 @@ func (vb *VB) createChunkFile(currentWALNum uint64, chunkIndex uint64, chunkBuff
 			StartBlock:   block.Block,
 			NumBlocks:    utils.SafeIntToUint16(numBlocks),
 			ObjectID:     chunkIndex,
-			ObjectOffset: utils.SafeIntToUint32(headerLen + (i * stride)),
+			ObjectOffset: utils.SafeIntToUint32(headerLen + (k * stride)),
 			SeqNum:       block.SeqNum,
 		}
 
 		// TODO: Optimise for number of consecutive blocks to reduce the memory size
 		vb.BlocksToObject.BlockLookup[block.Block] = newBlock
 
-		//slog.Info("Added block to BlockLookup", "block", block.Block, "newBlock", newBlock)
-
-		BlockObjectsToWAL = append(BlockObjectsToWAL, newBlock)
-
 		// Update BlockStore: transition from Pending to Persisted
 		if vb.UseBlockStore && vb.BlockStore != nil {
 			vb.BlockStore.MarkPersisted(block.Block, chunkIndex, newBlock.ObjectOffset)
 		}
-
-		i++
 	}
 
 	vb.BlocksToObject.mu.Unlock()
 
-	// Lastly, write the Block objects to it's own WAL for redundancy and checkpointing.
-	err = vb.WriteBlockWAL(&BlockObjectsToWAL)
-	if err != nil {
-		return err
+	// Flush the updated block→chunk mapping to S3 immediately after each chunk
+	// upload so the live checkpoint stays consistent with what is in S3. This
+	// shrinks the window in which a crash can leave the checkpoint pointing at a
+	// stale seqNum relative to the just-uploaded chunk ciphertext (the remaining
+	// window is the gap between Backend.Write and this call, not the full 30s
+	// background-uploader interval). Non-fatal: DrainToBackend will retry at the
+	// end of the current cycle regardless.
+	if cpErr := vb.SaveLiveCheckpoint(); cpErr != nil {
+		slog.Warn("createChunkFile: SaveLiveCheckpoint failed", "err", cpErr)
 	}
 
 	// Increment the object number


### PR DESCRIPTION
## Summary

- **`createChunkFile`**: removed dead `BlockObjectsToWAL` accumulator and no-op `WriteBlockWAL` call; added `SaveLiveCheckpoint()` immediately after each `BlockLookup` update, shrinking the crash window between chunk seal and checkpoint write from 30s (async timer) to microseconds. This closes the seqNum/checkpoint durability inversion that caused `cipher: message authentication failed` on RMW reads of cloned/snapshot volumes (mulga-be2ev).
- **Tests**: `TestChunkUploaderStopWithoutClose` and `TestChunkUploaderStopEncrypted` verify the `StopChunkUploader`+`StopWALSyncer`-without-`Close()` pattern is idempotent and leaves no running goroutines. `TestEncryptedChunk_LiveCheckpointSeqNumConsistency` verifies the seal-time `SeqNum` is preserved in the live checkpoint after `createChunkFile`, so a remounted VB can `ReadAt` without AEAD failure.

Fixes: mulga-be2ev (primary runtime cause fixed in spinifex PR; this closes the theoretical crash window)
Companion PR: spinifex fix/viperblock-regressions

## Test plan

- [x] `make preflight` passes (lint, govulncheck, tests, race detector)
- [x] `TestChunkUploaderStopWithoutClose` / `TestChunkUploaderStopEncrypted` — goroutine lifecycle
- [x] `TestEncryptedChunk_LiveCheckpointSeqNumConsistency` — AEAD ordering gate
- [x] Runtime: 141 MB of 512-byte random writes to AMI-cloned root disk over 10+ chunk drain cycles, zero AEAD auth failures in nbdkit/viperblockd