### PR TITLE
fix(telemetry): make backend.io a namespace + ES|QL-queryable duration sums

### DIFF
--- a/telemetry/metrics.go
+++ b/telemetry/metrics.go
@@ -17,12 +17,12 @@ const meterName = "github.com/mulgadc/viperblock/telemetry"
 var (
 	instrumentsOnce sync.Once
 
-	backendIOCount    metric.Int64Counter
-	backendIOBytes    metric.Int64Counter
-	backendIODuration metric.Float64Histogram
+	backendIOOps         metric.Int64Counter
+	backendIOBytes       metric.Int64Counter
+	backendIODurationSum metric.Float64Counter
 
-	walOpCount    metric.Int64Counter
-	walOpDuration metric.Float64Histogram
+	walOpCount       metric.Int64Counter
+	walOpDurationSum metric.Float64Counter
 
 	cacheLookups metric.Int64Counter
 
@@ -41,7 +41,11 @@ func instruments() {
 		m := otel.Meter(meterName)
 		var err error
 
-		backendIOCount, err = m.Int64Counter("viperblock.backend.io",
+		// "io" is a namespace (ops/bytes/duration.sum siblings), not a leaf,
+		// to avoid an ES leaf-vs-object mapping collision. Durations are
+		// recorded as seconds-sum counters (not histograms) so avg latency
+		// = sum/ops is computable in ES|QL; native ES histograms aren't.
+		backendIOOps, err = m.Int64Counter("viperblock.backend.io.ops",
 			metric.WithDescription("Count of block-storage backend read/write operations."),
 			metric.WithUnit("{operation}"))
 		if err != nil {
@@ -53,8 +57,8 @@ func instruments() {
 		if err != nil {
 			otel.Handle(err)
 		}
-		backendIODuration, err = m.Float64Histogram("viperblock.backend.io.duration",
-			metric.WithDescription("Duration of block-storage backend read/write operations."),
+		backendIODurationSum, err = m.Float64Counter("viperblock.backend.io.duration.sum",
+			metric.WithDescription("Cumulative seconds spent in block-storage backend read/write operations."),
 			metric.WithUnit("s"))
 		if err != nil {
 			otel.Handle(err)
@@ -66,8 +70,8 @@ func instruments() {
 		if err != nil {
 			otel.Handle(err)
 		}
-		walOpDuration, err = m.Float64Histogram("viperblock.wal.operation.duration",
-			metric.WithDescription("Duration of WAL flush/replay/consolidate operations."),
+		walOpDurationSum, err = m.Float64Counter("viperblock.wal.operation.duration.sum",
+			metric.WithDescription("Cumulative seconds spent in WAL flush/replay/consolidate operations."),
 			metric.WithUnit("s"))
 		if err != nil {
 			otel.Handle(err)
@@ -85,10 +89,10 @@ func instruments() {
 	})
 }
 
-// RecordBackendIO records one backend chunk-object read or write: IOPS,
-// bytes transferred, and latency. op is "read"/"write", backendType is
-// "s3"/"file", outcome is "success"/"error". volume is omitted from
-// attributes when empty.
+// RecordBackendIO records one backend chunk-object read or write: op count,
+// bytes transferred, and cumulative duration (as duration.sum, added to on
+// every call). op is "read"/"write", backendType is "s3"/"file", outcome is
+// "success"/"error". volume is omitted from attributes when empty.
 func RecordBackendIO(ctx context.Context, op, backendType, volume, outcome string, bytesTransferred int, elapsed time.Duration) {
 	instruments()
 	attrs := []attribute.KeyValue{
@@ -101,18 +105,19 @@ func RecordBackendIO(ctx context.Context, op, backendType, volume, outcome strin
 	}
 	opt := metric.WithAttributeSet(attribute.NewSet(attrs...))
 
-	if backendIOCount != nil {
-		backendIOCount.Add(ctx, 1, opt)
+	if backendIOOps != nil {
+		backendIOOps.Add(ctx, 1, opt)
 	}
 	if backendIOBytes != nil && bytesTransferred > 0 {
 		backendIOBytes.Add(ctx, int64(bytesTransferred), opt)
 	}
-	if backendIODuration != nil {
-		backendIODuration.Record(ctx, elapsed.Seconds(), opt)
+	if backendIODurationSum != nil {
+		backendIODurationSum.Add(ctx, elapsed.Seconds(), opt)
 	}
 }
 
-// RecordWALOp records one WAL lifecycle operation. phase is
+// RecordWALOp records one WAL lifecycle operation: op count and cumulative
+// duration (as duration.sum, added to on every call). phase is
 // "flush"/"replay"/"consolidate", outcome is "success"/"error".
 func RecordWALOp(ctx context.Context, phase, volume, outcome string, elapsed time.Duration) {
 	instruments()
@@ -128,8 +133,8 @@ func RecordWALOp(ctx context.Context, phase, volume, outcome string, elapsed tim
 	if walOpCount != nil {
 		walOpCount.Add(ctx, 1, opt)
 	}
-	if walOpDuration != nil {
-		walOpDuration.Record(ctx, elapsed.Seconds(), opt)
+	if walOpDurationSum != nil {
+		walOpDurationSum.Add(ctx, elapsed.Seconds(), opt)
 	}
 }
 

--- a/telemetry/metrics_test.go
+++ b/telemetry/metrics_test.go
@@ -67,12 +67,12 @@ func TestRecordBackendIOEmitsCounterBytesAndDuration(t *testing.T) {
 	}
 	metrics := collectMetrics(t, rm)
 
-	sum, ok := metrics["viperblock.backend.io"].(metricdata.Sum[int64])
+	sum, ok := metrics["viperblock.backend.io.ops"].(metricdata.Sum[int64])
 	if !ok || len(sum.DataPoints) != 1 {
-		t.Fatalf("viperblock.backend.io = %#v, want one int64 sum point", metrics["viperblock.backend.io"])
+		t.Fatalf("viperblock.backend.io.ops = %#v, want one int64 sum point", metrics["viperblock.backend.io.ops"])
 	}
 	if sum.DataPoints[0].Value != 1 {
-		t.Errorf("io count = %d, want 1", sum.DataPoints[0].Value)
+		t.Errorf("io ops = %d, want 1", sum.DataPoints[0].Value)
 	}
 
 	bytesSum, ok := metrics["viperblock.backend.io.bytes"].(metricdata.Sum[int64])
@@ -80,9 +80,9 @@ func TestRecordBackendIOEmitsCounterBytesAndDuration(t *testing.T) {
 		t.Fatalf("viperblock.backend.io.bytes = %#v, want 4096", metrics["viperblock.backend.io.bytes"])
 	}
 
-	hist, ok := metrics["viperblock.backend.io.duration"].(metricdata.Histogram[float64])
-	if !ok || len(hist.DataPoints) != 1 || hist.DataPoints[0].Count != 1 {
-		t.Fatalf("viperblock.backend.io.duration = %#v, want one histogram point with count 1", metrics["viperblock.backend.io.duration"])
+	durSum, ok := metrics["viperblock.backend.io.duration.sum"].(metricdata.Sum[float64])
+	if !ok || len(durSum.DataPoints) != 1 || durSum.DataPoints[0].Value <= 0 {
+		t.Fatalf("viperblock.backend.io.duration.sum = %#v, want one float64 sum point > 0", metrics["viperblock.backend.io.duration.sum"])
 	}
 
 	attrs := sum.DataPoints[0].Attributes
@@ -107,9 +107,9 @@ func TestRecordBackendIOZeroBytesAndEmptyVolume(t *testing.T) {
 		t.Errorf("expected no bytes data points recorded for a zero-byte op, got %d", len(bytesSum.DataPoints))
 	}
 
-	sum, ok := metrics["viperblock.backend.io"].(metricdata.Sum[int64])
+	sum, ok := metrics["viperblock.backend.io.ops"].(metricdata.Sum[int64])
 	if !ok || len(sum.DataPoints) != 1 {
-		t.Fatalf("viperblock.backend.io = %#v, want one int64 sum point", metrics["viperblock.backend.io"])
+		t.Fatalf("viperblock.backend.io.ops = %#v, want one int64 sum point", metrics["viperblock.backend.io.ops"])
 	}
 	wantAttr(t, sum.DataPoints[0].Attributes, "outcome", "error")
 	if _, ok := sum.DataPoints[0].Attributes.Value(attribute.Key("volume.name")); ok {
@@ -135,9 +135,9 @@ func TestRecordWALOpEmitsCounterAndDuration(t *testing.T) {
 	wantAttr(t, sum.DataPoints[0].Attributes, "phase", "consolidate")
 	wantAttr(t, sum.DataPoints[0].Attributes, "volume.name", "vol-9")
 
-	hist, ok := metrics["viperblock.wal.operation.duration"].(metricdata.Histogram[float64])
-	if !ok || len(hist.DataPoints) != 1 {
-		t.Fatalf("viperblock.wal.operation.duration = %#v, want one point", metrics["viperblock.wal.operation.duration"])
+	durSum, ok := metrics["viperblock.wal.operation.duration.sum"].(metricdata.Sum[float64])
+	if !ok || len(durSum.DataPoints) != 1 || durSum.DataPoints[0].Value <= 0 {
+		t.Fatalf("viperblock.wal.operation.duration.sum = %#v, want one float64 sum point > 0", metrics["viperblock.wal.operation.duration.sum"])
 	}
 }
 


### PR DESCRIPTION
## Summary
- `viperblock.backend.io` renamed to `viperblock.backend.io.ops` so `io` is a namespace (ops/bytes/duration.sum siblings) instead of a scalar leaf that collided with its own children in Elasticsearch's dynamic mapping, causing `.bytes`/`.duration` to be silently dropped.
- `viperblock.backend.io.duration` (Float64Histogram) replaced with `viperblock.backend.io.duration.sum` (Float64Counter, seconds), and `viperblock.wal.operation.duration` (Float64Histogram) replaced with `viperblock.wal.operation.duration.sum` (Float64Counter, seconds). Native ES `histogram` fields aren't ES|QL-aggregatable; a seconds-sum counter lets average latency be computed as `sum/ops` in ES|QL.
- Public `RecordBackendIO`/`RecordWALOp`/`RecordCacheLookup` signatures are unchanged; only internal instrument definitions and the `.Record(...)` → `.Add(...)` calls changed.

## Test plan
- [x] `GOWORK=off make preflight` passes (lint, govulncheck, tests, race tests; diff coverage skipped — only 26 changed lines, below the 100-line threshold)
- [x] `telemetry/metrics_test.go` updated to assert the new instrument names/types (`Sum[int64]` for `.ops`, `Sum[float64]` for `.duration.sum`)
- [x] Confirmed `viperblock/backends/{s3,file}` and `viperblock/viperblock.go` call sites compile unchanged (signature-only callers)