### PR TITLE
fix(viperblock): bound guest-write buffer memory with backpressure

### DIFF
--- a/nbd/viperblock.go
+++ b/nbd/viperblock.go
@@ -67,6 +67,7 @@ var secret_key string
 var host string
 var base_dir string
 var cache_size int = 20
+var max_pending_bytes uint64 = 0
 var use_shardwal bool = false
 var encryption_key_file string
 
@@ -122,6 +123,13 @@ func (p *ViperBlockPlugin) Config(key string, value string) error {
 	} else if key == "cache_size" {
 		var err error
 		cache_size, err = strconv.Atoi(value)
+		if err != nil {
+			return err
+		}
+		return nil
+	} else if key == "max_pending_bytes" {
+		var err error
+		max_pending_bytes, err = strconv.ParseUint(value, 0, 64)
 		if err != nil {
 			return err
 		}
@@ -213,6 +221,7 @@ func (p *ViperBlockPlugin) Open(readonly bool) (nbdkit.ConnectionInterface, erro
 				Size: cache_size,
 			},
 		},
+		MaxPendingBytes:   max_pending_bytes,
 		MasterKey:         loadedMasterKey,
 		EncryptionEnabled: loadedMasterKey != nil,
 	}

--- a/viperblock/backpressure_test.go
+++ b/viperblock/backpressure_test.go
@@ -1,0 +1,210 @@
+package viperblock
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/mulgadc/viperblock/types"
+	"github.com/mulgadc/viperblock/viperblock/backends/file"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// slowBackend wraps a real types.Backend and adds artificial latency to every
+// write, standing in for a backend (e.g. S3/predastore over the network)
+// that can't keep up with a fast local guest write. Everything else proxies
+// straight through via the embedded interface.
+type slowBackend struct {
+	types.Backend
+
+	delay time.Duration
+}
+
+func (s *slowBackend) Write(fileType types.FileType, objectId uint64, headers *[]byte, data *[]byte) error {
+	time.Sleep(s.delay)
+	return s.Backend.Write(fileType, objectId, headers, data)
+}
+
+func (s *slowBackend) WriteCtx(ctx context.Context, fileType types.FileType, objectId uint64, headers *[]byte, data *[]byte) error {
+	time.Sleep(s.delay)
+	return s.Backend.WriteCtx(ctx, fileType, objectId, headers, data)
+}
+
+// newBackpressureTestVB builds a minimal file-backed VB (legacy single-file
+// WAL, no LRU cache, periodic syncers disabled for deterministic behavior)
+// and swaps in a slowBackend so drains take drainDelay per backend write.
+func newBackpressureTestVB(t *testing.T, maxPendingBytes uint64, drainDelay time.Duration) *VB {
+	t.Helper()
+
+	tmpDir := os.TempDir()
+	testVol := fmt.Sprintf("test_backpressure_%d", time.Now().UnixNano())
+
+	backendConfig := file.FileConfig{
+		VolumeName: testVol,
+		VolumeSize: 64 * 1024 * 1024,
+		BaseDir:    tmpDir,
+	}
+
+	vbconfig := VB{
+		VolumeName: testVol,
+		VolumeSize: 64 * 1024 * 1024,
+		BaseDir:    fmt.Sprintf("%s/%s", tmpDir, "viperblock"),
+		// Deterministic: no background WAL fsync or ticker-driven chunk
+		// upload racing the test; the backpressure gate itself is what we're
+		// exercising.
+		WALSyncInterval:     -1,
+		ChunkUploadInterval: -1,
+		MaxPendingBytes:     maxPendingBytes,
+		Cache: Cache{
+			Config: CacheConfig{Size: 0},
+		},
+	}
+
+	vb, err := New(&vbconfig, FileBackend, backendConfig)
+	require.NoError(t, err)
+	require.NotNil(t, vb)
+
+	vb.UseShardedWAL = false
+	vb.ShardedWAL = nil
+
+	require.NoError(t, vb.Backend.Init())
+	vb.Backend = &slowBackend{Backend: vb.Backend, delay: drainDelay}
+
+	require.NoError(t, vb.OpenWAL(&vb.WAL, fmt.Sprintf("%s/%s", vb.WAL.BaseDir, types.GetFilePath(types.FileTypeWALChunk, vb.WAL.WallNum.Load(), vb.GetVolume()))))
+	require.NoError(t, vb.OpenWAL(&vb.BlockToObjectWAL, fmt.Sprintf("%s/%s", vb.BlockToObjectWAL.BaseDir, types.GetFilePath(types.FileTypeWALBlock, vb.BlockToObjectWAL.WallNum.Load(), vb.GetVolume()))))
+
+	t.Cleanup(func() {
+		_ = vb.RemoveLocalFiles()
+	})
+
+	return vb
+}
+
+// TestWriteAtBackpressureBoundsPendingBytes drives many WriteAt calls, single
+// threaded and back to back (i.e. faster than the artificially slowed backend
+// drain), and asserts that outstanding buffered bytes (Writes.Blocks +
+// PendingBackendWrites.Blocks) stay bounded near MaxPendingBytes instead of
+// growing to the full amount written — the core guest-write-balloons-memory
+// regression this backpressure gate fixes.
+func TestWriteAtBackpressureBoundsPendingBytes(t *testing.T) {
+	const maxPendingBytes = 256 * 1024 // 64 blocks @ 4KB
+	const numBlocks = 2000             // 2000 * 4KB ~= 8MB total written
+
+	vb := newBackpressureTestVB(t, maxPendingBytes, 15*time.Millisecond)
+
+	blockSize := uint64(vb.BlockSize)
+	totalWritten := uint64(numBlocks) * blockSize
+
+	var maxObserved atomic.Uint64
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		ticker := time.NewTicker(time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				if v := vb.PendingBytes(); v > maxObserved.Load() {
+					maxObserved.Store(v)
+				}
+			case <-stop:
+				return
+			}
+		}
+	}()
+
+	// Write each block with content identifying its block number, so we can
+	// verify no block was lost or reordered by the backpressure gate.
+	expected := make(map[uint64][]byte, numBlocks)
+	for i := range uint64(numBlocks) {
+		data := make([]byte, blockSize)
+		msg := fmt.Sprintf("block-%d-payload", i)
+		copy(data, msg)
+		expected[i] = data
+
+		err := vb.WriteAt(i*blockSize, data)
+		assert.NoError(t, err)
+	}
+
+	close(stop)
+	<-done
+
+	// Drain whatever remains under the watermark so a final readback can
+	// verify every block, including the tail that never crossed the gate.
+	require.NoError(t, vb.DrainToBackendCtx(context.Background()))
+
+	t.Logf("total written = %d bytes, max observed pending = %d bytes, MaxPendingBytes = %d",
+		totalWritten, maxObserved.Load(), maxPendingBytes)
+
+	// The gate must have actually engaged (buffer filled at least past the
+	// low watermark) — otherwise this test would trivially pass on a no-op
+	// implementation.
+	assert.Greater(t, maxObserved.Load(), uint64(maxPendingBytes/2),
+		"backpressure gate never appeared to engage; test is not exercising it")
+
+	// The real assertion: pending bytes stayed near MaxPendingBytes, not the
+	// full amount written. One in-flight WriteAt's worth of overshoot above
+	// the watermark is expected (the counter is bumped before the gate is
+	// checked), so allow a small margin.
+	assert.LessOrEqual(t, maxObserved.Load(), uint64(maxPendingBytes)+blockSize,
+		"outstanding buffered bytes exceeded MaxPendingBytes + one block; backpressure gate did not bound memory")
+	assert.Less(t, maxObserved.Load(), totalWritten/4,
+		"outstanding buffered bytes grew proportionally to total written; backpressure gate is not bounding memory")
+
+	assert.Equal(t, uint64(0), vb.PendingBytes(), "pending bytes should be fully drained after final DrainToBackendCtx")
+
+	// Correctness: every block must read back exactly what was written, in
+	// spite of being throttled through the gate.
+	for i := range uint64(numBlocks) {
+		got, err := vb.ReadAt(i*blockSize, blockSize)
+		if !assert.NoError(t, err, "block %d", i) {
+			continue
+		}
+		assert.Equal(t, expected[i], got, "block %d data mismatch", i)
+	}
+}
+
+// TestWriteAtBackpressureBlocksThenReleases directly measures that a single
+// WriteAt call which pushes pendingBytes over MaxPendingBytes blocks for
+// roughly the drain latency, and that pendingBytes drops back to the low
+// watermark (MaxPendingBytes/2) by the time the call returns.
+func TestWriteAtBackpressureBlocksThenReleases(t *testing.T) {
+	const maxPendingBytes = 64 * 1024 // 16 blocks @ 4KB
+	const drainDelay = 50 * time.Millisecond
+
+	vb := newBackpressureTestVB(t, maxPendingBytes, drainDelay)
+	blockSize := uint64(vb.BlockSize)
+
+	// Fill up to (but not past) the high watermark: these calls must not block.
+	fillBlocks := maxPendingBytes / blockSize
+	fillStart := time.Now()
+	for i := range fillBlocks {
+		data := make([]byte, blockSize)
+		err := vb.WriteAt(i*blockSize, data)
+		assert.NoError(t, err)
+	}
+	fillElapsed := time.Since(fillStart)
+	assert.Less(t, fillElapsed, drainDelay, "filling up to the watermark should not have blocked on a drain")
+	assert.Equal(t, uint64(maxPendingBytes), vb.PendingBytes(), "pending bytes should equal exactly what was written so far")
+
+	// This next write pushes pendingBytes past MaxPendingBytes and must block
+	// until a drain (paced by drainDelay) brings it back under the low
+	// watermark.
+	triggerStart := time.Now()
+	err := vb.WriteAt(fillBlocks*blockSize, make([]byte, blockSize))
+	triggerElapsed := time.Since(triggerStart)
+	assert.NoError(t, err)
+
+	assert.GreaterOrEqual(t, triggerElapsed, drainDelay,
+		"write crossing the high watermark should have blocked for at least one drain cycle")
+	assert.LessOrEqual(t, vb.PendingBytes(), uint64(maxPendingBytes/2),
+		"pending bytes should be at or below the low watermark once the blocking write returns")
+
+	require.NoError(t, vb.DrainToBackendCtx(context.Background()))
+	assert.Equal(t, uint64(0), vb.PendingBytes())
+}

--- a/viperblock/viperblock.go
+++ b/viperblock/viperblock.go
@@ -41,6 +41,13 @@ const DefaultFlushSize uint32 = 64 * 1024 * 1024
 const DefaultWALSyncInterval time.Duration = 200 * time.Millisecond
 const DefaultChunkUploadInterval time.Duration = 30 * time.Second
 
+// DefaultMaxPendingBytes bounds the combined size of Writes.Blocks and
+// PendingBackendWrites.Blocks — the guest-write backpressure high-watermark.
+// WriteAtCtx blocks the caller once this is crossed, draining synchronously
+// until back under MaxPendingBytes/2, so a sustained guest write self-throttles
+// to backend ingest rate instead of ballooning unbounded anonymous memory.
+const DefaultMaxPendingBytes uint64 = 256 * 1024 * 1024
+
 // seqNumReservation is the size of each SeqNum high-water reservation window.
 // reserveSeqNum hands out values lock-free via atomic.Add until the persisted
 // high-water is crossed; the slow path advances by seqNumReservation and
@@ -139,6 +146,34 @@ type VB struct {
 
 	// Pending writes to backend, when data flushed, WAL appended, and prior to backend upload completion (to avoid race conditions)
 	PendingBackendWrites Blocks
+
+	// MaxPendingBytes bounds outstanding buffered write bytes (Writes.Blocks +
+	// PendingBackendWrites.Blocks). 0 uses DefaultMaxPendingBytes. WriteAtCtx
+	// blocks once pendingBytes crosses this until a synchronous drain brings
+	// it back under MaxPendingBytes/2 — see awaitBackpressure.
+	MaxPendingBytes uint64
+
+	// pendingBytes tracks outstanding buffered write bytes across
+	// Writes.Blocks and PendingBackendWrites.Blocks. Incremented in
+	// WriteAtCtx when writes land in Writes.Blocks, decremented in
+	// createChunkFile when blocks are evicted from PendingBackendWrites
+	// after a successful chunk upload. Atomic and read without the
+	// Writes/PendingBackendWrites locks: an approximate watermark is fine,
+	// exact linearizability with the slices is not required.
+	pendingBytes atomic.Int64
+
+	// drainInFlight ensures at most one goroutine actively drives
+	// DrainToBackendCtx from inside awaitBackpressure at a time; concurrent
+	// blocked writers poll pendingBytes instead of each launching a
+	// redundant drain.
+	drainInFlight atomic.Bool
+
+	// chunkUploadTrigger lets WriteAtCtx ask the background chunk uploader
+	// to drain now instead of waiting for the next ChunkUploadInterval tick,
+	// once pendingBytes crosses FlushSize. Buffered 1: a pending trigger
+	// coalesces repeated sends. nil-safe to send on only after
+	// StartChunkUploader has run.
+	chunkUploadTrigger chan struct{}
 
 	// Periodically writes (Blocks) are flushed to the WAL log (default 5s, or when 64MB written, or OS flushes)
 	WAL WAL
@@ -637,6 +672,10 @@ func New(config *VB, btype string, backendConfig any) (vb *VB, err error) {
 		config.FlushSize = DefaultFlushSize
 	}
 
+	if config.MaxPendingBytes == 0 {
+		config.MaxPendingBytes = DefaultMaxPendingBytes
+	}
+
 	// WALSyncInterval: 0 means use default, negative means disabled
 	if config.WALSyncInterval == 0 {
 		config.WALSyncInterval = DefaultWALSyncInterval
@@ -684,6 +723,7 @@ func New(config *VB, btype string, backendConfig any) (vb *VB, err error) {
 		ObjBlockSize:        config.ObjBlockSize,
 		FlushInterval:       config.FlushInterval,
 		FlushSize:           config.FlushSize,
+		MaxPendingBytes:     config.MaxPendingBytes,
 		WALSyncInterval:     config.WALSyncInterval,
 		ChunkUploadInterval: config.ChunkUploadInterval,
 		Writes:              Blocks{},
@@ -711,6 +751,8 @@ func New(config *VB, btype string, backendConfig any) (vb *VB, err error) {
 
 		UseShardedWAL: false,
 		ShardedWAL:    NewShardedWAL(config.BaseDir, [4]byte{'V', 'B', 'W', 'L'}),
+
+		chunkUploadTrigger: make(chan struct{}, 1),
 
 		MasterKey:         config.MasterKey,
 		EncryptionEnabled: config.EncryptionEnabled,
@@ -867,6 +909,13 @@ func (vb *VB) StartChunkUploader() {
 			case <-vb.chunkUploadTicker.C:
 				if err := vb.DrainToBackendCtx(context.Background()); err != nil {
 					vb.logger().Warn("chunk uploader: DrainToBackend failed", "err", err)
+				}
+			case <-vb.chunkUploadTrigger:
+				// Size-triggered drain: pendingBytes crossed FlushSize in
+				// WriteAtCtx. Bounds steady-state memory to ~FlushSize
+				// without waiting on the ChunkUploadInterval ticker.
+				if err := vb.DrainToBackendCtx(context.Background()); err != nil {
+					vb.logger().Warn("chunk uploader: size-triggered DrainToBackend failed", "err", err)
 				}
 			case <-vb.chunkUploadStop:
 				return
@@ -1077,6 +1126,91 @@ func (vb *VB) WriteAt(offset uint64, data []byte) error {
 	return vb.WriteAtCtx(context.Background(), offset, data)
 }
 
+// PendingBytes returns the current outstanding buffered write bytes across
+// Writes.Blocks and PendingBackendWrites.Blocks — the counter the WriteAtCtx
+// backpressure gate watches.
+func (vb *VB) PendingBytes() uint64 {
+	return uint64(vb.pendingBytes.Load()) //nolint:gosec // G115: increments/decrements are matched byte counts, never negative
+}
+
+// maxPendingBytes returns the configured high-watermark, or the default if
+// unset (covers VB values assembled without going through New).
+func (vb *VB) maxPendingBytes() uint64 {
+	if vb.MaxPendingBytes == 0 {
+		return DefaultMaxPendingBytes
+	}
+	return vb.MaxPendingBytes
+}
+
+// signalSizeTrigger asks the background chunk uploader to drain now, once
+// pendingBytes crosses FlushSize, instead of waiting for the next
+// ChunkUploadInterval tick. Non-blocking: a trigger already pending
+// coalesces, and the synchronous gate in awaitBackpressure is the hard bound
+// if the uploader can't keep up.
+func (vb *VB) signalSizeTrigger() {
+	flushSize := vb.FlushSize
+	if flushSize == 0 {
+		flushSize = DefaultFlushSize
+	}
+	if vb.PendingBytes() < uint64(flushSize) {
+		return
+	}
+	select {
+	case vb.chunkUploadTrigger <- struct{}{}:
+	default:
+	}
+}
+
+// awaitBackpressure blocks the caller once pendingBytes has crossed
+// MaxPendingBytes, driving DrainToBackendCtx synchronously until pendingBytes
+// falls back under the low-watermark (MaxPendingBytes/2). This is the core
+// backpressure mechanism: a guest write that outruns the backend's ingest
+// rate self-throttles here instead of growing Writes.Blocks /
+// PendingBackendWrites.Blocks without bound.
+//
+// Called after WriteAtCtx has already released vb.Writes.mu, so the Flush()
+// invoked by DrainToBackendCtx (which takes that same lock) cannot deadlock
+// against us. drainInFlight ensures only one blocked writer actually drives
+// the drain at a time; the rest poll pendingBytes with a bounded backoff.
+func (vb *VB) awaitBackpressure(ctx context.Context) error {
+	high := vb.maxPendingBytes()
+	if vb.PendingBytes() <= high {
+		return nil
+	}
+
+	low := high / 2
+	backoff := 10 * time.Millisecond
+	const maxBackoff = 500 * time.Millisecond
+
+	for vb.PendingBytes() > low {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		if vb.drainInFlight.CompareAndSwap(false, true) {
+			err := vb.DrainToBackendCtx(ctx)
+			vb.drainInFlight.Store(false)
+			if err != nil {
+				vb.logger().Warn("write backpressure: drain failed, retrying", "err", err)
+			}
+			if vb.PendingBytes() <= low {
+				break
+			}
+		}
+
+		select {
+		case <-time.After(backoff):
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+		if backoff < maxBackoff {
+			backoff *= 2
+		}
+	}
+
+	return nil
+}
+
 // WriteAtCtx is WriteAt with a caller-supplied context that flows through any
 // read-modify-write backend fetches for trace propagation.
 func (vb *VB) WriteAtCtx(ctx context.Context, offset uint64, data []byte) error {
@@ -1180,6 +1314,17 @@ func (vb *VB) WriteAtCtx(ctx context.Context, offset uint64, data []byte) error 
 		for _, block := range writes {
 			vb.BlockStore.WriteWithSeqNum(block.Block, block.Data, block.SeqNum)
 		}
+	}
+
+	vb.pendingBytes.Add(int64(len(writes)) * int64(blockSize)) //nolint:gosec // G115: blockSize is 4KB-class, no overflow risk
+	vb.signalSizeTrigger()
+
+	// Backpressure gate: block this guest write until buffered bytes drop
+	// back under the low-watermark if MaxPendingBytes has been crossed. Runs
+	// after releasing vb.Writes.mu above so the drain this drives (which
+	// re-acquires that lock) cannot deadlock against us.
+	if err := vb.awaitBackpressure(ctx); err != nil {
+		return err
 	}
 
 	return nil
@@ -2343,6 +2488,7 @@ func (vb *VB) createChunkFile(ctx context.Context, currentWALNum uint64, chunkBu
 	// Filter pending writes in-place using the hash map for O(n) complexity
 	// We iterate through the slice once, keeping non-matched blocks at the front
 	n := 0
+	var freedBytes int64
 	for _, block := range vb.PendingBackendWrites.Blocks {
 		if _, matched := matchedBlockMap[block.Block]; !matched {
 			// Block not in matched set, keep it in pending writes
@@ -2353,12 +2499,18 @@ func (vb *VB) createChunkFile(ctx context.Context, currentWALNum uint64, chunkBu
 			if vb.Cache.Config.Size > 0 {
 				vb.Cache.lru.Add(block.Block, block.Data)
 			}
+			freedBytes += int64(len(block.Data))
 		}
 	}
 	// Truncate the slice to remove processed blocks
 	vb.PendingBackendWrites.Blocks = vb.PendingBackendWrites.Blocks[:n]
 
 	vb.PendingBackendWrites.mu.Unlock()
+
+	// This chunk's bytes have left both Writes.Blocks (filtered out at flush
+	// time) and PendingBackendWrites.Blocks (just above) — release them from
+	// the backpressure counter WriteAtCtx's awaitBackpressure gate watches.
+	vb.pendingBytes.Add(-freedBytes)
 
 	headerLen := len(headers)
 
@@ -4004,6 +4156,8 @@ func (vb *VB) Reset() error {
 	vb.PendingBackendWrites.mu.Lock()
 	vb.PendingBackendWrites.Blocks = make([]Block, 0)
 	vb.PendingBackendWrites.mu.Unlock()
+
+	vb.pendingBytes.Store(0)
 
 	if vb.Cache.lru != nil {
 		vb.Cache.lru.Purge()


### PR DESCRIPTION
## Summary

Bound the viperblock NBD write buffer with end-to-end backpressure so a large sustained guest write (e.g. a ~9 GB `docker`/EKS image pull) no longer grows the nbdkit plugin's memory without limit.

**The bug:** the write path retained the full payload of every written-but-not-yet-uploaded block in `PendingBackendWrites` with no watermark — `WriteAtCtx` never blocked. A 9 GB pull (~2.3 M × 4 KB blocks) accumulated ~11.5 GiB of anonymous, unreclaimable heap in the nbdkit process, saturating the `spinifex.slice` cgroup and driving the host into throttle/OOM. The `FlushSize` (64 MB) watermark the struct comment promised was never wired to the write path.

## Fix

- `MaxPendingBytes` (config, default 256 MB) added to `VB` and applied in `New()`. `pendingBytes` atomic tracks outstanding bytes across `Writes.Blocks` + `PendingBackendWrites.Blocks`.
- `awaitBackpressure()` — called from `WriteAtCtx` after releasing `Writes.mu` (so the drain it triggers can't deadlock on that lock) — blocks the guest write once `pendingBytes > MaxPendingBytes`, driving `DrainToBackendCtx` until back under the low watermark.
- `signalSizeTrigger()` wires `FlushSize` into the uploader's select loop, so drains are size-triggered (well before the 30 s ticker), not just time-triggered.
- New `max_pending_bytes` nbdkit plugin arg (mirrors `cache_size`).

## Verified live

Deployed to a node and re-ran the failing scenario (a vLLM image pull inside a GPU guest):
- Peak nbdkit `RssAnon` **8.56 GiB → 3.48 GiB**, **bounded** (drained rather than climbed; flat when writes paused), `oom_kill = 0` throughout — the balloon is eliminated.
- Backpressure unit tests: peak outstanding bytes stay at `MaxPendingBytes + 1 block` regardless of total written; drain releases the producer; data reads back correctly. `go test -race` + `golangci-lint` clean.

## Important: this is the memory fix, not the throughput fix

Backpressure bounds **memory** by **stalling the guest write** whenever the backend drain falls behind. The drain sustains only ~14 MB/s (serial single-consumer upload + S3-over-HTTPS self-loop + RS/QUIC/Raft on the synchronous hot path + WAL on a loop-backed store), so under a heavy pull the failure mode shifts from *host OOM* to *guest write starvation* — the pull is still unusably slow. This PR is **necessary but not sufficient**.

The full write-plane profile, flaw catalog (F1–F13), and the staged throughput redesign (parallel upload pipeline, kill the S3 self-loop, decouple WAL durability from async reclaimable upload, larger objects, erasure off the hot path) are documented in `docs/development/improvements/viperblock-write-plane-throughput.md` in the mulga repo.
