### PR TITLE
fix(checkpoint): remove per-chunk live-checkpoint PUT to close reorder race

### DIFF
--- a/viperblock/checkpoint_amplification_test.go
+++ b/viperblock/checkpoint_amplification_test.go
@@ -105,9 +105,12 @@ func TestCheckpointIdleGating(t *testing.T) {
 		"idle ticks must not PUT blocks.live.bin when no blocks changed")
 }
 
-// TestCheckpointWriteProportionality verifies that after a drain, checkpoint
-// PUTs equal chunk uploads (one per dirty chunk), and that subsequent idle
-// ticks do not add further writes.
+// TestCheckpointWriteProportionality verifies that a drain writes the live
+// checkpoint exactly once — a single coalesced PUT after all chunk uploads
+// land, regardless of chunk count — and that subsequent idle ticks add no
+// further writes. Per-chunk checkpointing was removed: concurrent per-chunk
+// PUTs from the parallel upload pool could land out of snapshot order and
+// leave a stale seqNum in the checkpoint (encrypted reattach bad superblock).
 func TestCheckpointWriteProportionality(t *testing.T) {
 	dir := t.TempDir()
 	// Slow ticker so it does not fire during the explicit drain below.
@@ -126,8 +129,8 @@ func TestCheckpointWriteProportionality(t *testing.T) {
 	chunkWrites := cb.count(types.FileTypeChunk)
 	cpWrites := cb.count(types.FileTypeBlockCheckpointLive)
 	require.Equal(t, 2, chunkWrites, "expected 2 chunk uploads")
-	assert.Equal(t, chunkWrites, cpWrites,
-		"checkpoint PUTs must equal chunk uploads, not tick count")
+	assert.Equal(t, 1, cpWrites,
+		"drain must write the live checkpoint once (coalesced), not per chunk")
 	assert.False(t, vb.BlocksToObject.dirty.Load(),
 		"dirty must be clear after successful drain")
 

--- a/viperblock/viperblock.go
+++ b/viperblock/viperblock.go
@@ -2577,17 +2577,14 @@ func (vb *VB) createChunkFile(ctx context.Context, currentWALNum uint64, chunkBu
 	vb.BlocksToObject.dirty.Store(true)
 	vb.BlocksToObject.mu.Unlock()
 
-	// Flush the updated block→chunk mapping to S3 immediately after each chunk
-	// upload so the live checkpoint stays consistent with what is in S3. This
-	// shrinks the window in which a crash can leave the checkpoint pointing at a
-	// stale seqNum relative to the just-uploaded chunk ciphertext (the remaining
-	// window is the gap between Backend.Write and this call, not the full 30s
-	// background-uploader interval). If this write fails, dirty remains set and
-	// DrainToBackend's trailing SaveLiveCheckpointCtx call will retry.
-	if cpErr := vb.SaveLiveCheckpointCtx(ctx); cpErr != nil {
-		slog.WarnContext(ctx, "createChunkFile: SaveLiveCheckpoint failed", "err", cpErr)
-	}
-
+	// Do NOT checkpoint per chunk here. createChunkFile runs under the parallel
+	// upload pool, so concurrent per-chunk SaveLiveCheckpointCtx calls can PUT
+	// out of snapshot order: a worker holding an early, partial map can land its
+	// write last and leave the live checkpoint pointing at a stale seqNum, which
+	// an encrypted reattach then decrypts as garbage (bad superblock). dirty is
+	// set above; the single serialized SaveLiveCheckpointCtx that every driver
+	// runs after up.wait() (DrainToBackendCtx, RecoverLocalWALs, Close) writes
+	// the complete coalesced map exactly once, after all chunk PUTs have landed.
 	return nil
 }
 


### PR DESCRIPTION
## Problem
`createChunkFile` ran under the parallel upload pool and issued a `SaveLiveCheckpointCtx` after every chunk. Concurrent per-chunk PUTs could land out of snapshot order — a worker holding an early, partial block map could complete its write last and leave the live checkpoint pointing at a stale seqNum. On an encrypted volume the seqNum is AEAD-bound, so a reattach decrypts the stale entry as garbage and the guest sees `mount: bad superblock` (exit 32): silent data loss on detach->reattach. Regressed single-node `TestVolumeDurability` after v1.12.0 (introduced by #30).

## Fix
Remove the per-chunk checkpoint. The map mutation still sets `dirty`; every driver (`DrainToBackendCtx`, `RecoverLocalWALs`, `Close`) already runs a single serialized `SaveLiveCheckpointCtx` after `up.wait()`, which writes the complete coalesced map exactly once after all chunk PUTs have landed. Eliminates the reorder race and further cuts checkpoint write volume (one PUT per drain, not per chunk — also helps the #30 disk-fill target).

`TestCheckpointWriteProportionality` updated to assert the coalesced contract (one checkpoint PUT per drain).

## Validation
- Local: build clean, checkpoint + snapshot tests pass, race-clean.
- CI bisect isolated the regression to ac01d6a (#30); reverting it alone went green.
- Full E2E on this fix (single + multi `TestVolumeDurability`): green — run 29320467298.