### PR TITLE
fix(test): root test volumes in t.TempDir() to stop /tmp leak

### DIFF
--- a/viperblock/backpressure_test.go
+++ b/viperblock/backpressure_test.go
@@ -3,7 +3,6 @@ package viperblock
 import (
 	"context"
 	"fmt"
-	"os"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -40,7 +39,7 @@ func (s *slowBackend) WriteCtx(ctx context.Context, fileType types.FileType, obj
 func newBackpressureTestVB(t *testing.T, maxPendingBytes uint64, drainDelay time.Duration) *VB {
 	t.Helper()
 
-	tmpDir := os.TempDir()
+	tmpDir := t.TempDir()
 	testVol := fmt.Sprintf("test_backpressure_%d", time.Now().UnixNano())
 
 	backendConfig := file.FileConfig{
@@ -68,6 +67,12 @@ func newBackpressureTestVB(t *testing.T, maxPendingBytes uint64, drainDelay time
 	require.NoError(t, err)
 	require.NotNil(t, vb)
 
+	// Registered before the setup below can call FailNow, which would otherwise
+	// skip cleanup and leave the VB tree behind.
+	t.Cleanup(func() {
+		assert.NoError(t, vb.RemoveLocalFiles())
+	})
+
 	vb.UseShardedWAL = false
 	vb.ShardedWAL = nil
 
@@ -76,10 +81,6 @@ func newBackpressureTestVB(t *testing.T, maxPendingBytes uint64, drainDelay time
 
 	require.NoError(t, vb.OpenWAL(&vb.WAL, fmt.Sprintf("%s/%s", vb.WAL.BaseDir, types.GetFilePath(types.FileTypeWALChunk, vb.WAL.WallNum.Load(), vb.GetVolume()))))
 	require.NoError(t, vb.OpenWAL(&vb.BlockToObjectWAL, fmt.Sprintf("%s/%s", vb.BlockToObjectWAL.BaseDir, types.GetFilePath(types.FileTypeWALBlock, vb.BlockToObjectWAL.WallNum.Load(), vb.GetVolume()))))
-
-	t.Cleanup(func() {
-		_ = vb.RemoveLocalFiles()
-	})
 
 	return vb
 }

--- a/viperblock/snapshot_test.go
+++ b/viperblock/snapshot_test.go
@@ -791,13 +791,15 @@ func createCloneVB(t *testing.T, source *VB, snapshotID string) *VB {
 
 	switch btype {
 	case "file":
-		// Use the same base dir as setupTestVB uses for the file backend.
-		// The VB.BaseDir is "{tmpDir}/viperblock" while the file backend's
-		// BaseDir is just tmpDir. Both must share the same storage root.
+		// Derive the backend root from the source rather than naming it, so the
+		// clone follows its source wherever that is rooted. setupTestVB roots
+		// the VB at "{tmpDir}/viperblock" and the file backend at tmpDir, so
+		// the source's parent is the storage root both must share for ReadFrom
+		// and OpenFromSnapshot to resolve the source's chunks.
 		cloneBackendConfig = file.FileConfig{
 			VolumeName: cloneName,
 			VolumeSize: source.VolumeSize,
-			BaseDir:    os.TempDir(),
+			BaseDir:    filepath.Dir(source.BaseDir),
 		}
 	case "s3":
 		// Reconstruct S3 config with the clone's volume name
@@ -826,6 +828,12 @@ func createCloneVB(t *testing.T, source *VB, snapshotID string) *VB {
 	clone, err := New(&vbconfig, btype, cloneBackendConfig)
 	require.NoError(t, err)
 
+	// Registered before the setup below can call FailNow, which would otherwise
+	// skip cleanup and leave the clone's VB tree behind.
+	t.Cleanup(func() {
+		assert.NoError(t, clone.RemoveLocalFiles())
+	})
+
 	err = clone.Backend.Init()
 	require.NoError(t, err)
 
@@ -843,10 +851,6 @@ func createCloneVB(t *testing.T, source *VB, snapshotID string) *VB {
 	// Load snapshot base map
 	err = clone.OpenFromSnapshot(snapshotID)
 	require.NoError(t, err)
-
-	t.Cleanup(func() {
-		clone.RemoveLocalFiles()
-	})
 
 	return clone
 }

--- a/viperblock/viperblock_test.go
+++ b/viperblock/viperblock_test.go
@@ -164,9 +164,13 @@ func loadTestCredentials() (accessKey, secretKey string) {
 
 // setupTestVB creates a new VB instance for testing with the specified backend
 func setupTestVB(t *testing.T, testCase TestVB, backendType BackendTest) (vb *VB, baseURL string, shutdown func(volName string), err error) {
-	// Create a temporary directory for test data
-	//tmpDir, err := os.MkdirTemp("", "viperblock_test_*")
-	tmpDir := os.TempDir()
+	// Per-test storage root shared by both trees: the file backend is rooted at
+	// tmpDir and creates "{tmpDir}/{volume}", while the VB is rooted at
+	// "{tmpDir}/viperblock". RemoveLocalFiles() only owns the VB tree, so the
+	// root must be a t.TempDir() for the backend tree to be cleaned up too.
+	// createCloneVB re-derives this root from source.BaseDir, so a clone and its
+	// source resolve each other's chunks only while this layout holds.
+	tmpDir := t.TempDir()
 	testVol := fmt.Sprintf("test_volume_%d", time.Now().UnixNano())
 
 	t.Cleanup(func() {
@@ -176,8 +180,6 @@ func setupTestVB(t *testing.T, testCase TestVB, backendType BackendTest) (vb *VB
 			err = vb.RemoveLocalFiles()
 
 			assert.NoError(t, err)
-
-			//os.RemoveAll(fmt.Sprintf("%s/%s", tmpDir, testVol))
 		}
 	})
 
@@ -359,11 +361,16 @@ func runWithBackends(t *testing.T, testName string, testFunc func(t *testing.T, 
 }
 
 func TestNew(t *testing.T) {
+	// New() creates "{BaseDir}/{volume}" itself, so both roots are explicit
+	// here: an unset VB.BaseDir would default to the shared /tmp/viperblock,
+	// and a relative backend BaseDir would resolve inside the repo.
+	tmpDir := t.TempDir()
+
 	testCases := []TestVB{
 		{
 			name: "file",
 			config: file.FileConfig{
-				BaseDir:    "test_data",
+				BaseDir:    filepath.Join(tmpDir, "test_data"),
 				VolumeName: "test_s3",
 				VolumeSize: volumeSize,
 			},
@@ -388,7 +395,7 @@ func TestNew(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			vb, err := New(&VB{VolumeName: "test", VolumeSize: 1024 * 1024}, tc.name, tc.config)
+			vb, err := New(&VB{VolumeName: "test", VolumeSize: 1024 * 1024, BaseDir: filepath.Join(tmpDir, "viperblock")}, tc.name, tc.config)
 			assert.NoError(t, err)
 			assert.NotNil(t, vb)
 			assert.Equal(t, tc.blockSize, vb.BlockSize)
@@ -908,7 +915,7 @@ func TestWriteWALTruncatesOnShortWrite(t *testing.T) {
 // registered with t.Cleanup.
 func setupWALTruncateTestVB(t *testing.T, tag string) (*VB, string) {
 	t.Helper()
-	tmpDir := os.TempDir()
+	tmpDir := t.TempDir()
 	testVol := fmt.Sprintf("test_wal_truncate_%s_%d", tag, time.Now().UnixNano())
 
 	backendConfig := file.FileConfig{
@@ -932,7 +939,6 @@ func setupWALTruncateTestVB(t *testing.T, tag string) (*VB, string) {
 
 	t.Cleanup(func() {
 		vb.StopWALSyncer()
-		os.RemoveAll(filepath.Join(vb.BaseDir, testVol))
 	})
 
 	require.NoError(t, vb.Backend.Init())
@@ -947,7 +953,7 @@ func setupWALTruncateTestVB(t *testing.T, tag string) (*VB, string) {
 // TestWALPeriodicSync tests the periodic WAL fsync functionality
 // following patterns from PostgreSQL (wal_writer_delay), BadgerDB, and MongoDB
 func TestWALPeriodicSync(t *testing.T) {
-	tmpDir := os.TempDir()
+	tmpDir := t.TempDir()
 
 	testCases := []struct {
 		name            string
@@ -994,7 +1000,6 @@ func TestWALPeriodicSync(t *testing.T) {
 
 			t.Cleanup(func() {
 				vb.StopWALSyncer()
-				os.RemoveAll(filepath.Join(vb.BaseDir, testVol))
 			})
 
 			// Verify syncer state matches expectation
@@ -1085,7 +1090,7 @@ func TestWALPeriodicSync(t *testing.T) {
 
 // TestWALSyncerConcurrency tests that the syncer handles concurrent writes correctly
 func TestWALSyncerConcurrency(t *testing.T) {
-	tmpDir := os.TempDir()
+	tmpDir := t.TempDir()
 	testVol := fmt.Sprintf("test_wal_sync_concurrent_%d", time.Now().UnixNano())
 
 	backendConfig := file.FileConfig{
@@ -1106,7 +1111,6 @@ func TestWALSyncerConcurrency(t *testing.T) {
 
 	t.Cleanup(func() {
 		vb.StopWALSyncer()
-		os.RemoveAll(filepath.Join(vb.BaseDir, testVol))
 	})
 
 	err = vb.Backend.Init()


### PR DESCRIPTION
## Summary

viperblock's test helpers called `os.TempDir()` and treated the result as a private per-run scratch directory. It is not one: `os.TempDir()` returns the string `/tmp` and creates nothing.

Each file-backed test volume produces two directory trees — the VB tree at `{tmpDir}/viperblock/{volume}` and the file backend tree at `{tmpDir}/{volume}`. `RemoveLocalFiles()` removes only the VB tree, so the backend tree was orphaned by construction.

The regression was visible in the source: `viperblock_test.go:168` still carried the original `os.MkdirTemp` call commented out directly above its replacement, with the matching `os.RemoveAll` commented out in the cleanup. Per-run isolation and backend cleanup were dropped together.

## Measured impact

Baseline on a dev box before this change, after one full `go test ./viperblock/...`:

| Pattern | Dirs |
| --- | --- |
| `test_volume_*` | 1548 |
| `clone-*` | 532 |
| `test_wal_*` | 72 |
| `test_backpressure_*` | 24 |

628MB total, plus 579 subdirectories under `/tmp/viperblock`. `/tmp` is tmpfs on dev boxes, so this is RAM, and nothing ever reclaimed it.

After this change all four patterns are `0`, confirmed across three full runs and a complete `make preflight`.

## Changes

**Per-test root in the five non-clone helpers.** `t.TempDir()` replaces `os.TempDir()` in `setupTestVB`, `setupWALTruncateTestVB`, `TestWALPeriodicSync`, `TestWALSyncerConcurrency` and `newBackpressureTestVB`. The `{tmpDir}` / `{tmpDir}/viperblock` layout is preserved relative to the new root. `t.TempDir()` is called at the top of each helper so its removal, registered first, runs last under `t.Cleanup`'s LIFO order — background writers stop before their directory is removed. The now-redundant explicit `os.RemoveAll` calls are dropped so ownership is unambiguous.

**Shared root derived in `createCloneVB`.** This one cannot call `t.TempDir()` independently. A clone creates its own backend so writes target the clone's namespace, while `ReadFrom` and `OpenFromSnapshot` still resolve the *source's* chunks from the shared root — independent roots would split that and break all 11 clone call sites. The `Backend` interface exposes no `GetBaseDir()`, so the root is derived from the VB root the clone already inherits: `filepath.Dir(source.BaseDir)`. The sharing was correct; only its scope was wrong (one root per machine, owned by nobody → one root per test, auto-cleaned).

**Cleanup registered before it can be skipped.** In `createCloneVB` and `newBackpressureTestVB`, `t.Cleanup` sat after several `require.NoError` calls whose `FailNow` would skip registration, leaking even the VB tree on failure. Both now register immediately after `New()`, and the discarded `RemoveLocalFiles()` errors are checked.