### PR TITLE
feat: export ParseBlockCheckpointBytes for out-of-process checkpoint reads

### DIFF
--- a/viperblock/parse_checkpoint_test.go
+++ b/viperblock/parse_checkpoint_test.go
@@ -1,0 +1,154 @@
+package viperblock
+
+import (
+	"crypto/rand"
+	"encoding/binary"
+	"testing"
+
+	"github.com/mulgadc/viperblock/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// buildTestCheckpoint serialises entries into the on-disk checkpoint format
+// using the production writer, so these tests exercise the real encoder rather
+// than a hand-rolled copy of it.
+func buildTestCheckpoint(t *testing.T, version uint16, magic [4]byte, entries []BlockLookup) []byte {
+	t.Helper()
+
+	header := make([]byte, blockCheckpointHeaderSize)
+	copy(header[:4], magic[:])
+	binary.BigEndian.PutUint16(header[4:6], version)
+	binary.BigEndian.PutUint64(header[6:14], 0)
+
+	raw := make([]byte, 0, blockCheckpointHeaderSize+len(entries)*blockWalChunkSize)
+	raw = append(raw, header...)
+
+	vb := &VB{}
+	for i := range entries {
+		raw = append(raw, vb.writeBlockWalChunk(&entries[i])...)
+	}
+	return raw
+}
+
+// TestParseBlockCheckpointBytesRoundtrip checks the exported parser decodes
+// every field the encoder wrote, keyed by StartBlock.
+func TestParseBlockCheckpointBytesRoundtrip(t *testing.T) {
+	entries := []BlockLookup{
+		{StartBlock: 0, NumBlocks: 1, ObjectID: 0, ObjectOffset: 0, SeqNum: 1},
+		{StartBlock: 1, NumBlocks: 1, ObjectID: 0, ObjectOffset: 4096, SeqNum: 2},
+		{StartBlock: 9000, NumBlocks: 1, ObjectID: 7, ObjectOffset: 8192, SeqNum: 3},
+	}
+
+	raw := buildTestCheckpoint(t, 1, blockToObjectWALMagic, entries)
+
+	got, err := ParseBlockCheckpointBytes(raw, 1)
+	require.NoError(t, err)
+	require.Len(t, got, len(entries))
+
+	for _, want := range entries {
+		have, ok := got[want.StartBlock]
+		require.True(t, ok, "block %d missing", want.StartBlock)
+		assert.Equal(t, want, have, "block %d roundtrip mismatch", want.StartBlock)
+	}
+}
+
+// TestParseBlockCheckpointBytesEmpty checks a header-only checkpoint parses to
+// an empty map rather than an error: a volume that has never drained a chunk
+// legitimately has no referenced blocks, and that is zero, not a failure.
+func TestParseBlockCheckpointBytesEmpty(t *testing.T) {
+	raw := buildTestCheckpoint(t, 1, blockToObjectWALMagic, nil)
+
+	got, err := ParseBlockCheckpointBytes(raw, 1)
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+// TestParseBlockCheckpointBytesRejects covers every malformed input that must
+// produce a hard error. A reader of this map decides which chunks are garbage,
+// so a silently-short or silently-wrong parse is worse than no answer at all.
+func TestParseBlockCheckpointBytesRejects(t *testing.T) {
+	valid := buildTestCheckpoint(t, 1, blockToObjectWALMagic, []BlockLookup{
+		{StartBlock: 0, NumBlocks: 1, ObjectID: 0, ObjectOffset: 0, SeqNum: 1},
+		{StartBlock: 1, NumBlocks: 1, ObjectID: 1, ObjectOffset: 0, SeqNum: 2},
+	})
+
+	t.Run("empty input", func(t *testing.T) {
+		_, err := ParseBlockCheckpointBytes(nil, 1)
+		require.ErrorContains(t, err, "shorter than")
+	})
+
+	t.Run("truncated header", func(t *testing.T) {
+		_, err := ParseBlockCheckpointBytes(valid[:blockCheckpointHeaderSize-1], 1)
+		require.ErrorContains(t, err, "shorter than")
+	})
+
+	t.Run("magic mismatch", func(t *testing.T) {
+		bad := buildTestCheckpoint(t, 1, [4]byte{'N', 'O', 'P', 'E'}, nil)
+		_, err := ParseBlockCheckpointBytes(bad, 1)
+		require.ErrorContains(t, err, "magic mismatch")
+	})
+
+	t.Run("version mismatch", func(t *testing.T) {
+		_, err := ParseBlockCheckpointBytes(valid, 2)
+		require.ErrorContains(t, err, "version mismatch")
+	})
+
+	// A truncated read is the realistic failure for a network reader. The
+	// fixed-width loop must reject it up front: slicing a partial record
+	// either panics (when the backing array ends at the data) or, when the
+	// slice has spare capacity, silently decodes bytes past the end as a
+	// phantom record. Both are worse than an error.
+	t.Run("trailing partial record", func(t *testing.T) {
+		truncated := valid[:len(valid)-5]
+		_, err := ParseBlockCheckpointBytes(truncated, 1)
+		require.ErrorContains(t, err, "trailing bytes")
+	})
+
+	t.Run("corrupt record crc", func(t *testing.T) {
+		corrupt := make([]byte, len(valid))
+		copy(corrupt, valid)
+		// Flip a byte inside the second record's CRC-covered region.
+		corrupt[blockCheckpointHeaderSize+blockWalChunkSize] ^= 0xFF
+		_, err := ParseBlockCheckpointBytes(corrupt, 1)
+		require.ErrorContains(t, err, "checksum mismatch")
+	})
+}
+
+// TestParseBlockCheckpointBytesMatchesVBLoad pins the exported parser to the
+// in-process loader: both must decode a real drained volume's live checkpoint
+// to the same map. This is the guard against the two paths drifting apart.
+func TestParseBlockCheckpointBytesMatchesVBLoad(t *testing.T) {
+	runWithBackends(t, "parse_checkpoint_matches_vb_load", func(t *testing.T, vb *VB) {
+		for i := range uint64(4) {
+			data := make([]byte, DefaultBlockSize)
+			_, err := rand.Read(data)
+			require.NoError(t, err)
+			require.NoError(t, vb.Write(i, data))
+		}
+		require.NoError(t, vb.Flush())
+		if vb.UseShardedWAL {
+			require.NoError(t, vb.WriteShardedWALToChunk(true))
+		} else {
+			require.NoError(t, vb.WriteWALToChunk(true))
+		}
+		require.NoError(t, vb.SaveLiveCheckpoint())
+
+		// Read the same bytes the VB persisted, straight off the backend.
+		raw, err := vb.Backend.Read(types.FileTypeBlockCheckpointLive, 0, 0, 0)
+		require.NoError(t, err)
+
+		got, err := ParseBlockCheckpointBytes(raw, vb.Version)
+		require.NoError(t, err)
+
+		vb.BlocksToObject.mu.RLock()
+		defer vb.BlocksToObject.mu.RUnlock()
+
+		require.Len(t, got, len(vb.BlocksToObject.BlockLookup))
+		for blockNum, want := range vb.BlocksToObject.BlockLookup {
+			have, ok := got[blockNum]
+			require.True(t, ok, "block %d missing from parsed map", blockNum)
+			assert.Equal(t, want, have, "block %d mismatch", blockNum)
+		}
+	})
+}

--- a/viperblock/viperblock.go
+++ b/viperblock/viperblock.go
@@ -746,7 +746,7 @@ func New(config *VB, btype string, backendConfig any) (vb *VB, err error) {
 		ChunkUploadInterval: config.ChunkUploadInterval,
 		Writes:              Blocks{},
 		WAL:                 WAL{BaseDir: config.BaseDir, WALMagic: walMagic},
-		BlockToObjectWAL:    WAL{BaseDir: config.BaseDir, WALMagic: [4]byte{'V', 'B', 'W', 'B'}},
+		BlockToObjectWAL:    WAL{BaseDir: config.BaseDir, WALMagic: blockToObjectWALMagic},
 		Cache: Cache{
 			lru: lruCache,
 			Config: CacheConfig{
@@ -1863,6 +1863,19 @@ func (vb *VB) WriteBlockWAL(blocks *[]BlockLookup) (err error) {
 // metadata because the checkpoint stays plaintext (not AEAD-sealed).
 const blockWalChunkSize = 34
 
+// blockToObjectWALMagic identifies a block-to-object checkpoint stream.
+//
+// Unlike the chunk and single-file-WAL magics, this one is NOT switched by
+// EncryptionEnabled: the block map is metadata and stays plaintext on both
+// encrypted and unencrypted volumes, so both write the same magic. That is
+// what lets a checkpoint be decoded from its bytes alone, with no volume
+// identity and no master key.
+var blockToObjectWALMagic = [4]byte{'V', 'B', 'W', 'B'}
+
+// blockCheckpointHeaderSize is the size of the header preceding the
+// blockWalChunkSize-sized records: magic(4) + Version(2) + Timestamp(8).
+const blockCheckpointHeaderSize = 14
+
 func (vb *VB) writeBlockWalChunk(block *BlockLookup) (data []byte) {
 	data = make([]byte, blockWalChunkSize)
 
@@ -1878,7 +1891,15 @@ func (vb *VB) writeBlockWalChunk(block *BlockLookup) (data []byte) {
 	return data
 }
 
-func (vb *VB) readBlockWalChunk(data []byte) (block BlockLookup, err error) {
+// decodeBlockWalChunk decodes one blockWalChunkSize-sized record and verifies
+// its CRC32. data must be exactly blockWalChunkSize bytes; callers slice it.
+// Receiver-free so the checkpoint format can be decoded without a VB — see
+// ParseBlockCheckpointBytes.
+func decodeBlockWalChunk(data []byte) (block BlockLookup, err error) {
+	if len(data) != blockWalChunkSize {
+		return block, fmt.Errorf("block record is %d bytes, want %d", len(data), blockWalChunkSize)
+	}
+
 	block.StartBlock = binary.BigEndian.Uint64(data[:8])
 	block.NumBlocks = binary.BigEndian.Uint16(data[8:10])
 	block.ObjectID = binary.BigEndian.Uint64(data[10:18])
@@ -1889,10 +1910,18 @@ func (vb *VB) readBlockWalChunk(data []byte) (block BlockLookup, err error) {
 
 	checksumValidated := crc32.ChecksumIEEE(data[:30])
 	if checksumValidated != checksum {
-		vb.logger().Error("Checksum mismatch", "checksum", checksum, "checksum_validated", checksumValidated)
-		return block, fmt.Errorf("checksum mismatch")
+		return block, fmt.Errorf("checksum mismatch: got %d, want %d", checksumValidated, checksum)
 	}
 
+	return block, nil
+}
+
+func (vb *VB) readBlockWalChunk(data []byte) (block BlockLookup, err error) {
+	block, err = decodeBlockWalChunk(data)
+	if err != nil {
+		vb.logger().Error("Block record decode failed", "error", err)
+		return block, err
+	}
 	return block, nil
 }
 
@@ -2674,6 +2703,68 @@ func (vb *VB) SaveBlockStateCtx(ctx context.Context) (err error) {
 	return err
 }
 
+// walkBlockCheckpoint validates a serialized block checkpoint's header
+// (magic + version) and calls fn once per decoded record, in on-disk order.
+//
+// Receiver-free and the single place the checkpoint wire format is parsed, so
+// every caller — in-process load, and out-of-process readers that have only
+// the bytes — decodes identically. Two copies of this loop drifting apart
+// would make one caller silently wrong with no test noticing.
+func walkBlockCheckpoint(raw []byte, version uint16, walMagic [4]byte, fn func(BlockLookup)) error {
+	if len(raw) < blockCheckpointHeaderSize {
+		return fmt.Errorf("checkpoint is %d bytes, shorter than the %d-byte header", len(raw), blockCheckpointHeaderSize)
+	}
+
+	if !bytes.Equal(raw[:4], walMagic[:]) {
+		return fmt.Errorf("magic mismatch: got %q, want %q", raw[:4], walMagic[:])
+	}
+
+	if got := binary.BigEndian.Uint16(raw[4:6]); got != version {
+		return fmt.Errorf("version mismatch: got %d, want %d", got, version)
+	}
+
+	// Reject a partial trailing record rather than reading up to it and
+	// returning a short map: the records are fixed-width, so a remainder
+	// means the bytes are truncated or not a checkpoint at all, and a
+	// silently-short referenced set is worse than a hard error.
+	dataSize := len(raw) - blockCheckpointHeaderSize
+	if dataSize%blockWalChunkSize != 0 {
+		return fmt.Errorf("checkpoint has %d trailing bytes (data section %d bytes is not a multiple of %d-byte records)",
+			dataSize%blockWalChunkSize, dataSize, blockWalChunkSize)
+	}
+
+	for offset := blockCheckpointHeaderSize; offset+blockWalChunkSize <= len(raw); offset += blockWalChunkSize {
+		block, err := decodeBlockWalChunk(raw[offset : offset+blockWalChunkSize])
+		if err != nil {
+			return fmt.Errorf("record at offset %d: %w", offset, err)
+		}
+		fn(block)
+	}
+
+	return nil
+}
+
+// ParseBlockCheckpointBytes decodes a block-to-object checkpoint into its
+// block map, keyed by StartBlock, from the raw bytes alone.
+//
+// This is the read-only, no-side-effect way to inspect a volume's referenced
+// chunk set. Constructing a VB to reach the same map is not equivalent: New()
+// creates directories and starts the WAL syncer and chunk uploader, and the
+// uploader writes to the backend — attaching a second writer to the volume
+// being inspected. This function touches nothing.
+//
+// No master key is required: the block map is metadata and is written
+// plaintext on encrypted volumes too (see blockToObjectWALMagic).
+func ParseBlockCheckpointBytes(raw []byte, version uint16) (map[uint64]BlockLookup, error) {
+	blocks := make(map[uint64]BlockLookup)
+	if err := walkBlockCheckpoint(raw, version, blockToObjectWALMagic, func(block BlockLookup) {
+		blocks[block.StartBlock] = block
+	}); err != nil {
+		return nil, err
+	}
+	return blocks, nil
+}
+
 // parseBlockCheckpoint deserialises a checkpoint binary into BlocksToObject.BlockLookup.
 // Caller must hold BlocksToObject.mu (write).
 func (vb *VB) parseBlockCheckpoint(checkpoint []byte) error {
@@ -2681,28 +2772,12 @@ func (vb *VB) parseBlockCheckpoint(checkpoint []byte) error {
 
 	vb.logger().Debug("Loaded checkpoint", "checkpoint", checkpoint)
 
-	headers := checkpoint[:vb.BlockToObjectWALHeaderSize()]
-
-	if !bytes.Equal(headers[:4], vb.BlockToObjectWAL.WALMagic[:]) {
-		return fmt.Errorf("magic mismatch")
-	}
-
-	if binary.BigEndian.Uint16(headers[4:6]) != vb.Version {
-		return fmt.Errorf("version mismatch")
-	}
-
 	// Track the highest chunk ObjectID the map references so ObjectNum can be
 	// reconciled to max+1 below, mirroring SeqNum -> maxSeqNum in RecoverLocalWALs.
 	var maxObjectID uint64
 	haveObject := false
 
-	offset := vb.BlockToObjectWALHeaderSize()
-	for offset < len(checkpoint) {
-		block, err := vb.readBlockWalChunk(checkpoint[offset : offset+blockWalChunkSize])
-		if err != nil {
-			vb.logger().Error("Error reading block", "error", err)
-			return err
-		}
+	err := walkBlockCheckpoint(checkpoint, vb.Version, vb.BlockToObjectWAL.WALMagic, func(block BlockLookup) {
 		vb.BlocksToObject.BlockLookup[block.StartBlock] = block
 		if !haveObject || block.ObjectID > maxObjectID {
 			maxObjectID = block.ObjectID
@@ -2711,7 +2786,10 @@ func (vb *VB) parseBlockCheckpoint(checkpoint []byte) error {
 		if vb.UseBlockStore && vb.BlockStore != nil {
 			vb.BlockStore.SetPersisted(block.StartBlock, block.ObjectID, block.ObjectOffset, block.SeqNum)
 		}
-		offset += blockWalChunkSize
+	})
+	if err != nil {
+		vb.logger().Error("Error reading checkpoint", "error", err)
+		return err
 	}
 
 	// Runtime drains persist chunks but not config.json ObjectNum, so a re-Open can
@@ -4296,7 +4374,7 @@ func (vb *VB) BlockToObjectWALHeader() []byte {
 
 func (vb *VB) BlockToObjectWALHeaderSize() int {
 	// Magic bytes (4) + Version (2) + Timestamp (8)
-	return len(vb.BlockToObjectWAL.WALMagic) + binary.Size(vb.Version) + binary.Size(time.Now().Unix())
+	return blockCheckpointHeaderSize
 }
 
 func (vb *VB) ChunkHeader() []byte {


### PR DESCRIPTION
Measuring a volume's referenced chunk set needs the block map, and today the only
way to reach it is to construct a `VB`. That is not read-only: `New()` creates
directories and starts the WAL syncer and chunk uploader, and the uploader writes
to the backend — attaching a second writer to the volume being inspected.

`ParseBlockCheckpointBytes` decodes a checkpoint from its bytes alone and touches
nothing. No master key is needed: the block map is metadata and is written
plaintext on encrypted volumes too. `BlockToObjectWAL`'s magic is not switched by
`EncryptionEnabled` (unlike the chunk and single-file-WAL magics), which is what
makes decoding from `(raw, version)` sound; the literal is hoisted into
`blockToObjectWALMagic` so the exported parser cannot drift from `New()`.

Both the in-process load and the exported parser now go through one receiver-free
`walkBlockCheckpoint`, so the wire format is parsed in exactly one place. Two
copies of that loop drifting apart would make one caller silently wrong with no
test noticing.

This also fixes a latent bug on the in-process path. The old loop guarded
`offset < len(checkpoint)` but sliced `checkpoint[offset : offset+34]`, so a
truncated checkpoint either panicked (`cap == len`) or — worse — silently decoded
bytes past `len` as a phantom block-map record when the slice had spare capacity.
A phantom entry maps a logical block to the wrong chunk, which is silent
corruption of the block map rather than a crash. The walker now rejects a data
section that is not a whole multiple of the record size, before decoding
anything. A truncated read is the realistic failure mode for a reader that pulls
the checkpoint over the network.

Tests cover the roundtrip, an empty map, a short header, a trailing partial
record (constructed with spare capacity, i.e. the phantom case), and that the
exported parser agrees with the in-process load on the same bytes.