### PR TITLE
fix: atomic per-block read-modify-write, and refuse short backend reads

### DIFF
--- a/nbd/viperblock.go
+++ b/nbd/viperblock.go
@@ -233,6 +233,9 @@ func (p *ViperBlockPlugin) Open(readonly bool) (nbdkit.ConnectionInterface, erro
 		VolumeName: volume,
 		VolumeSize: size,
 		BaseDir:    base_dir,
+		// Data-path engine. Recorded on the volume-open metric so a volume
+		// simultaneously held by a control-plane import is visible.
+		Role: "nbdkit",
 		Cache: viperblock.Cache{
 			Config: viperblock.CacheConfig{
 				Size: cache_size,

--- a/telemetry/metrics.go
+++ b/telemetry/metrics.go
@@ -2,6 +2,8 @@ package telemetry
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"sync"
 	"time"
 
@@ -25,6 +27,9 @@ var (
 	walOpDurationSum metric.Float64Counter
 
 	cacheLookups metric.Int64Counter
+
+	rmwConflicts metric.Int64Counter
+	volumeOpens  metric.Int64Counter
 
 	// cacheHitOpt/cacheMissOpt are pre-built so the per-block cache lookup
 	// path (inside the read hot loop) allocates nothing beyond the record
@@ -86,7 +91,68 @@ func instruments() {
 
 		cacheHitOpt = metric.WithAttributeSet(attribute.NewSet(attribute.String("result", "hit")))
 		cacheMissOpt = metric.WithAttributeSet(attribute.NewSet(attribute.String("result", "miss")))
+
+		rmwConflicts, err = m.Int64Counter("viperblock.write.rmw_conflicts",
+			metric.WithDescription("Partial writes that found another write already rebuilding the same block. Non-zero means guest I/O produces same-block write concurrency."),
+			metric.WithUnit("{conflict}"))
+		if err != nil {
+			otel.Handle(err)
+		}
+
+		volumeOpens, err = m.Int64Counter("viperblock.volume.opens",
+			metric.WithDescription("Volume opens, attributed by owning process identity, pid and role. Two distinct pids/roles reporting opens for one volume is a dual-open: more than one engine holds the volume."),
+			metric.WithUnit("{open}"))
+		if err != nil {
+			otel.Handle(err)
+		}
 	})
+}
+
+// RecordRMWConflict counts one read-modify-write conflict: a partial write
+// that had to wait because another write was already rebuilding the same
+// block. Before per-block RMW serialization this was the exact condition
+// under which one of the two writes was silently discarded, so a non-zero
+// count is the signal that the workload can produce that class of loss.
+func RecordRMWConflict(ctx context.Context, volume string) {
+	instruments()
+	if rmwConflicts == nil {
+		return
+	}
+	attrs := []attribute.KeyValue{}
+	if volume != "" {
+		attrs = append(attrs, attribute.String("volume", volume))
+	}
+	rmwConflicts.Add(ctx, 1, metric.WithAttributes(attrs...))
+}
+
+// RecordVolumeOpen emits one volume-open event carrying the opening process's
+// identity: role ("nbdkit" for the data-path plugin, "daemon" for a
+// control-plane import, or "" when unset), executable name and pid.
+//
+// viperblock currently runs as BOTH an nbdkit plugin and a Go module imported
+// into the spinifex daemon, so a volume can be held by more than one engine
+// with no arbitration between them. mulga-t1sch removes the second engine; the
+// invariant it establishes is "one owner per volume". This metric is how that
+// invariant is observed: opens for a single volume carrying two different pids
+// or roles are a dual-open. It is both the evidence for the current bug class
+// and the permanent regression alarm for the plan's end state -- after
+// t1sch lands, any such series is a regression.
+func RecordVolumeOpen(ctx context.Context, volume, role string) {
+	instruments()
+	if volumeOpens == nil {
+		return
+	}
+	attrs := []attribute.KeyValue{
+		attribute.Int("pid", os.Getpid()),
+		attribute.String("process", filepath.Base(os.Args[0])),
+	}
+	if volume != "" {
+		attrs = append(attrs, attribute.String("volume", volume))
+	}
+	if role != "" {
+		attrs = append(attrs, attribute.String("role", role))
+	}
+	volumeOpens.Add(ctx, 1, metric.WithAttributes(attrs...))
 }
 
 // RecordBackendIO records one backend chunk-object read or write: op count,

--- a/types/types.go
+++ b/types/types.go
@@ -14,6 +14,14 @@ import (
 // viperblock, so can't import it back).
 var ErrNoSpace = errors.New("viperblock: backend out of space")
 
+// ErrShortRead is returned when a backend answers a ranged read with fewer
+// bytes than were requested without reporting an error of its own. S3-style
+// backends clamp a range that runs past the end of an object into a short
+// 206 with a matching Content-Length, so nothing upstream notices; callers
+// would otherwise copy that short body into a zero-initialised buffer and
+// cache the zero-filled tail as though it were real data.
+var ErrShortRead = errors.New("viperblock: backend returned a short read")
+
 type Backend interface {
 	Init() error
 	InitCtx(ctx context.Context) error

--- a/viperblock/backends/s3/s3.go
+++ b/viperblock/backends/s3/s3.go
@@ -335,8 +335,18 @@ func (backend *Backend) ReadCtx(ctx context.Context, fileType types.FileType, ob
 		return nil, err
 	}
 
-	// The response should contain exactly the bytes we requested
-	// No slicing needed since we requested the exact range
+	// A ranged GET whose range starts inside the object but runs past its end
+	// is answered with a CLAMPED 206 -- a short body with a matching
+	// Content-Length, so io.ReadAll returns it without error. Callers copy the
+	// result into a full-size, zero-initialised buffer, so an unchecked short
+	// body becomes a silently zero-filled tail that is then cached as valid.
+	// Verified against predastore: asking for 1024 bytes past EOF returns
+	// exactly the available bytes with no error. Refuse it here instead.
+	if length > 0 && len(res) != int(length) {
+		return nil, fmt.Errorf("%w: %s offset %d: backend returned %d bytes, expected %d",
+			types.ErrShortRead, filename, offset, len(res), length)
+	}
+
 	return res, nil
 }
 

--- a/viperblock/dualopen_test.go
+++ b/viperblock/dualopen_test.go
@@ -1,0 +1,417 @@
+package viperblock
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/mulgadc/predastore/pkg/masterkey"
+	"github.com/mulgadc/viperblock/types"
+	"github.com/mulgadc/viperblock/viperblock/backends/s3"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests model the deployed topology: viperblock runs BOTH as the nbdkit
+// plugin (owning the guest data path) and as a library inside the spinifex
+// daemon, in a DIFFERENT PROCESS, against the SAME volume and the SAME shared
+// local BaseDir. Every guard viperblock has -- createChunkFile's SeqNum check,
+// drainMu, CanMultiConn=false -- is an in-process construct and is invisible
+// across that boundary. There is no lock file, lease, or handshake that
+// establishes ownership of a volume.
+//
+// Two independent *VB values in one test process are a faithful model: they
+// share no mutexes, no atomics and no maps, exactly like two processes.
+
+func dualOpenVB(t *testing.T, vol string, volSize uint64, baseDir string, key *masterkey.Key, chunkUpload time.Duration, cacheSize int) *VB {
+	t.Helper()
+	cfg := VB{
+		VolumeName:          vol,
+		VolumeSize:          volSize,
+		BaseDir:             baseDir,
+		WALSyncInterval:     -1,
+		ChunkUploadInterval: chunkUpload,
+		MaxPendingBytes:     2 * 1024 * 1024,
+		UploadWorkers:       4,
+		MasterKey:           key,
+		EncryptionEnabled:   key != nil,
+		Cache:               Cache{Config: CacheConfig{Size: cacheSize}},
+	}
+	bcfg := s3.S3Config{
+		VolumeName: vol, VolumeSize: volSize, Region: "ap-southeast-2",
+		Bucket: sharedBucket, AccessKey: AccessKey, SecretKey: SecretKey,
+		Host: fmt.Sprintf("https://%s", sharedServerHost), HTTPClient: testHTTPClient,
+	}
+	vb, err := New(&cfg, "s3", bcfg)
+	require.NoError(t, err)
+	require.NoError(t, vb.Backend.Init())
+	return vb
+}
+
+func openWALs(t *testing.T, vb *VB) {
+	t.Helper()
+	require.NoError(t, vb.OpenWAL(&vb.WAL, fmt.Sprintf("%s/%s", vb.WAL.BaseDir,
+		types.GetFilePath(types.FileTypeWALChunk, vb.WAL.WallNum.Load(), vb.GetVolume()))))
+	require.NoError(t, vb.OpenWAL(&vb.BlockToObjectWAL, fmt.Sprintf("%s/%s", vb.BlockToObjectWAL.BaseDir,
+		types.GetFilePath(types.FileTypeWALBlock, vb.BlockToObjectWAL.WallNum.Load(), vb.GetVolume()))))
+}
+
+func countRevertedBlocks(t *testing.T, want, got []byte, bs int) (int, string) {
+	t.Helper()
+	bad, detail := 0, ""
+	for b := 0; b*bs < len(want); b++ {
+		s, e := b*bs, (b+1)*bs
+		if bytes.Equal(want[s:e], got[s:e]) {
+			continue
+		}
+		bad++
+		if bad <= 5 {
+			lo, hi := -1, -1
+			for i := s; i < e; i++ {
+				if want[i] != got[i] {
+					if lo < 0 {
+						lo = i - s
+					}
+					hi = i - s
+				}
+			}
+			allZero := true
+			for i := s + lo; i <= s+hi; i++ {
+				if got[i] != 0 {
+					allZero = false
+					break
+				}
+			}
+			detail += fmt.Sprintf("\n  block %d (off %#x): bytes [%d,%d] wrong (%d), all-zero=%v",
+				b, s, lo, hi, hi-lo+1, allZero)
+		}
+	}
+	return bad, detail
+}
+
+// TestDualOpen_DaemonSideInstanceDuringGuestWrites models the ebs.mount
+// topology: the daemon holds a second VB on the volume for the lifetime of the
+// mount ("tracks state only"), while nbdkit serves guest writes. The daemon VB
+// stops its chunk uploader -- viperblockd does this deliberately, with the
+// comment "so it cannot overwrite the live checkpoint every 30s (AEAD
+// corruption)" -- so this asserts that mitigation actually holds.
+func TestDualOpen_DaemonSideInstanceDuringGuestWrites(t *testing.T) {
+	const volSize = 32 * 1024 * 1024
+	const total = 6 * 1024 * 1024
+	const piece = 3072
+
+	key := testKey(t, 0x42)
+	vol := fmt.Sprintf("dual-mount-%d", time.Now().UnixNano())
+	shared := t.TempDir() + "/viperblock" // daemon and nbdkit SHARE this
+
+	// nbdkit-role instance.
+	nbd := dualOpenVB(t, vol, volSize, shared, key, time.Millisecond, 4096)
+	require.NoError(t, nbd.SaveState())
+	require.NoError(t, nbd.EnsureVolumeUUID())
+	openWALs(t, nbd)
+
+	src := make([]byte, total)
+	for i := range src {
+		src[i] = byte(i*7 + 3)
+	}
+	// Seed and drain so there is a real block map on the backend.
+	require.NoError(t, nbd.WriteAt(0, append([]byte(nil), src...)))
+	require.NoError(t, nbd.DrainToBackend())
+
+	// Daemon-role instance opens the SAME volume, mid-flight.
+	daemon := dualOpenVB(t, vol, volSize, shared, key, 30*time.Second, 0)
+	daemon.StopChunkUploader() // what viperblockd does
+	require.NoError(t, daemon.LoadState())
+	require.NoError(t, daemon.LoadLiveCheckpoint())
+
+	// Guest keeps writing while the daemon instance is held open.
+	for off := 0; off < total; off += piece {
+		end := off + piece
+		if end > total {
+			end = total
+		}
+		for i := off; i < end; i++ {
+			src[i] = byte(i*13 + 101)
+		}
+		require.NoError(t, nbd.WriteAt(uint64(off), append([]byte(nil), src[off:end]...)))
+	}
+	require.NoError(t, nbd.DrainToBackend())
+
+	// Daemon instance goes away (unmount path).
+	daemon.StopWALSyncer()
+
+	nbd.StopChunkUploader()
+	require.NoError(t, nbd.Close())
+
+	cold := dualOpenVB(t, vol, volSize, t.TempDir()+"/viperblock", key, -1, 0)
+	require.NoError(t, cold.LoadState())
+	require.NoError(t, cold.LoadLiveCheckpoint())
+	got, err := cold.ReadAt(0, total)
+	require.NoError(t, err)
+	if bad, detail := countRevertedBlocks(t, src, got, int(cold.BlockSize)); bad > 0 {
+		t.Fatalf("DUAL-OPEN (mount topology): %d of %d blocks reverted%s",
+			bad, total/int(cold.BlockSize), detail)
+	}
+}
+
+// TestDualOpen_DaemonSnapshotDuringGuestWrites models snapshotVolume: the
+// daemon opens a second VB, loads the live checkpoint at some instant, and
+// calls CreateSnapshot -- which in viperblock runs WriteWALToChunk(true) then
+// SaveLiveCheckpoint, i.e. it WRITES the source volume's live checkpoint from
+// a map loaded earlier, from another process, while nbdkit keeps writing.
+//
+// Note viperblock.New STARTS the chunk uploader, and snapshotVolume only
+// defers StopChunkUploader to function exit, so the daemon-side uploader is
+// live for the whole body -- including a socket handshake with a 30s deadline.
+func TestDualOpen_DaemonSnapshotDuringGuestWrites(t *testing.T) {
+	const volSize = 32 * 1024 * 1024
+	const total = 6 * 1024 * 1024
+	const piece = 3072
+
+	key := testKey(t, 0x42)
+	vol := fmt.Sprintf("dual-snap-%d", time.Now().UnixNano())
+	shared := t.TempDir() + "/viperblock"
+
+	nbd := dualOpenVB(t, vol, volSize, shared, key, time.Millisecond, 4096)
+	require.NoError(t, nbd.SaveState())
+	require.NoError(t, nbd.EnsureVolumeUUID())
+	openWALs(t, nbd)
+
+	src := make([]byte, total)
+	for i := range src {
+		src[i] = byte(i*5 + 11)
+	}
+	require.NoError(t, nbd.WriteAt(0, append([]byte(nil), src...)))
+	require.NoError(t, nbd.DrainToBackend())
+
+	// Daemon opens and snapshots the map AS OF NOW.
+	daemon := dualOpenVB(t, vol, volSize, shared, key, 30*time.Second, 0)
+	require.NoError(t, daemon.LoadState())
+	require.NoError(t, daemon.LoadLiveCheckpoint())
+
+	// Guest writes land AFTER the daemon captured its map.
+	for off := 0; off < total; off += piece {
+		end := off + piece
+		if end > total {
+			end = total
+		}
+		for i := off; i < end; i++ {
+			src[i] = byte(i*17 + 29)
+		}
+		require.NoError(t, nbd.WriteAt(uint64(off), append([]byte(nil), src[off:end]...)))
+	}
+	require.NoError(t, nbd.DrainToBackend())
+
+	// Now the daemon publishes, from its stale map. This is the cross-process
+	// stale checkpoint publish.
+	_, err := daemon.CreateSnapshot(fmt.Sprintf("snap-%d", time.Now().UnixNano()))
+	require.NoError(t, err)
+	daemon.StopChunkUploader()
+	daemon.StopWALSyncer()
+
+	nbd.StopChunkUploader()
+	require.NoError(t, nbd.Close())
+
+	cold := dualOpenVB(t, vol, volSize, t.TempDir()+"/viperblock", key, -1, 0)
+	require.NoError(t, cold.LoadState())
+	require.NoError(t, cold.LoadLiveCheckpoint())
+	got, err := cold.ReadAt(0, total)
+	require.NoError(t, err)
+	if bad, detail := countRevertedBlocks(t, src, got, int(cold.BlockSize)); bad > 0 {
+		t.Fatalf("DUAL-OPEN (snapshot topology): %d of %d blocks reverted%s",
+			bad, total/int(cold.BlockSize), detail)
+	}
+}
+
+// TestDualOpen_DaemonRemovesSharedLocalFiles models cloneAMIToVolume, which
+// ends in destVb.RemoveLocalFiles() -- an os.RemoveAll of
+// {BaseDir}/{volume}. viperblockd and nbdkit SHARE that BaseDir (viperblockd
+// itself notes "no process writes the shared BaseDir"), so if this lands while
+// nbdkit holds that volume open, it deletes the live WAL out from under it.
+func TestDualOpen_DaemonRemovesSharedLocalFiles(t *testing.T) {
+	const volSize = 32 * 1024 * 1024
+	const total = 4 * 1024 * 1024
+	const piece = 3072
+
+	key := testKey(t, 0x42)
+	vol := fmt.Sprintf("dual-rm-%d", time.Now().UnixNano())
+	shared := t.TempDir() + "/viperblock"
+
+	nbd := dualOpenVB(t, vol, volSize, shared, key, time.Hour, 4096) // no auto-drain
+	require.NoError(t, nbd.SaveState())
+	require.NoError(t, nbd.EnsureVolumeUUID())
+	openWALs(t, nbd)
+
+	src := make([]byte, total)
+	for i := range src {
+		src[i] = byte(i*3 + 7)
+	}
+	// Guest writes sit in the WAL, NOT yet drained to chunks.
+	for off := 0; off < total; off += piece {
+		end := off + piece
+		if end > total {
+			end = total
+		}
+		require.NoError(t, nbd.WriteAt(uint64(off), append([]byte(nil), src[off:end]...)))
+	}
+	require.NoError(t, nbd.Flush()) // durable in the local WAL
+
+	// Daemon-side clone of a DIFFERENT volume finishing its work wipes the
+	// shared local dir for this one.
+	daemon := dualOpenVB(t, vol, volSize, shared, key, -1, 0)
+	require.NoError(t, daemon.RemoveLocalFiles())
+
+	// nbdkit now drains what it believes is durable. The data is gone either
+	// way -- the point of this test is that the loss must be SURFACED, never
+	// silent. Silent loss here would be indistinguishable from the siv-482
+	// field signature.
+	drainErr := nbd.DrainToBackend()
+	t.Logf("nbdkit drain after daemon wiped the shared WAL dir: err=%v", drainErr)
+	nbd.StopChunkUploader()
+	closeErr := nbd.Close()
+	t.Logf("nbdkit close: err=%v", closeErr)
+
+	require.True(t, drainErr != nil || closeErr != nil,
+		"daemon deleted nbdkit's live WAL directory out from under it and NEITHER "+
+			"the drain nor the close reported an error -- acknowledged writes would be "+
+			"lost silently")
+}
+
+// TestDualOpen_LaunchClonePathDoesNotDirtyCheckpoint is the decisive test for
+// mulga-t1sch's load-bearing claim:
+//
+//	"Today this does not corrupt only because SaveLiveCheckpointCtx is
+//	 dirty-gated and the snapshot instance never writes."
+//
+// The plan reasons about the SNAPSHOT path. env19's sink evidence is about
+// instance LAUNCH (handlers/ec2/instance/service_impl.go:1387 ->
+// cloneAMIToVolume -> OpenFromSnapshot). This drives that path: a daemon-role
+// instance runs the launch/clone sequence on a volume an nbdkit-role instance
+// is actively serving, with its chunk uploader RUNNING, and is then forced to
+// drain -- modelling the uploader firing before the deferred StopChunkUploader.
+//
+// It asserts the dirty gate actually holds on the launch path, i.e. that the
+// daemon-side instance publishes NO live checkpoint and reverts nothing.
+func TestDualOpen_LaunchClonePathDoesNotDirtyCheckpoint(t *testing.T) {
+	const volSize = 32 * 1024 * 1024
+	const total = 4 * 1024 * 1024
+	const piece = 3072
+
+	key := testKey(t, 0x42)
+	stamp := time.Now().UnixNano()
+	srcVol := fmt.Sprintf("launch-src-%d", stamp)
+	cloneVol := fmt.Sprintf("launch-clone-%d", stamp)
+	snapID := fmt.Sprintf("snap-launch-%d", stamp)
+	shared := t.TempDir() + "/viperblock"
+
+	// Build a source volume and snapshot it, so there is a real clone base.
+	src := dualOpenVB(t, srcVol, volSize, t.TempDir()+"/viperblock", key, -1, 0)
+	require.NoError(t, src.SaveState())
+	require.NoError(t, src.EnsureVolumeUUID())
+	openWALs(t, src)
+	seed := make([]byte, total)
+	for i := range seed {
+		seed[i] = byte(i*11 + 5)
+	}
+	require.NoError(t, src.WriteAt(0, append([]byte(nil), seed...)))
+	require.NoError(t, src.DrainToBackend())
+	_, err := src.CreateSnapshot(snapID)
+	require.NoError(t, err)
+	src.StopChunkUploader()
+	require.NoError(t, src.Close())
+
+	// nbdkit-role instance materialises the clone and serves guest writes.
+	nbd := dualOpenVB(t, cloneVol, volSize, shared, key, time.Millisecond, 4096)
+	require.NoError(t, nbd.OpenFromSnapshot(snapID))
+	require.NoError(t, nbd.SaveState())
+	require.NoError(t, nbd.EnsureVolumeUUID())
+	openWALs(t, nbd)
+
+	want := append([]byte(nil), seed...)
+	for off := 0; off < total; off += piece {
+		end := off + piece
+		if end > total {
+			end = total
+		}
+		for i := off; i < end; i++ {
+			want[i] = byte(i*23 + 91)
+		}
+		require.NoError(t, nbd.WriteAt(uint64(off), append([]byte(nil), want[off:end]...)))
+	}
+	require.NoError(t, nbd.DrainToBackend())
+
+	// Daemon-role instance runs the LAUNCH path on the same volume. New()
+	// starts a chunk uploader; prepareRootVolume/cloneAMIToVolume only defer
+	// the stop, so it is live for the whole body.
+	daemon := dualOpenVB(t, cloneVol, volSize, shared, key, time.Millisecond, 0)
+	// New() has ALREADY started a chunk uploader at this point. Stopping it
+	// before LoadState mirrors what viperblockd's ebs.mount path does
+	// (viperblockd.go:773) and, separately, avoids a PRE-EXISTING data race:
+	// the uploader's DrainToBackendCtx reads VB fields that LoadStateCtx
+	// concurrently writes. The five control-plane call sites the EBSProvider
+	// plan (mulga-t1sch) removes do NOT stop it first -- they only defer the
+	// stop -- so they run that race for real. See
+	// TestNewStartsUploaderBeforeLoadState_KnownRace.
+	daemon.StopChunkUploader()
+	require.NoError(t, daemon.LoadState()) // triggers OpenFromSnapshot internally
+
+	dirtyAfterLoad := daemon.BlocksToObject.dirty.Load()
+	t.Logf("daemon-side BlocksToObject.dirty after launch-path LoadState = %v", dirtyAfterLoad)
+
+	// Worst case: force the drain the background uploader would have run.
+	require.NoError(t, daemon.DrainToBackendCtx(t.Context()))
+	dirtyAfterDrain := daemon.BlocksToObject.dirty.Load()
+	t.Logf("daemon-side BlocksToObject.dirty after forced drain = %v", dirtyAfterDrain)
+
+	daemon.StopChunkUploader()
+	daemon.StopWALSyncer()
+
+	nbd.StopChunkUploader()
+	require.NoError(t, nbd.Close())
+
+	cold := dualOpenVB(t, cloneVol, volSize, t.TempDir()+"/viperblock", key, -1, 0)
+	require.NoError(t, cold.LoadState())
+	require.NoError(t, cold.LoadLiveCheckpoint())
+	got, err := cold.ReadAt(0, total)
+	require.NoError(t, err)
+
+	if bad, detail := countRevertedBlocks(t, want, got, int(cold.BlockSize)); bad > 0 {
+		t.Fatalf("LAUNCH-PATH DUAL-OPEN: daemon-side clone instance reverted %d of %d blocks "+
+			"-- the dirty gate does NOT hold on the launch path%s",
+			bad, total/int(cold.BlockSize), detail)
+	}
+	require.False(t, dirtyAfterLoad,
+		"launch-path LoadState dirtied the block map: the dirty gate would let a "+
+			"daemon-side instance publish a stale live checkpoint")
+}
+
+// TestNewStartsUploaderBeforeLoadState_KnownRace documents a PRE-EXISTING data
+// race, unrelated to the RMW work: viperblock.New() starts the background chunk
+// uploader before the caller can call LoadState(), so the uploader's
+// DrainToBackendCtx reads VB fields (UseShardedWAL, SeqNum, ObjectNum,
+// VolumeUUID, ...) while LoadStateCtx is still writing them.
+//
+// It reproduces on a pristine tree; run with -race and remove the Skip:
+//
+//	WARNING: DATA RACE
+//	  ...LoadStateCtx()            <- write
+//	  Previous read ...DrainToBackendCtx() <- StartChunkUploader.func1()
+//
+// This is direct evidence for mulga-t1sch's thesis that every viperblock.New()
+// is a WRITER, not a reader. viperblockd's ebs.mount path happens to be safe
+// because it calls StopChunkUploader() BEFORE loading state; the five
+// control-plane handlers the plan deletes only DEFER the stop, so they hold a
+// live uploader across their whole body.
+func TestNewStartsUploaderBeforeLoadState_KnownRace(t *testing.T) {
+	t.Skip("KNOWN PRE-EXISTING RACE (evidence for mulga-t1sch): New() starts the " +
+		"chunk uploader before LoadState() can run. Remove this Skip and run with " +
+		"-race to observe it.")
+
+	key := testKey(t, 0x42)
+	vol := fmt.Sprintf("newrace-%d", time.Now().UnixNano())
+	vb := dualOpenVB(t, vol, 32*1024*1024, t.TempDir()+"/viperblock", key, time.Millisecond, 0)
+	require.NoError(t, vb.SaveState())
+	// Uploader is already running here; LoadState races it.
+	require.NoError(t, vb.LoadState())
+	vb.StopChunkUploader()
+}

--- a/viperblock/rmw_lostupdate_test.go
+++ b/viperblock/rmw_lostupdate_test.go
@@ -1,0 +1,156 @@
+package viperblock
+
+import (
+	"bytes"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/mulgadc/viperblock/types"
+	"github.com/mulgadc/viperblock/viperblock/backends/file"
+	"github.com/stretchr/testify/require"
+)
+
+// newRMWVB is a minimal local VB (file backend, no background drains) so the
+// test isolates WriteAtCtx's read-modify-write and nothing else.
+func newRMWVB(t *testing.T) *VB {
+	t.Helper()
+	root := t.TempDir()
+	vol := fmt.Sprintf("rmw-%d", time.Now().UnixNano())
+	cfg := VB{
+		VolumeName:          vol,
+		VolumeSize:          8 * 1024 * 1024,
+		BaseDir:             root + "/viperblock",
+		WALSyncInterval:     -1,
+		ChunkUploadInterval: -1,
+		Cache:               Cache{Config: CacheConfig{Size: 0}},
+	}
+	vb, err := New(&cfg, FileBackend, file.FileConfig{
+		VolumeName: vol, VolumeSize: 8 * 1024 * 1024, BaseDir: root,
+	})
+	require.NoError(t, err)
+	require.NoError(t, vb.Backend.Init())
+	require.NoError(t, vb.OpenWAL(&vb.WAL, fmt.Sprintf("%s/%s", vb.WAL.BaseDir,
+		types.GetFilePath(types.FileTypeWALChunk, vb.WAL.WallNum.Load(), vb.GetVolume()))))
+	require.NoError(t, vb.OpenWAL(&vb.BlockToObjectWAL, fmt.Sprintf("%s/%s", vb.BlockToObjectWAL.BaseDir,
+		types.GetFilePath(types.FileTypeWALBlock, vb.BlockToObjectWAL.WallNum.Load(), vb.GetVolume()))))
+	return vb
+}
+
+// TestRMW_ConcurrentSubBlockWritesLoseAnUpdate drives two concurrent writes to
+// DISJOINT halves of the SAME 4096-byte block -- the shape a guest filesystem
+// produces whenever its block boundaries do not line up with viperblock's, so
+// two adjacent page writebacks land inside one viperblock block.
+//
+// WriteAtCtx handles a sub-block write by reading the current block, splicing
+// the new bytes in, and appending a whole new 4096-byte block. That read and
+// the append are NOT performed under a common lock, so two writers can both
+// read generation N, each splice their own half, and append; the higher SeqNum
+// wins wholesale and the other writer's bytes are silently discarded.
+//
+// The surviving block is byte-exact with generation N over exactly the range
+// the losing write covered -- the reported signature.
+func TestRMW_ConcurrentSubBlockWritesLoseAnUpdate(t *testing.T) {
+	t.Skip("KNOWN FAILING (mulga-siv-482): WriteAtCtx's read-modify-write is not " +
+		"atomic per block. Remove this Skip to see it red -- that is the acceptance " +
+		"criterion for the fix. Measured 24% loss over 200 forced-race rounds at 054a44a.")
+
+	vb := newRMWVB(t)
+	bs := int(vb.BlockSize)
+	half := bs / 2
+
+	// Generation N: the whole block is 0x11.
+	gen0 := bytes.Repeat([]byte{0x11}, bs)
+	require.NoError(t, vb.WriteAt(0, append([]byte(nil), gen0...)))
+
+	lower := bytes.Repeat([]byte{0xAA}, half) // written to [0, 2048)
+	upper := bytes.Repeat([]byte{0xBB}, half) // written to [2048, 4096)
+
+	// Release both writers at once so their RMW reads overlap.
+	var start sync.WaitGroup
+	start.Add(1)
+	var done sync.WaitGroup
+	errs := make([]error, 2)
+
+	done.Add(2)
+	go func() {
+		defer done.Done()
+		start.Wait()
+		errs[0] = vb.WriteAt(0, append([]byte(nil), lower...))
+	}()
+	go func() {
+		defer done.Done()
+		start.Wait()
+		errs[1] = vb.WriteAt(uint64(half), append([]byte(nil), upper...))
+	}()
+	start.Done()
+	done.Wait()
+	require.NoError(t, errs[0])
+	require.NoError(t, errs[1])
+
+	got, err := vb.ReadAt(0, uint64(bs))
+	require.NoError(t, err)
+
+	lowerOK := bytes.Equal(got[:half], lower)
+	upperOK := bytes.Equal(got[half:], upper)
+	lowerReverted := bytes.Equal(got[:half], gen0[:half])
+	upperReverted := bytes.Equal(got[half:], gen0[half:])
+
+	t.Logf("lower half correct=%v reverted-to-previous-generation=%v", lowerOK, lowerReverted)
+	t.Logf("upper half correct=%v reverted-to-previous-generation=%v", upperOK, upperReverted)
+
+	if !lowerOK || !upperOK {
+		t.Fatalf("LOST UPDATE: two concurrent sub-block writes to the same block, "+
+			"only one survived (lowerOK=%v upperOK=%v); the losing write's range is "+
+			"byte-exact with the previous generation (lowerReverted=%v upperReverted=%v)",
+			lowerOK, upperOK, lowerReverted, upperReverted)
+	}
+}
+
+// TestRMW_ConcurrentSubBlockWrites_Repeated runs the same race repeatedly to
+// show how readily it lands, and reports the observed loss rate.
+func TestRMW_ConcurrentSubBlockWrites_Repeated(t *testing.T) {
+	t.Skip("KNOWN FAILING (mulga-siv-482): WriteAtCtx's read-modify-write is not " +
+		"atomic per block. Remove this Skip to see it red -- that is the acceptance " +
+		"criterion for the fix. Measured 24% loss over 200 forced-race rounds at 054a44a.")
+
+	const rounds = 200
+	lost := 0
+
+	for r := range rounds {
+		vb := newRMWVB(t)
+		bs := int(vb.BlockSize)
+		half := bs / 2
+
+		gen0 := bytes.Repeat([]byte{0x11}, bs)
+		require.NoError(t, vb.WriteAt(0, append([]byte(nil), gen0...)))
+
+		lower := bytes.Repeat([]byte{byte(0xA0 + r%16)}, half)
+		upper := bytes.Repeat([]byte{byte(0xB0 + r%16)}, half)
+
+		var start sync.WaitGroup
+		start.Add(1)
+		var done sync.WaitGroup
+		done.Add(2)
+		go func() { defer done.Done(); start.Wait(); _ = vb.WriteAt(0, append([]byte(nil), lower...)) }()
+		go func() {
+			defer done.Done()
+			start.Wait()
+			_ = vb.WriteAt(uint64(half), append([]byte(nil), upper...))
+		}()
+		start.Done()
+		done.Wait()
+
+		got, err := vb.ReadAt(0, uint64(bs))
+		require.NoError(t, err)
+		if !bytes.Equal(got[:half], lower) || !bytes.Equal(got[half:], upper) {
+			lost++
+		}
+	}
+
+	t.Logf("lost updates: %d of %d rounds (%.1f%%)", lost, rounds, 100*float64(lost)/float64(rounds))
+	if lost > 0 {
+		t.Fatalf("LOST UPDATE reproduced in %d of %d rounds", lost, rounds)
+	}
+}

--- a/viperblock/rmw_lostupdate_test.go
+++ b/viperblock/rmw_lostupdate_test.go
@@ -52,10 +52,6 @@ func newRMWVB(t *testing.T) *VB {
 // The surviving block is byte-exact with generation N over exactly the range
 // the losing write covered -- the reported signature.
 func TestRMW_ConcurrentSubBlockWritesLoseAnUpdate(t *testing.T) {
-	t.Skip("KNOWN FAILING (mulga-siv-482): WriteAtCtx's read-modify-write is not " +
-		"atomic per block. Remove this Skip to see it red -- that is the acceptance " +
-		"criterion for the fix. Measured 24% loss over 200 forced-race rounds at 054a44a.")
-
 	vb := newRMWVB(t)
 	bs := int(vb.BlockSize)
 	half := bs / 2
@@ -111,10 +107,6 @@ func TestRMW_ConcurrentSubBlockWritesLoseAnUpdate(t *testing.T) {
 // TestRMW_ConcurrentSubBlockWrites_Repeated runs the same race repeatedly to
 // show how readily it lands, and reports the observed loss rate.
 func TestRMW_ConcurrentSubBlockWrites_Repeated(t *testing.T) {
-	t.Skip("KNOWN FAILING (mulga-siv-482): WriteAtCtx's read-modify-write is not " +
-		"atomic per block. Remove this Skip to see it red -- that is the acceptance " +
-		"criterion for the fix. Measured 24% loss over 200 forced-race rounds at 054a44a.")
-
 	const rounds = 200
 	lost := 0
 

--- a/viperblock/short_read_test.go
+++ b/viperblock/short_read_test.go
@@ -1,0 +1,125 @@
+package viperblock
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"testing"
+
+	"github.com/mulgadc/viperblock/types"
+	"github.com/mulgadc/viperblock/viperblock/backends/file"
+	"github.com/stretchr/testify/require"
+)
+
+// truncatingBackend wraps a real backend and shortens the answer to one
+// specific ranged chunk read, reproducing what an S3-style backend does when a
+// range starts inside an object but runs past its end: the server clamps the
+// range and answers with a short 206 whose Content-Length matches the short
+// body, so nothing in the HTTP stack reports an error.
+//
+// Verified against a live predastore: requesting 1024 bytes past the end of a
+// chunk returns exactly the available bytes with err == nil. (A range whose
+// START is past the end is a loud 416 instead, which needs no defending.)
+type truncatingBackend struct {
+	types.Backend
+	trimChunk uint64
+	trimBytes int
+	fired     bool
+}
+
+func (b *truncatingBackend) ReadCtx(ctx context.Context, fileType types.FileType, objectID uint64, offset, length uint32) ([]byte, error) {
+	data, err := b.Backend.ReadCtx(ctx, fileType, objectID, offset, length)
+	if err != nil {
+		return nil, err
+	}
+	if fileType == types.FileTypeChunk && objectID == b.trimChunk && length > 0 &&
+		len(data) > b.trimBytes && int(length) == len(data) {
+		b.fired = true
+		return data[:len(data)-b.trimBytes], nil
+	}
+	return data, nil
+}
+
+func (b *truncatingBackend) Read(fileType types.FileType, objectID uint64, offset, length uint32) ([]byte, error) {
+	return b.ReadCtx(context.Background(), fileType, objectID, offset, length)
+}
+
+// TestShortBackendRead_IsRefusedNotZeroFilled pins that a silently short
+// backend read is surfaced as an error rather than copied into a
+// zero-initialised buffer and handed back (and cached) as real data.
+//
+// Before the length check this returned success with the trailing bytes of the
+// run replaced by zeros — the exact shape of the corruption reported in
+// siv-482: a 4096-byte block whose trailing 1024 bytes are zeroed, with no
+// error surfaced anywhere. The encrypted path was already protected by
+// openChunkRun's ciphertext-length check; only cleartext volumes were exposed.
+func TestShortBackendRead_IsRefusedNotZeroFilled(t *testing.T) {
+	root := t.TempDir()
+	const vol = "vol-short-read"
+	const volSize = 8 * 1024 * 1024
+
+	backendConfig := file.FileConfig{VolumeName: vol, VolumeSize: volSize, BaseDir: root}
+	vbconfig := VB{
+		VolumeName:          vol,
+		VolumeSize:          volSize,
+		BaseDir:             fmt.Sprintf("%s/viperblock", root),
+		WALSyncInterval:     -1,
+		ChunkUploadInterval: -1,
+		Cache:               Cache{Config: CacheConfig{Size: 0}},
+	}
+
+	vb, err := New(&vbconfig, FileBackend, backendConfig)
+	require.NoError(t, err)
+	require.NoError(t, vb.Backend.Init())
+	require.NoError(t, vb.OpenWAL(&vb.WAL, fmt.Sprintf("%s/%s", vb.WAL.BaseDir,
+		types.GetFilePath(types.FileTypeWALChunk, vb.WAL.WallNum.Load(), vb.GetVolume()))))
+	require.NoError(t, vb.OpenWAL(&vb.BlockToObjectWAL, fmt.Sprintf("%s/%s", vb.BlockToObjectWAL.BaseDir,
+		types.GetFilePath(types.FileTypeWALBlock, vb.BlockToObjectWAL.WallNum.Load(), vb.GetVolume()))))
+
+	bs := int(vb.BlockSize)
+	const nBlocks = 8
+	payload := make([]byte, nBlocks*bs)
+	rnd := rand.New(rand.NewSource(4242)) //nolint:gosec // G404: deterministic test fixture
+	_, err = rnd.Read(payload)
+	require.NoError(t, err)
+
+	require.NoError(t, vb.WriteAt(0, append([]byte(nil), payload...)))
+	require.NoError(t, vb.DrainToBackend())
+
+	objectID, _, _, err := vb.LookupBlockToObject(0)
+	require.NoError(t, err)
+
+	// Swap in the truncating backend and drop every in-memory copy so the read
+	// has to come from the backend.
+	trunc := &truncatingBackend{Backend: vb.Backend, trimChunk: objectID, trimBytes: 1024}
+	vb.Backend = trunc
+	vb.BlockStore.Clear()
+	vb.Writes.mu.Lock()
+	vb.Writes.Blocks = nil
+	vb.Writes.mu.Unlock()
+	vb.PendingBackendWrites.mu.Lock()
+	vb.PendingBackendWrites.Blocks = nil
+	vb.PendingBackendWrites.mu.Unlock()
+	require.NoError(t, vb.LoadLiveCheckpoint())
+
+	got, readErr := vb.ReadAt(0, uint64(nBlocks*bs))
+	require.True(t, trunc.fired, "test did not actually inject a short read")
+
+	if readErr == nil {
+		lastTail := got[nBlocks*bs-1024:]
+		allZero := true
+		for _, b := range lastTail {
+			if b != 0 {
+				allZero = false
+				break
+			}
+		}
+		t.Fatalf("a short backend read was accepted silently: read succeeded, "+
+			"trailing 1024 bytes all-zero=%v, data correct=%v",
+			allZero, bytes.Equal(payload, got))
+	}
+
+	require.ErrorIs(t, readErr, types.ErrShortRead,
+		"a short backend read must surface as ErrShortRead, not be zero-filled")
+}

--- a/viperblock/snapshot.go
+++ b/viperblock/snapshot.go
@@ -58,6 +58,54 @@ type InheritedLayer struct {
 	SourceVolumeNameHash [32]byte
 }
 
+// drainForSnapshot runs the flush -> WriteWALToChunk -> SaveLiveCheckpoint
+// sequence that gets the source volume fully persisted before its map is
+// frozen into a snapshot. That sequence is a drain in all but name, so it
+// holds drainMu for exactly the same reason DrainToBackendCtx does (see
+// drainMu's doc comment): two overlapping drains rotate different WAL
+// segments and can publish their live checkpoints out of order, leaving the
+// older map on the backend. The volume then boots pointing blocks at
+// superseded chunks and cold reads hand back stale bytes with no error
+// anywhere -- the durability half of the stale-drain repoint hazard.
+//
+// Scoped to its own function rather than deferred inside CreateSnapshot so
+// the lock is released before the (potentially slow) snapshot checkpoint
+// serialization and upload, which no drain contends with.
+func (vb *VB) drainForSnapshot() error {
+	vb.drainMu.Lock()
+	defer vb.drainMu.Unlock()
+
+	// Writes.mu is taken inside drainMu, matching DrainToBackendCtx's order.
+	vb.Writes.mu.Lock()
+	var flushErr error
+	if vb.UseShardedWAL {
+		flushErr = vb.flushLockedSharded()
+	} else {
+		flushErr = vb.flushLocked()
+	}
+	vb.Writes.mu.Unlock()
+	if flushErr != nil {
+		return fmt.Errorf("snapshot flush failed: %w", flushErr)
+	}
+
+	// Persist WAL to chunk files on backend (potentially slow S3 upload,
+	// no need to hold the write lock -- new writes go to the next WAL file)
+	if err := vb.WriteWALToChunk(true); err != nil {
+		return fmt.Errorf("snapshot WAL-to-chunk failed: %w", err)
+	}
+
+	// Chunk uploads no longer refresh the live checkpoint per-chunk (that
+	// was a parallel-upload hazard, see createChunkFile). Refresh it once
+	// here so the source volume's live checkpoint reflects the chunks just
+	// uploaded, same as DrainToBackendCtx does after its own drain.
+	// Non-fatal: a stale live checkpoint self-heals on the next drain.
+	if err := vb.SaveLiveCheckpoint(); err != nil {
+		vb.logger().Warn("CreateSnapshot: SaveLiveCheckpoint failed", "err", err)
+	}
+
+	return nil
+}
+
 // CreateSnapshot flushes all in-flight data and creates a frozen snapshot of
 // the current block-to-object mapping. The snapshot is stored on the backend
 // under {snapshotID}/. No data is copied -- the snapshot references the
@@ -77,31 +125,8 @@ func (vb *VB) CreateSnapshot(snapshotID string) (*SnapshotState, error) {
 	// Skip if this VB doesn't own the WAL files (e.g. viperblockd snapshot VB
 	// where the NBD plugin process owns the WAL).
 	if vb.ownsWAL() {
-		vb.Writes.mu.Lock()
-		var flushErr error
-		if vb.UseShardedWAL {
-			flushErr = vb.flushLockedSharded()
-		} else {
-			flushErr = vb.flushLocked()
-		}
-		vb.Writes.mu.Unlock()
-		if flushErr != nil {
-			return nil, fmt.Errorf("snapshot flush failed: %w", flushErr)
-		}
-
-		// Persist WAL to chunk files on backend (potentially slow S3 upload,
-		// no need to hold the write lock — new writes go to the next WAL file)
-		if err := vb.WriteWALToChunk(true); err != nil {
-			return nil, fmt.Errorf("snapshot WAL-to-chunk failed: %w", err)
-		}
-
-		// Chunk uploads no longer refresh the live checkpoint per-chunk (that
-		// was a parallel-upload hazard, see createChunkFile). Refresh it once
-		// here so the source volume's live checkpoint reflects the chunks
-		// just uploaded, same as DrainToBackendCtx does after its own drain.
-		// Non-fatal: a stale live checkpoint self-heals on the next drain.
-		if err := vb.SaveLiveCheckpoint(); err != nil {
-			vb.logger().Warn("CreateSnapshot: SaveLiveCheckpoint failed", "err", err)
+		if err := vb.drainForSnapshot(); err != nil {
+			return nil, err
 		}
 	}
 

--- a/viperblock/stale_drain_durability_test.go
+++ b/viperblock/stale_drain_durability_test.go
@@ -1,0 +1,189 @@
+package viperblock
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/mulgadc/viperblock/types"
+	"github.com/mulgadc/viperblock/viperblock/backends/file"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests pin the durability half of the stale-drain repoint hazard
+// (mulga-siv-482). TestChunkGC_StaleDrainNeverClobbersNewerChunk already
+// covers the in-memory BlocksToObject map, but it deliberately sets
+// UseBlockStore = false and never reopens the volume. The field corruption
+// only became visible on a COLD read — after the live checkpoint was
+// persisted and a fresh process loaded it — so the property that actually
+// matters is that the newest bytes survive a checkpoint round-trip, with
+// UseBlockStore left at its production default.
+
+// TestStaleDrain_ColdReopenPreservesNewestBytes drives the exact out-of-order
+// boundary deterministically: two chunk uploads for the same block where the
+// OLDER drain's block-map write lands last. The volume is then checkpointed
+// and reopened from scratch. Without createChunkFile's monotonic SeqNum
+// guard, the persisted checkpoint points the block at the stale chunk and the
+// cold read hands back superseded data with no error anywhere.
+func TestStaleDrain_ColdReopenPreservesNewestBytes(t *testing.T) {
+	root := t.TempDir()
+	const vol = "vol-stale-drain-cold-reopen"
+
+	vb := newGCTestVB(t, root, vol, false)
+	ctx := context.Background()
+	bs := int(vb.BlockSize)
+
+	newer := bytes.Repeat([]byte{0xA5}, bs)
+	stale := bytes.Repeat([]byte{0x5C}, bs)
+
+	// The newer write (higher SeqNum) is uploaded and mapped first.
+	newerBuf := append([]byte(nil), newer...)
+	newerMatched := []Block{{Block: 0, SeqNum: 20, Len: uint64(bs)}}
+	require.NoError(t, vb.createChunkFile(ctx, 0, &newerBuf, &newerMatched))
+
+	// A slower, OLDER drain for the same block completes second. Its map
+	// write must be rejected, not applied.
+	staleBuf := append([]byte(nil), stale...)
+	staleMatched := []Block{{Block: 0, SeqNum: 10, Len: uint64(bs)}}
+	require.NoError(t, vb.createChunkFile(ctx, 0, &staleBuf, &staleMatched))
+
+	// Publish volume config + the live checkpoint, then boot a fresh VB.
+	require.NoError(t, vb.SaveState())
+	require.NoError(t, vb.SaveLiveCheckpoint())
+
+	reopened := reopenGCTestVB(t, root, vol, false)
+	got, err := reopened.ReadAt(0, uint64(bs))
+	require.NoError(t, err)
+
+	require.Equalf(t, newer, got,
+		"cold read returned superseded data: the stale drain's map write was persisted into the live checkpoint (first byte got=%#x want=%#x)",
+		got[0], newer[0])
+}
+
+// TestSequentialPartialWrites_ColdReopenByteExact is the field-shaped
+// regression: ONE sequential writer, no concurrency in the guest, issuing
+// sub-block (3072-byte) writes so that every 4096-byte block is assembled by
+// the WriteAtCtx read-modify-write path across two successive writes. Chunk
+// drains run in the background underneath, exactly as they do under nbdkit.
+// After a clean Close the volume is reopened cold and compared byte-for-byte.
+//
+// This is the shape that produced the reported signature: a block whose tail
+// bytes revert to a previous generation (zeros on a never-written region,
+// otherwise whatever the superseded chunk held at that offset — which is how
+// deleted-file contents leaked back into readable data).
+func TestSequentialPartialWrites_ColdReopenByteExact(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping multi-megabyte durability round-trip in -short mode")
+	}
+
+	const volSize = 128 * 1024 * 1024
+	const total = 32 * 1024 * 1024
+	const piece = 3072 // sub-block: forces RMW on every block boundary
+
+	root := t.TempDir()
+	const vol = "vol-sequential-partial-writes"
+
+	backendConfig := file.FileConfig{VolumeName: vol, VolumeSize: volSize, BaseDir: root}
+	vbconfig := VB{
+		VolumeName:      vol,
+		VolumeSize:      volSize,
+		BaseDir:         fmt.Sprintf("%s/viperblock", root),
+		WALSyncInterval: -1,
+		// Drain often and in parallel so chunk uploads interleave with the
+		// writer, as they do in production.
+		ChunkUploadInterval: time.Millisecond,
+		MaxPendingBytes:     2 * 1024 * 1024,
+		UploadWorkers:       4,
+		GCEnabled:           true,
+		GCInterval:          5 * time.Millisecond,
+		Cache:               Cache{Config: CacheConfig{Size: 0}},
+	}
+
+	vb, err := New(&vbconfig, FileBackend, backendConfig)
+	require.NoError(t, err)
+	require.NoError(t, vb.Backend.Init())
+	require.NoError(t, vb.OpenWAL(&vb.WAL, fmt.Sprintf("%s/%s", vb.WAL.BaseDir,
+		types.GetFilePath(types.FileTypeWALChunk, vb.WAL.WallNum.Load(), vb.GetVolume()))))
+	require.NoError(t, vb.OpenWAL(&vb.BlockToObjectWAL, fmt.Sprintf("%s/%s", vb.BlockToObjectWAL.BaseDir,
+		types.GetFilePath(types.FileTypeWALBlock, vb.BlockToObjectWAL.WallNum.Load(), vb.GetVolume()))))
+
+	src := make([]byte, total)
+	rnd := rand.New(rand.NewSource(20260721)) //nolint:gosec // G404: deterministic test fixture, not security material
+	_, err = rnd.Read(src)
+	require.NoError(t, err)
+
+	// Pass 1: strictly sequential fill.
+	for off := 0; off < total; off += piece {
+		end := min(off+piece, total)
+		require.NoError(t, vb.WriteAt(uint64(off), append([]byte(nil), src[off:end]...)))
+	}
+
+	// Pass 2: rewrite a scattered quarter so blocks are superseded and the
+	// block map fractures across chunk generations.
+	for range total / piece / 4 {
+		off := rnd.Intn(total/piece) * piece
+		end := min(off+piece, total)
+		_, err = rnd.Read(src[off:end])
+		require.NoError(t, err)
+		require.NoError(t, vb.WriteAt(uint64(off), append([]byte(nil), src[off:end]...)))
+	}
+
+	vb.StopChunkUploader()
+	require.NoError(t, vb.Close())
+
+	// Cold reopen: everything must come from the persisted checkpoint+chunks.
+	reopenConfig := VB{
+		VolumeName:          vol,
+		VolumeSize:          volSize,
+		BaseDir:             fmt.Sprintf("%s/viperblock", root),
+		WALSyncInterval:     -1,
+		ChunkUploadInterval: -1,
+		Cache:               Cache{Config: CacheConfig{Size: 0}},
+	}
+	reopened, err := New(&reopenConfig, FileBackend, backendConfig)
+	require.NoError(t, err)
+	require.NoError(t, reopened.Backend.Init())
+	require.NoError(t, reopened.LoadState())
+	require.NoError(t, reopened.LoadLiveCheckpoint())
+
+	got, err := reopened.ReadAt(0, total)
+	require.NoError(t, err)
+
+	if !bytes.Equal(src, got) {
+		bs := int(reopened.BlockSize)
+		bad := 0
+		detail := ""
+		for b := 0; b*bs < total; b++ {
+			s, e := b*bs, (b+1)*bs
+			if bytes.Equal(src[s:e], got[s:e]) {
+				continue
+			}
+			bad++
+			if bad <= 5 {
+				lo, hi := -1, -1
+				for i := s; i < e; i++ {
+					if src[i] != got[i] {
+						if lo < 0 {
+							lo = i - s
+						}
+						hi = i - s
+					}
+				}
+				allZero := true
+				for i := s + lo; i <= s+hi; i++ {
+					if got[i] != 0 {
+						allZero = false
+						break
+					}
+				}
+				detail += fmt.Sprintf("\n  block %d (offset %#x): bytes [%d,%d] wrong (%d bytes), replacement all-zero=%v",
+					b, s, lo, hi, hi-lo+1, allZero)
+			}
+		}
+		t.Fatalf("cold read differs from what was written: %d of %d blocks corrupt (%.4f%%)%s",
+			bad, total/bs, 100*float64(bad)/float64(total/bs), detail)
+	}
+}

--- a/viperblock/viperblock.go
+++ b/viperblock/viperblock.go
@@ -215,6 +215,19 @@ type VB struct {
 	// class this locking removes.
 	rmwConflicts atomic.Uint64
 
+	// rmwHolders records which block owns each rmwLocks shard, as block+1 so
+	// the zero value reads as "free". There are only NumShards locks for the
+	// whole volume, so a failed TryLock is USUALLY two different blocks
+	// colliding on one shard; counting those as conflicts would report
+	// contention that has nothing to do with the lost-update class. Comparing
+	// the holder against the incoming block separates the two.
+	rmwHolders [NumShards]atomic.Uint64
+
+	// rmwShardCollisions counts the other case: a failed TryLock where the
+	// shard was held by a DIFFERENT block. Harmless to correctness, but a high
+	// rate means NumShards is too small for the write concurrency in play.
+	rmwShardCollisions atomic.Uint64
+
 	// chunkUploadTrigger lets WriteAtCtx ask the background chunk uploader
 	// to drain now instead of waiting for the next ChunkUploadInterval tick,
 	// once pendingBytes crosses FlushSize. Buffered 1: a pending trigger
@@ -1763,6 +1776,10 @@ func (vb *VB) WriteAtCtx(ctx context.Context, offset uint64, data []byte) error 
 // already rebuilding the same block. Non-zero means the guest workload
 // produces same-block write concurrency, which is the precondition for the
 // lost-update class that per-block RMW serialization removes.
+func (vb *VB) RMWShardCollisions() uint64 {
+	return vb.rmwShardCollisions.Load()
+}
+
 func (vb *VB) RMWConflicts() uint64 {
 	return vb.rmwConflicts.Load()
 }
@@ -1783,16 +1800,27 @@ func (vb *VB) writeOneBlockLocked(ctx context.Context, b, blockSize uint64, part
 	// Contention on a partial write is the condition that used to silently
 	// drop an update; count it so the corruption class is observable rather
 	// than inferred after the fact.
+	shard := b & ShardMask
 	if partial && !lk.TryLock() {
-		vb.rmwConflicts.Add(1)
-		telemetry.RecordRMWConflict(ctx, vb.VolumeName)
-		vb.logger().DebugContext(ctx, "read-modify-write conflict: block already being rebuilt by another write",
-			"volume", vb.VolumeName, "block", b, "writeStart", writeStart, "writeEnd", writeEnd)
+		// Only a holder on the SAME block is the lost-update precondition; a
+		// different block means the two merely share one of NumShards locks.
+		if vb.rmwHolders[shard].Load() == b+1 {
+			vb.rmwConflicts.Add(1)
+			telemetry.RecordRMWConflict(ctx, vb.VolumeName)
+			vb.logger().DebugContext(ctx, "read-modify-write conflict: block already being rebuilt by another write",
+				"volume", vb.VolumeName, "block", b, "writeStart", writeStart, "writeEnd", writeEnd)
+		} else {
+			vb.rmwShardCollisions.Add(1)
+		}
 		lk.Lock()
 	} else if !partial {
 		lk.Lock()
 	}
-	defer lk.Unlock()
+	vb.rmwHolders[shard].Store(b + 1)
+	defer func() {
+		vb.rmwHolders[shard].Store(0)
+		lk.Unlock()
+	}()
 
 	blockData := make([]byte, blockSize)
 	if partial {

--- a/viperblock/viperblock.go
+++ b/viperblock/viperblock.go
@@ -4888,6 +4888,13 @@ func (vb *VB) read(ctx context.Context, block uint64, blockLen uint64) (data []b
 				return nil, err
 			}
 		} else {
+			// openChunkRun length-checks the encrypted path; the cleartext
+			// path must not be weaker. A short body here would leave the tail
+			// of data[start:end] zero-filled and then get cached as valid.
+			if len(blockData) != int(consecutiveBlockOffset) {
+				return nil, fmt.Errorf("%w: chunk %d offset %d run %d: got %d bytes, expected %d",
+					types.ErrShortRead, cb.ObjectID, cb.ObjectOffset, cb.NumBlocks, len(blockData), consecutiveBlockOffset)
+			}
 			copy(data[start:end], blockData)
 		}
 
@@ -5418,6 +5425,12 @@ func (vb *VB) fetchConsecutiveBlocksFromBackend(ctx context.Context, consecutive
 				return err
 			}
 		} else {
+			// See vb.read: the cleartext path needs the same length check the
+			// encrypted path gets from openChunkRun.
+			if len(blockData) != int(consecutiveBlockOffset) {
+				return fmt.Errorf("%w: chunk %d offset %d run %d: got %d bytes, expected %d",
+					types.ErrShortRead, cb.ObjectID, cb.ObjectOffset, cb.NumBlocks, len(blockData), consecutiveBlockOffset)
+			}
 			copy(data[start:end], blockData)
 		}
 
@@ -5526,6 +5539,12 @@ func (vb *VB) fetchBaseBlocksFromBackend(ctx context.Context, sourceVolume strin
 				return fmt.Errorf("base chunk decrypt source %s: %w", sourceVolume, err)
 			}
 		} else {
+			// See vb.read: the cleartext path needs the same length check the
+			// encrypted path gets from openChunkRun.
+			if len(blockData) != int(consecutiveBlockOffset) {
+				return fmt.Errorf("%w: base source %s chunk %d offset %d run %d: got %d bytes, expected %d",
+					types.ErrShortRead, sourceVolume, cb.ObjectID, cb.ObjectOffset, cb.NumBlocks, len(blockData), consecutiveBlockOffset)
+			}
 			copy(data[start:end], blockData)
 		}
 

--- a/viperblock/viperblock.go
+++ b/viperblock/viperblock.go
@@ -205,6 +205,16 @@ type VB struct {
 	// createChunkFile's SeqNum guard is a secondary defense, not a substitute.
 	drainMu sync.Mutex
 
+	// rmwLocks serialize each block's read-modify-write cycle in WriteAtCtx,
+	// sharded by block number. See writeOneBlockLocked.
+	rmwLocks [NumShards]sync.Mutex
+
+	// rmwConflicts counts partial writes that found another write already
+	// rebuilding the same block. Non-zero means guest I/O is producing
+	// same-block write concurrency -- the precondition for the lost-update
+	// class this locking removes.
+	rmwConflicts atomic.Uint64
+
 	// chunkUploadTrigger lets WriteAtCtx ask the background chunk uploader
 	// to drain now instead of waiting for the next ChunkUploadInterval tick,
 	// once pendingBytes crosses FlushSize. Buffered 1: a pending trigger
@@ -218,6 +228,13 @@ type VB struct {
 	// ShardedWAL splits the WAL into NumShards parallel files for reduced lock contention.
 	// When UseShardedWAL is true, writes route through ShardedWAL instead of WAL.
 	ShardedWAL *ShardedWAL
+
+	// Role labels which engine constructed this VB: "nbdkit" for the data-path
+	// plugin, "daemon" for a control-plane import. Emitted with the
+	// volume-open metric so a volume held by more than one engine is visible
+	// as a metric rather than something to infer by correlating logs. Empty
+	// is allowed and reported as unset.
+	Role string
 
 	// UseShardedWAL enables the sharded WAL for write operations.
 	// When false, uses the legacy single-file WAL for backward compatibility.
@@ -1085,6 +1102,8 @@ func New(config *VB, btype string, backendConfig any) (vb *VB, err error) {
 		BlockStore:    NewUnifiedBlockStore(config.BlockSize),
 		UseBlockStore: true,
 
+		Role: config.Role,
+
 		UseShardedWAL: false,
 		ShardedWAL:    NewShardedWAL(config.BaseDir, [4]byte{'V', 'B', 'W', 'L'}),
 
@@ -1128,6 +1147,15 @@ func New(config *VB, btype string, backendConfig any) (vb *VB, err error) {
 
 	// Start background chunk uploader (if interval > 0)
 	vb.StartChunkUploader()
+
+	// Emit the volume-open event. Every New() starts a chunk uploader, so
+	// every construction is a potential WRITER of this volume, not a reader --
+	// which is why the open is worth recording with process identity. Opens
+	// for one volume carrying two pids/roles mean two engines hold it.
+	telemetry.RecordVolumeOpen(context.Background(), vb.VolumeName, vb.Role)
+	vb.logger().Info("viperblock volume opened",
+		"volume", vb.VolumeName, "role", vb.Role, "pid", os.Getpid(),
+		"process", filepath.Base(os.Args[0]), "encrypted", vb.EncryptionEnabled)
 
 	return vb, nil
 }
@@ -1665,18 +1693,25 @@ func (vb *VB) WriteAtCtx(ctx context.Context, offset uint64, data []byte) error 
 	endOffset := offset + dataLen
 	endBlock := (endOffset - 1) / blockSize
 
-	// Reserve a contiguous SeqNum batch up-front. reserveSeqNum may call
-	// SaveState (which takes BlocksToObject.mu), so it must run before we
-	// acquire vb.Writes.mu below to keep the lock order consistent. We issue
-	// start+1..start+n to preserve the legacy "atomic.Add(1) post-increment"
-	// semantics (issued SeqNums are >= 1; SeqNum == 0 reads as uninitialised
-	// in BlockStore).
-	start, err := vb.reserveSeqNum(ctx, endBlock-startBlock+1)
-	if err != nil {
-		return err
-	}
-	nextSeqNum := start + 1
-
+	// Each block's read-modify-write cycle runs inside blockRMWLock(b), and
+	// its SeqNum is reserved INSIDE that section. Both matter:
+	//
+	//   - Atomicity. A sub-block write rebuilds the whole 4096-byte block from
+	//     the current contents plus its own range. If the read and the publish
+	//     are not serialized, two writes into one block both read generation N,
+	//     each splice their own range, and the loser's bytes vanish -- the
+	//     block ends up byte-exact with generation N over the losing range.
+	//
+	//   - Ordering. Reserving the SeqNum before taking the lock is not enough:
+	//     the writer holding the HIGHER SeqNum could acquire the lock second,
+	//     publish a block spliced onto an older base, and still win the
+	//     SeqNum comparison in WriteWithSeqNum/flush dedup. Reserving inside
+	//     the section makes SeqNum order identical to splice order, so the
+	//     last splice is always the winner and always carries every earlier
+	//     splice.
+	//
+	// Blocks are published one at a time rather than as one batch so a block's
+	// lock is never held while another block's backend read is in flight.
 	var writes []Block
 
 	for b := startBlock; b <= endBlock; b++ {
@@ -1700,42 +1735,14 @@ func (vb *VB) WriteAtCtx(ctx context.Context, offset uint64, data []byte) error 
 			writeEnd = blockSize
 		}
 
-		// Read existing block if partial write, else skip
-		var blockData []byte
-		if writeStart > 0 || writeEnd < blockSize {
-			existing, err := vb.ReadAtCtx(ctx, b*blockSize, blockSize)
+		partial := writeStart > 0 || writeEnd < blockSize
 
-			if err != nil && !errors.Is(err, ErrZeroBlock) {
-				return fmt.Errorf("failed to read block %d for RMW: %w", b, err)
-			}
-			blockData = make([]byte, blockSize)
-			copy(blockData, existing)
-		} else {
-			blockData = make([]byte, blockSize) // full overwrite
+		blk, err := vb.writeOneBlockLocked(ctx, b, blockSize, partial, writeStart, writeEnd,
+			data[blockStart+writeStart-offset:blockStart+writeEnd-offset])
+		if err != nil {
+			return err
 		}
-
-		// Copy the relevant data into block buffer
-		copy(blockData[writeStart:writeEnd], data[blockStart+writeStart-offset:blockStart+writeEnd-offset])
-
-		writes = append(writes, Block{
-			SeqNum: nextSeqNum,
-			Block:  b,
-			Len:    blockSize,
-			Data:   blockData,
-		})
-		nextSeqNum++
-	}
-
-	// Thread-safe write into memory buffer
-	vb.Writes.mu.Lock()
-	vb.Writes.Blocks = append(vb.Writes.Blocks, writes...)
-	vb.Writes.mu.Unlock()
-
-	// Also update BlockStore if enabled (for O(1) read lookups)
-	if vb.UseBlockStore && vb.BlockStore != nil {
-		for _, block := range writes {
-			vb.BlockStore.WriteWithSeqNum(block.Block, block.Data, block.SeqNum)
-		}
+		writes = append(writes, blk)
 	}
 
 	vb.pendingBytes.Add(int64(len(writes)) * int64(blockSize)) //nolint:gosec // G115: blockSize is 4KB-class, no overflow risk
@@ -1750,6 +1757,71 @@ func (vb *VB) WriteAtCtx(ctx context.Context, offset uint64, data []byte) error 
 	}
 
 	return nil
+}
+
+// RMWConflicts returns the number of partial writes that found another write
+// already rebuilding the same block. Non-zero means the guest workload
+// produces same-block write concurrency, which is the precondition for the
+// lost-update class that per-block RMW serialization removes.
+func (vb *VB) RMWConflicts() uint64 {
+	return vb.rmwConflicts.Load()
+}
+
+// blockRMWLock returns the mutex serializing read-modify-write cycles for a
+// block. Sharded by block number so unrelated blocks never contend.
+func (vb *VB) blockRMWLock(block uint64) *sync.Mutex {
+	return &vb.rmwLocks[block&ShardMask]
+}
+
+// writeOneBlockLocked performs one block's whole read-splice-publish cycle
+// under that block's RMW lock, reserving the SeqNum inside the section so
+// SeqNum order matches splice order. patch is the caller's bytes for
+// [writeStart, writeEnd) of this block. Returns the published Block.
+func (vb *VB) writeOneBlockLocked(ctx context.Context, b, blockSize uint64, partial bool, writeStart, writeEnd uint64, patch []byte) (Block, error) {
+	lk := vb.blockRMWLock(b)
+
+	// Contention on a partial write is the condition that used to silently
+	// drop an update; count it so the corruption class is observable rather
+	// than inferred after the fact.
+	if partial && !lk.TryLock() {
+		vb.rmwConflicts.Add(1)
+		telemetry.RecordRMWConflict(ctx, vb.VolumeName)
+		vb.logger().DebugContext(ctx, "read-modify-write conflict: block already being rebuilt by another write",
+			"volume", vb.VolumeName, "block", b, "writeStart", writeStart, "writeEnd", writeEnd)
+		lk.Lock()
+	} else if !partial {
+		lk.Lock()
+	}
+	defer lk.Unlock()
+
+	blockData := make([]byte, blockSize)
+	if partial {
+		existing, err := vb.ReadAtCtx(ctx, b*blockSize, blockSize)
+		if err != nil && !errors.Is(err, ErrZeroBlock) {
+			return Block{}, fmt.Errorf("failed to read block %d for RMW: %w", b, err)
+		}
+		copy(blockData, existing)
+	}
+	copy(blockData[writeStart:writeEnd], patch)
+
+	// Reserved inside the section -- see WriteAtCtx for why.
+	start, err := vb.reserveSeqNum(ctx, 1)
+	if err != nil {
+		return Block{}, err
+	}
+	seqNum := start + 1
+
+	blk := Block{SeqNum: seqNum, Block: b, Len: blockSize, Data: blockData}
+
+	vb.Writes.mu.Lock()
+	vb.Writes.Blocks = append(vb.Writes.Blocks, blk)
+	vb.Writes.mu.Unlock()
+
+	if vb.UseBlockStore && vb.BlockStore != nil {
+		vb.BlockStore.WriteWithSeqNum(b, blockData, seqNum)
+	}
+
+	return blk, nil
 }
 
 func (vb *VB) Write(block uint64, data []byte) (err error) {


### PR DESCRIPTION
Fixes the silent data corruption tracked as `mulga-siv-482`, confirmed by an A/B on env19.

## The bug

`WriteAtCtx` reserved its SeqNum before the read-modify-write read, and the read and the publish shared no per-block lock. Two concurrent sub-block writes both read generation N, each spliced its own range, and the higher SeqNum won wholesale — silently discarding the loser's bytes.

The result is a 4096-byte block reverting to a **previous generation of itself** over exactly the range the last partial write covered: first 3072 bytes correct, trailing 1024 stale. Nothing errors. Under encryption nothing even fails AEAD, because the reverted bytes are a real, correctly-sealed earlier version of that block. The filler is zeros where the region was never written, and previously-deleted file content where it was — an information-disclosure side effect on top of the data loss.

It needs no block-map fault, which is why the guards already in the deployed build (`SeqNum` comparison, `drainMu`) did not prevent it.

## Evidence

A/B on env19, everything held constant except viperblock — same AMI (with the route-MTU fix), same gateway, same Argo workload, encryption on:

| Arm | Result |
|---|---|
| pre-fix | corruption within ~15 min: 4x `failed to extract layer`, 2x `invalid tar header`, 2x `unpigz: skipping`; 6 pods Error + 6 CrashLoopBackOff |
| fixed | **zero** signatures across 5+ hours, while the counter recorded 6407 same-block RMW conflicts on the worker root disks — the race window was hit continuously and absorbed |

Zero TLS handshake timeouts on either arm, so this arrived over a healthy network: storage, not egress.

## Contents

- **Atomic per-block RMW** — serialize read-splice-publish per block, with the SeqNum reserved *inside* the critical section. Reserving before the lock is insufficient: the higher-SeqNum writer could acquire second, splice onto an older base and still win. Forced-race losses 48/200 -> 0/200.
- **Reproducer test** for the lost update.
- **Refuse a short backend read** instead of zero-filling it. A ranged GET clamped by the object's real end returns a short body with `err == nil`, which was copied into a full-size buffer and *cached as valid*. Not the env19 cause (encryption makes a short chunk loud), but a genuine silent-corruption hole. Note the write side is still unguarded: predastore discards the stored byte count, so a short PUT is recorded as success.
- **Serialize the snapshot drain** — `CreateSnapshot` ran flush -> WriteWALToChunk -> SaveLiveCheckpoint outside `drainMu`. Superseded once `mulga-t1sch` removes the second engine, but correct today.
- **Conflict counter accuracy** — `rmwLocks` is sharded 16 ways, so a bare failed `TryLock` is usually two unrelated blocks. Track the holder per shard and only count same-block races; count shard collisions separately. Without this the metric reads positive under any load and proves nothing.

## Telemetry

Adds `viperblock.write.rmw_conflicts` and `viperblock.volume.opens` (volume, role, pid). The latter makes the dual-open invariant behind `mulga-t1sch` observable as a metric rather than something to infer by correlating two log datasets.