### PR TITLE
refactor: order hot-path struct fields pointer-first

### DIFF
--- a/viperblock/blockstore.go
+++ b/viperblock/blockstore.go
@@ -42,11 +42,11 @@ func (s BlockState) String() string {
 
 // BlockEntry represents a single block's metadata and data in the unified store.
 type BlockEntry struct {
-	SeqNum       uint64     // Sequence number for ordering writes
-	State        BlockState // Current state of the block
 	Data         []byte     // Block data for Hot/Pending/Cached states
+	SeqNum       uint64     // Sequence number for ordering writes
 	ObjectID     uint64     // Object ID for Persisted state (which chunk file)
 	ObjectOffset uint32     // Offset within the chunk file for Persisted state
+	State        BlockState // Current state of the block
 }
 
 // IndexShard is a single shard of the block index with its own lock.
@@ -97,12 +97,12 @@ type UnifiedBlockStore struct {
 // numerically consecutive blocks are not necessarily from the same guest
 // write and the exact per-block value is needed to reconstruct the AEAD nonce.
 type persistedExtent struct {
+	seqNums      []uint64
 	startBlock   uint64
-	numBlocks    uint16
 	objectID     uint64
 	objectOffset uint32
 	stride       uint32
-	seqNums      []uint64
+	numBlocks    uint16
 }
 
 // end returns the exclusive end block of the extent.

--- a/viperblock/viperblock.go
+++ b/viperblock/viperblock.go
@@ -435,11 +435,11 @@ type BlockCache struct {
 }
 
 type Block struct {
+	Data   []byte `json:"Data"`
 	SeqNum uint64 `json:"SeqNum"`
 	Block  uint64 `json:"Block"`
 	Offset uint64 `json:"Offset"`
 	Len    uint64 `json:"Len"`
-	Data   []byte `json:"Data"`
 }
 
 type BlockOptimised struct {
@@ -460,10 +460,11 @@ type BlocksToObject struct {
 }
 
 type BlockLookup struct {
-	StartBlock   uint64
-	NumBlocks    uint16
-	ObjectID     uint64
-	ObjectOffset uint32
+	SeqNums []uint64
+
+	StartBlock uint64
+	ObjectID   uint64
+
 	// SeqNum is the chunk-write generation that produced this block's
 	// ciphertext on the backend. Drives nonce + AAD reconstruction on the
 	// decrypt path: the on-disk chunk carries no nonce, so the per-block
@@ -473,15 +474,12 @@ type BlockLookup struct {
 	//
 	// For NumBlocks == 1 this is the block's own SeqNum. For NumBlocks > 1
 	// it is StartBlock's SeqNum only, kept for wire-format compatibility;
-	// SeqNums below carries every block's own value, since blocks in a run
+	// SeqNums above carries every block's own value, since blocks in a run
 	// are not guaranteed to share one.
 	SeqNum uint64
 
-	// SeqNums holds one SeqNum per block in this entry's [StartBlock,
-	// StartBlock+NumBlocks) run, in order. Nil for single-block entries,
-	// where SeqNum alone is authoritative. Never serialized directly — the
-	// on-disk format stays one record per physical block (expandBlockLookup).
-	SeqNums []uint64
+	ObjectOffset uint32
+	NumBlocks    uint16
 }
 
 // end returns the exclusive upper bound of the block range this entry


### PR DESCRIPTION
## Summary

Reorders four hot-path structs pointer-first, then by descending scalar width. Pure field reordering — no logic, call-site or wire-format change.

| struct | size | GC scan region per object |
|---|---|---|
| `Block` | 56 -> 56 | 40 -> 8 |
| `BlockEntry` | 56 -> **48** | 24 -> 8 |
| `BlockLookup` | 64 -> **56** | 48 -> 8 |
| `persistedExtent` | 64 -> **56** | 48 -> 8 |

`BlockEntry` is the one that matters: it is heap-allocated per hot block via `map[uint64]*BlockEntry`, and 48 bytes lands exactly on Go's 48-byte size class where 56 rounded up into the 64-byte one. That is a real 25% per-entry saving, not the nominal 8 bytes.

This is a memory and GC-pressure change, not a throughput change. The drain is I/O-bound at ~14 MB/s, so it reduces RSS and mark work; it does not raise write bandwidth.

### Wire safety

Every viperblock record is serialized manually with explicit `binary.BigEndian.PutUint64` into slices sized by `WALHeaderSize()` / `ChunkHeaderSize()`. There is no `binary.Write`/`binary.Read` over a whole struct anywhere in the repo, and the only `unsafe` is cgo/nbdkit plumbing. JSON is name-keyed, so `Block`'s tags are unaffected by order. All struct literals are keyed, so the compiler covers the rest.

## Benchmarks

Measured on an 8-core Xeon Gold 6148, `-count=10`, benchstat. Field order changes neither allocation count nor, for `Block`, allocation size, so `ns/op` and `allocs/op` are flat by construction — the measurement is GC scan volume (`/gc/scan/heap:bytes`), mark CPU (`/cpu/classes/gc/mark/{dedicated,assist}`) and `HeapInuse`, over a retained population of 500k blocks (~2 GiB live) with forced collections.

```
                          │  before      │            after             │
                          │ gc-scan-MiB  │ gc-scan-MiB  vs base         │
RetainedBlocks_GC-8          30.24 ± 0%     30.24 ± 0%       ~ (p=0.357)
RetainedBlockEntries_GC-8    33.00 ± 0%     25.37 ± 0%  -23.15% (p=0.000)

                          │ gc-cpu-ms/op │ gc-cpu-ms/op vs base         │
RetainedBlocks_GC-8          15.25 ± 18%    14.61 ± 19%      ~ (p=1.000)
RetainedBlockEntries_GC-8    43.84 ±  8%    43.14 ±  8%      ~ (p=0.481)
```

### The `Block` reorder does not do what the plan claimed

The plan predicted mark-phase scan work for `[]Block` dropping ~5x on the strength of ptrdata falling 40 -> 8. **It measured as exactly zero change** (30.24 MiB before and after, p=0.357), and that result is correct rather than noise.

Modern Go's `scanobject` walks a pointer bitmap with an iterator that skips zero words in bulk and records scan work as *the offset of the last pointer it actually found, plus one word* — not the type's nominal ptrdata. For a large `[]Block` backing array, the array is split into 128 KiB oblets and the last pointer in each oblet sits in that oblet's final element either way. Moving `Data` from offset 32 to offset 0 changes the scanned span by 32 bytes out of 131072. The per-element ptrdata reduction never materialises, because the elements are contiguous in one object.

The reduction is real only where each struct is *its own heap object*, which is why `BlockEntry` shows a genuine 23% drop and `Block` shows none. The `Block` reorder is retained because it is free and correct, but it should not be credited with a GC win.

`heap-MiB` moved -0.32% on the entries benchmark: the 16-byte-per-entry saving is real (8 MiB over 500k entries) but small against the ~2 GiB of block data those entries point at.

### No throughput regression

```
                                 │   sec/op    │  sec/op     vs base        │
BlockStore_SingleRead-8            37.92n ± 11%  36.55n ± 4%  -3.61%
BlockStore_SingleWrite-8           1.439µ ± 10%  1.535µ ± 18%      ~
BlockStore_ConcurrentReadWrite-8   315.6n ± 12%  316.9n ±  2%      ~
BlockStore_ConcurrentRead-8        122.4n ±  4%  118.5n ±  3%      ~
BlockStore_RandomReadWrite-8       413.8n ±  4%  386.2n ±  3%  -6.66%
BlockStore_StateTransition-8       2.991µ ±  7%  2.891µ ±  5%      ~
```

The two significant `sec/op` improvements are not attributable to this change and are most likely run-to-run drift; treat them as "no regression", not as a speedup.

`BlockStore_SingleWrite` B/op drops 4.136Ki -> 4.120Ki, exactly the 16-byte `BlockEntry` size-class saving. That existing benchmark is the standing regression signal for this work, so no bespoke harness is checked in.