### PR TITLE
fix: guard the background goroutine lifecycle against concurrent callers

### DIFF
--- a/viperblock/background_lifecycle_test.go
+++ b/viperblock/background_lifecycle_test.go
@@ -1,0 +1,207 @@
+package viperblock
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/mulgadc/viperblock/viperblock/backends/file"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newLifecycleTestVB builds a VB with both background goroutines running on a
+// fast cadence, so a test can stop them without waiting on production
+// intervals. New() starts the syncer and the uploader itself.
+func newLifecycleTestVB(t *testing.T) *VB {
+	t.Helper()
+
+	tmpDir := t.TempDir()
+	testVol := fmt.Sprintf("test_bg_lifecycle_%d", time.Now().UnixNano())
+
+	backendConfig := file.FileConfig{
+		VolumeName: testVol,
+		VolumeSize: volumeSize,
+		BaseDir:    tmpDir,
+	}
+
+	vbconfig := VB{
+		VolumeName:          testVol,
+		VolumeSize:          volumeSize,
+		BaseDir:             fmt.Sprintf("%s/%s", tmpDir, "viperblock"),
+		WALSyncInterval:     5 * time.Millisecond,
+		ChunkUploadInterval: 10 * time.Millisecond,
+	}
+
+	vb, err := New(&vbconfig, FileBackend, backendConfig)
+	require.NoError(t, err)
+
+	require.NoError(t, vb.Backend.Init())
+	require.NoError(t, vb.OpenWAL(&vb.WAL, fmt.Sprintf("%s/%s/wal/chunks/wal.%08d.bin",
+		vb.BaseDir, vb.GetVolume(), vb.WAL.WallNum.Load())))
+
+	t.Cleanup(func() {
+		vb.StopChunkUploader()
+		vb.StopWALSyncer()
+	})
+
+	return vb
+}
+
+// Both goroutines must actually be running, or every test below passes
+// vacuously against a VB that had nothing to stop.
+func requireBackgroundRunning(t *testing.T, vb *VB) {
+	t.Helper()
+	require.NotNil(t, vb.chunkUploadStop, "chunk uploader should be running")
+	require.NotNil(t, vb.walSyncStop, "WAL syncer should be running")
+}
+
+// The regression gate. On dev both stoppers are an unsynchronised
+// check-then-act, so racing callers either close an already-closed channel or
+// receive from one a competing caller has nil'd. Run under -race.
+func TestBackgroundLifecycle_ConcurrentStopIsSafe(t *testing.T) {
+	vb := newLifecycleTestVB(t)
+	requireBackgroundRunning(t, vb)
+
+	const stoppers = 16
+
+	// Release every goroutine at once so they collide inside the stop
+	// functions rather than arriving in a queue.
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+
+	for range stoppers {
+		wg.Go(func() {
+			<-start
+			vb.StopChunkUploader()
+			vb.StopWALSyncer()
+		})
+	}
+	close(start)
+
+	// A nil-channel receive in the buggy version hangs forever, so bound the
+	// wait rather than letting the whole suite time out on it.
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("concurrent StopChunkUploader/StopWALSyncer did not all return: a caller is blocked on a nil channel")
+	}
+
+	assert.Nil(t, vb.chunkUploadStop, "uploader fields should be cleared after stop")
+	assert.Nil(t, vb.walSyncStop, "syncer fields should be cleared after stop")
+}
+
+func TestBackgroundLifecycle_StopIsIdempotent(t *testing.T) {
+	vb := newLifecycleTestVB(t)
+	requireBackgroundRunning(t, vb)
+
+	for range 3 {
+		vb.StopChunkUploader()
+		vb.StopWALSyncer()
+	}
+
+	assert.Nil(t, vb.chunkUploadStop)
+	assert.Nil(t, vb.chunkUploadDone)
+	assert.Nil(t, vb.chunkUploadTicker)
+	assert.Nil(t, vb.gcTicker)
+	assert.Nil(t, vb.walSyncStop)
+	assert.Nil(t, vb.walSyncDone)
+	assert.Nil(t, vb.walSyncTicker)
+}
+
+func TestBackgroundLifecycle_RestartAfterStop(t *testing.T) {
+	vb := newLifecycleTestVB(t)
+	requireBackgroundRunning(t, vb)
+
+	vb.StopChunkUploader()
+	vb.StopWALSyncer()
+
+	vb.StartChunkUploader()
+	vb.StartWALSyncer()
+	requireBackgroundRunning(t, vb)
+
+	// A second start must be a no-op, not a second goroutine: the orphan would
+	// keep running against fields the next stop nils.
+	uploaderStop, syncerStop := vb.chunkUploadStop, vb.walSyncStop
+	vb.StartChunkUploader()
+	vb.StartWALSyncer()
+	assert.Equal(t, uploaderStop, vb.chunkUploadStop, "second StartChunkUploader replaced the running goroutine's stop channel")
+	assert.Equal(t, syncerStop, vb.walSyncStop, "second StartWALSyncer replaced the running goroutine's stop channel")
+
+	vb.StopChunkUploader()
+	vb.StopWALSyncer()
+	assert.Nil(t, vb.chunkUploadStop)
+	assert.Nil(t, vb.walSyncStop)
+}
+
+// Stop must mean stopped, not merely signalled: callers such as
+// viperblockd.shutdownVolumes flush the WAL immediately afterwards.
+func TestBackgroundLifecycle_StopHaltsTheGoroutine(t *testing.T) {
+	vb := newLifecycleTestVB(t)
+	requireBackgroundRunning(t, vb)
+
+	// Captured before the stop nils them — these are the goroutines' own exit
+	// signals, so a closed channel here is direct proof each one returned.
+	uploaderDone, syncerDone := vb.chunkUploadDone, vb.walSyncDone
+
+	vb.StopChunkUploader()
+	vb.StopWALSyncer()
+
+	for name, ch := range map[string]chan struct{}{"uploader": uploaderDone, "syncer": syncerDone} {
+		select {
+		case <-ch:
+		default:
+			t.Fatalf("%s goroutine still running after its stop returned", name)
+		}
+	}
+
+	// And it stays stopped: writes after the stop must not be drained by a
+	// goroutine that outlived it.
+	objectsAfterStop := vb.ObjectNum.Load()
+
+	data := make([]byte, DefaultBlockSize)
+	copy(data, "post-stop write")
+	require.NoError(t, vb.WriteAt(0, data))
+
+	time.Sleep(100 * time.Millisecond) // 10x ChunkUploadInterval
+
+	assert.Equal(t, objectsAfterStop, vb.ObjectNum.Load(), "a drain ran after the uploader was stopped")
+}
+
+// Close stops both goroutines itself, which is the overlap that bites in
+// production: a NATS unmount handler calls Close while the SIGTERM sweep is
+// stopping the same VB.
+func TestBackgroundLifecycle_StopRacesClose(t *testing.T) {
+	vb := newLifecycleTestVB(t)
+	requireBackgroundRunning(t, vb)
+
+	data := make([]byte, DefaultBlockSize)
+	copy(data, "close race")
+	require.NoError(t, vb.WriteAt(0, data))
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	var closeErr error
+
+	wg.Go(func() {
+		<-start
+		closeErr = vb.Close()
+	})
+	wg.Go(func() {
+		<-start
+		vb.StopChunkUploader()
+		vb.StopWALSyncer()
+	})
+
+	close(start)
+	wg.Wait()
+
+	require.NoError(t, closeErr, "Close failed while racing a concurrent stop")
+}

--- a/viperblock/viperblock.go
+++ b/viperblock/viperblock.go
@@ -141,6 +141,14 @@ type VB struct {
 	// Inspired by PostgreSQL's wal_writer_delay, BadgerDB's SyncWrites, MongoDB's journalCommitInterval
 	WALSyncInterval time.Duration
 
+	// bgMu serialises the start and stop of both background goroutines (the
+	// WAL syncer and the chunk uploader). Their control fields below are
+	// otherwise a check-then-act that concurrent stoppers — a SIGTERM sweep
+	// racing a NATS unmount, say — turn into a double close or a nil-channel
+	// receive. Held across the wait for the goroutine to exit, so "stop
+	// returned" means "stopped" for every caller, not just the first.
+	bgMu sync.Mutex
+
 	// WAL syncer control (background goroutine for periodic fsync)
 	walSyncTicker *time.Ticker
 	walSyncStop   chan struct{}
@@ -1217,23 +1225,37 @@ func (vb *VB) StartWALSyncer() {
 		return
 	}
 
+	vb.bgMu.Lock()
+	defer vb.bgMu.Unlock()
+
+	// Already running: starting a second goroutine would orphan the first,
+	// which would then keep syncing against fields the stopper has nil'd.
+	if vb.walSyncStop != nil {
+		return
+	}
+
 	vb.walSyncStop = make(chan struct{})
 	vb.walSyncDone = make(chan struct{})
 	vb.walSyncTicker = time.NewTicker(vb.WALSyncInterval)
 
+	// The goroutine closes over locals, never the VB fields: the stopper nils
+	// those, and a field read here would race that write however well the
+	// stopper itself is locked.
+	stop, done, ticker := vb.walSyncStop, vb.walSyncDone, vb.walSyncTicker
+
 	go func() {
-		defer close(vb.walSyncDone)
-		defer vb.walSyncTicker.Stop()
+		defer close(done)
+		defer ticker.Stop()
 
 		for {
 			select {
-			case <-vb.walSyncTicker.C:
+			case <-ticker.C:
 				if vb.UseShardedWAL {
 					vb.syncShardedWALIfDirty()
 				} else {
 					vb.syncWALIfDirty()
 				}
-			case <-vb.walSyncStop:
+			case <-stop:
 				// Final sync before shutdown
 				if vb.UseShardedWAL {
 					vb.syncShardedWALIfDirty()
@@ -1251,6 +1273,11 @@ func (vb *VB) StartWALSyncer() {
 // StopWALSyncer gracefully stops the background WAL sync goroutine.
 // It signals the goroutine to stop and waits for it to complete its final sync.
 func (vb *VB) StopWALSyncer() {
+	vb.bgMu.Lock()
+	defer vb.bgMu.Unlock()
+
+	// Not running, or a concurrent caller already stopped it and nil'd the
+	// fields while this one waited for the mutex. Either way it is stopped.
 	if vb.walSyncStop == nil {
 		return
 	}
@@ -1274,6 +1301,15 @@ func (vb *VB) StartChunkUploader() {
 		return
 	}
 
+	vb.bgMu.Lock()
+	defer vb.bgMu.Unlock()
+
+	// Already running — see StartWALSyncer for why a second goroutine is not
+	// merely redundant but unsafe.
+	if vb.chunkUploadStop != nil {
+		return
+	}
+
 	vb.chunkUploadStop = make(chan struct{})
 	vb.chunkUploadDone = make(chan struct{})
 	vb.chunkUploadTicker = time.NewTicker(vb.ChunkUploadInterval)
@@ -1283,23 +1319,28 @@ func (vb *VB) StartChunkUploader() {
 	// ensureGCSnapshotSafe) to run more often than necessary. gcTickerC
 	// stays nil (never fires below) when GC is off or GCInterval <= 0.
 	var gcTickerC <-chan time.Time
+	var gcTicker *time.Ticker
 	if vb.GCEnabled && vb.GCInterval > 0 {
 		vb.gcTicker = time.NewTicker(vb.GCInterval)
+		gcTicker = vb.gcTicker
 		gcTickerC = vb.gcTicker.C
 	}
 
+	// Locals, not VB fields, for the same reason as the WAL syncer.
+	stop, done, ticker := vb.chunkUploadStop, vb.chunkUploadDone, vb.chunkUploadTicker
+
 	go func() {
-		defer close(vb.chunkUploadDone)
-		defer vb.chunkUploadTicker.Stop()
+		defer close(done)
+		defer ticker.Stop()
 		defer func() {
-			if vb.gcTicker != nil {
-				vb.gcTicker.Stop()
+			if gcTicker != nil {
+				gcTicker.Stop()
 			}
 		}()
 
 		for {
 			select {
-			case <-vb.chunkUploadTicker.C:
+			case <-ticker.C:
 				// DrainToBackendCtx itself latches/clears backendFull on
 				// ErrNoSpace/success, so a dropped error here is not
 				// silently lost — WriteAtCtx's up-front gate will start
@@ -1316,7 +1357,7 @@ func (vb *VB) StartChunkUploader() {
 				}
 			case <-gcTickerC:
 				vb.runGCSweep(context.Background())
-			case <-vb.chunkUploadStop:
+			case <-stop:
 				return
 			}
 		}
@@ -1327,6 +1368,11 @@ func (vb *VB) StartChunkUploader() {
 
 // StopChunkUploader stops the background chunk upload goroutine.
 func (vb *VB) StopChunkUploader() {
+	vb.bgMu.Lock()
+	defer vb.bgMu.Unlock()
+
+	// Not running, or a concurrent caller stopped it while this one waited
+	// for the mutex — see StopWALSyncer.
 	if vb.chunkUploadStop == nil {
 		return
 	}


### PR DESCRIPTION
## Summary

`StopChunkUploader` and `StopWALSyncer` were a check-then-act on unsynchronised state. Two callers both passed the nil check and both closed the stop channel, panicking with "close of closed channel"; if the nil store landed between one caller's check and its receive, that caller instead waited on a nil channel and blocked forever. The goroutines compounded it by re-reading `vb.chunkUploadTicker.C` and `vb.gcTicker` on every iteration — the same fields the stopper nils.

This is not just a crash. `viperblockd.shutdownVolumes` stops every mounted volume in a loop on SIGTERM, so a panic there leaves every volume after the failing one with an unflushed WAL.

The exposure is the SIGTERM sweep overlapping the NATS unmount/detach handlers, which stop the same VB and then call `Close()`, which stops it again. Sequential stop-then-`Close` is safe; the overlap is what bites. Chunk GC widens the window by adding a second ticker to the same select.

Scope covers both goroutine pairs, not just the uploader named in the issue: `StartWALSyncer`/`StopWALSyncer` have the identical bug down to the field names, and the two stops are called as a pair at all 14 call sites, so fixing one would have left the same panic on the adjacent line.

## Changes

- New `bgMu` on `VB`, held across all four start/stop functions. It is deliberately held across the wait for the goroutine to exit, so "stop returned" means "stopped" for every caller rather than only the first — callers such as `shutdownVolumes` flush the WAL immediately afterwards. This cannot deadlock: neither `DrainToBackendCtx` nor `runGCSweep` calls back into any start/stop function, so nothing the goroutine runs can want the mutex.
- Both goroutines now close over locals (`stop`, `done`, `ticker`, `gcTicker`) instead of `VB` fields. This is what actually removes the data race, since the goroutines never take the mutex themselves. `gcTickerC` already followed this pattern; the rest now match it.
- Starting an already-running goroutine is a no-op rather than orphaning the first one, which would otherwise keep running against fields the next stop nils.
- `chunkUploadTrigger` is still read from the goroutine, deliberately: it is created once in `New` and never nil'd, so it is immutable for the VB's lifetime.

## Testing

Five new tests in `viperblock/background_lifecycle_test.go`: concurrent stop, idempotent stop, restart after stop, stop actually halting the goroutine, and stop racing `Close`.

They are a genuine regression gate rather than green-on-green. Run unchanged against pristine `dev` (`ca47645`) they fail with `panic: close of closed channel` and 13 `WARNING: DATA RACE` reports; on this branch they pass under `-race`.

`make preflight` passes, total coverage 77.0%. This branch is off `dev` and so predates the preflight change in the GC snapshot-marker work — it still ran the integration tier and the old 300s race budget, and fitted inside both.
