### PR TITLE
fix: report every chunk GC sweep outcome at Info

### DIFF
--- a/viperblock/chunk_gc_test.go
+++ b/viperblock/chunk_gc_test.go
@@ -1,10 +1,12 @@
 package viperblock
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"errors"
 	"fmt"
+	"log/slog"
 	"maps"
 	"os"
 	"path/filepath"
@@ -1143,5 +1145,70 @@ func TestChunkGC_UnchangedMarkerStillSweeps(t *testing.T) {
 		assertClosure(t, vb)
 		assertChunkGone(t, vb.Backend, volumeName, garbageChunkID)
 		assert.Falsef(t, vb.gcLatchedOff.Load(), "pass %d: an unmoved marker must not latch GC off", pass)
+	}
+}
+
+// newGCLogCaptureVB builds a GC-enabled VB whose logger writes to buf at Info
+// level. The level is the point: anything these tests assert on must survive a
+// handler that drops Debug, which is how the nbdkit plugin runs in production.
+func newGCLogCaptureVB(t *testing.T, root, volumeName string, buf *bytes.Buffer) *VB {
+	t.Helper()
+
+	vb := newGCTestVB(t, root, volumeName, true)
+	vb.log = slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	return vb
+}
+
+// A sweep that reclaims nothing is the normal case for a healthy volume, and
+// it has to be visible at the level production actually runs at. Otherwise a
+// correctly-idle GC is indistinguishable from a GC that never ran, which is
+// what forced the env13 verification to count objects in the volume prefix
+// instead of reading the log.
+func TestChunkGC_IdleSweepIsVisibleAtInfoLevel(t *testing.T) {
+	root := t.TempDir()
+	ctx := context.Background()
+
+	var buf bytes.Buffer
+	vb := newGCLogCaptureVB(t, root, "vol-idle-sweep-log", &buf)
+
+	// Live data only: every chunk is still referenced, so the sweep runs to
+	// completion and finds nothing to reclaim.
+	writeAndChunk(t, vb, 0, randomBlockData(4))
+	require.NoError(t, vb.DrainToBackendCtx(ctx))
+
+	buf.Reset()
+	vb.runGCSweep(ctx)
+
+	logged := buf.String()
+	require.Contains(t, logged, "chunk GC: sweep complete",
+		"a sweep that reclaimed nothing must still report at Info; at Debug it is invisible in production")
+	assert.Contains(t, logged, "swept=0", "the sweep outcome must say how much it reclaimed, including none")
+	assert.Contains(t, logged, "candidates=0")
+	assert.Contains(t, logged, "volume=vol-idle-sweep-log", "the line must name the volume it swept")
+}
+
+// The snapshot-declined path is the silent-forever one: ensureGCSnapshotSafe
+// warns on its first scan, then answers from cache and says nothing, so every
+// later sweep on a pinned volume must report for itself.
+func TestChunkGC_DeclinedSweepIsVisibleOnEveryPass(t *testing.T) {
+	root := t.TempDir()
+	ctx := context.Background()
+
+	var buf bytes.Buffer
+	vb := newGCLogCaptureVB(t, root, "vol-declined-sweep-log", &buf)
+
+	writeAndChunk(t, vb, 0, randomBlockData(4))
+	_, err := vb.CreateSnapshot("snap-vol-declined-sweep-log")
+	require.NoError(t, err)
+	require.NoError(t, vb.DrainToBackendCtx(ctx))
+
+	// Two passes: the second is the one that matters, since by then the
+	// snapshot-safety answer is cached and logs nothing of its own.
+	for pass := range 2 {
+		buf.Reset()
+		vb.runGCSweep(ctx)
+		assert.Contains(t, buf.String(), "chunk GC: sweep skipped",
+			"pass %d: a declined sweep must say so every time, not just on the first scan", pass+1)
 	}
 }

--- a/viperblock/viperblock.go
+++ b/viperblock/viperblock.go
@@ -3761,6 +3761,11 @@ func (vb *VB) sweepChunks(ctx context.Context) {
 		return
 	}
 	if !vb.ensureGCSnapshotSafe(ctx) {
+		// Info rather than Debug because this is the silent-forever case: after
+		// the first scan ensureGCSnapshotSafe answers from its cache and logs
+		// nothing, so a volume GC has declined to touch would otherwise look
+		// exactly like a volume GC never visited.
+		vb.logger().Info("chunk GC: sweep skipped, snapshot-safety check declined", "volume", vb.VolumeName)
 		return
 	}
 
@@ -3788,16 +3793,21 @@ func (vb *VB) sweepChunks(ctx context.Context) {
 	// that froze the same or a newer map cannot reference these candidates at
 	// all, since a chunk absent from the live map never returns to it.
 	if vb.gcSnapshotMarkerMoved(ctx) {
+		vb.logger().Info("chunk GC: sweep abandoned, another process snapshotted this volume",
+			"volume", vb.VolumeName, "candidates", len(candidates))
 		return
 	}
 
 	swept := vb.deleteChunkObjects(ctx, candidates)
 
-	if swept > 0 {
-		vb.logger().Info("chunk GC: sweep complete", "swept", swept, "candidates", len(candidates), "floor", floor, "watermark", watermark)
-	} else {
-		vb.logger().Debug("chunk GC: sweep found nothing to reclaim", "floor", floor, "watermark", watermark)
-	}
+	// One line per sweep at Info, whatever the outcome. Reclaiming nothing is
+	// the normal, healthy case and has to be as visible as reclaiming
+	// something: at Debug it isn't, and a correctly-idle GC then reads
+	// identically to a GC that never ran — which is the wrong property for the
+	// component whose job is deleting data. At DefaultGCInterval this costs
+	// twelve lines an hour per volume.
+	vb.logger().Info("chunk GC: sweep complete",
+		"volume", vb.VolumeName, "swept", swept, "candidates", len(candidates), "floor", floor, "watermark", watermark)
 }
 
 // deleteChunkObjects issues a DeleteObject call per chunk ObjectID and


### PR DESCRIPTION
## Summary

Chunk GC was effectively silent in production. A sweep that reclaimed nothing logged at Debug, and the snapshot-declined path logged nothing at all once `ensureGCSnapshotSafe` began answering from its cache. The nbdkit plugin runs at Info unless `VIPERBLOCK_DEBUG=1`, so a correctly-idle GC was indistinguishable from a GC that never ran — which is why verifying GC on env13 meant counting objects in the backend prefix rather than reading a log line.

## Changes

- `sweepChunks` now emits exactly one Info line per sweep, whatever the outcome:
  - `chunk GC: sweep skipped, snapshot-safety check declined` — the silent-forever case.
  - `chunk GC: sweep abandoned, another process snapshotted this volume`.
  - `chunk GC: sweep complete` with `swept`, `candidates`, `floor` and `watermark`, unconditionally (was `swept > 0 ? Info : Debug`).
- No new per-read or per-block logging. At `DefaultGCInterval` (5m) this is 12 lines an hour per volume.

## Tests

Two new tests in `chunk_gc_test.go`, both asserting through a handler pinned to `slog.LevelInfo` so they fail if the lines regress to Debug:

- `TestChunkGC_IdleSweepIsVisibleAtInfoLevel` — a live-data-only volume still reports `swept=0 candidates=0`.
- `TestChunkGC_DeclinedSweepIsVisibleOnEveryPass` — two passes on a snapshot-pinned volume; the second is the one that matters, since the safety answer is cached by then.

Both verified red against pristine `dev` and green with the change. `make preflight` passes.