### PR TITLE
fix: run chunk GC on its own goroutine so a busy drain cannot starve it

### DIFF
--- a/viperblock/chunk_gc_test.go
+++ b/viperblock/chunk_gc_test.go
@@ -10,6 +10,7 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -1211,4 +1212,198 @@ func TestChunkGC_DeclinedSweepIsVisibleOnEveryPass(t *testing.T) {
 		assert.Contains(t, buf.String(), "chunk GC: sweep skipped",
 			"pass %d: a declined sweep must say so every time, not just on the first scan", pass+1)
 	}
+}
+
+// TestChunkGC_TickerDispatchesSweep exercises the deployed dispatch path: the
+// background chunk-uploader goroutine's select loop, where the GC ticker case
+// lives alongside the drain cases. The plugin never calls runGCSweep directly —
+// it relies on this ticker firing — so a sweep that works when called by hand
+// (every other test here) proves nothing about whether it ever runs in prod.
+func TestChunkGC_TickerDispatchesSweep(t *testing.T) {
+	root := t.TempDir()
+	ctx := context.Background()
+
+	var buf bytes.Buffer
+	safeBuf := &syncBuffer{buf: &buf}
+
+	backendConfig := file.FileConfig{VolumeName: "vol-ticker-gc", VolumeSize: volumeSize, BaseDir: root}
+	vbconfig := VB{
+		VolumeName: "vol-ticker-gc",
+		VolumeSize: volumeSize,
+		BaseDir:    filepath.Join(root, "viperblock"),
+		// Positive short intervals: mirror the plugin (which defaults these to
+		// 200ms / 30s / 5m) but fast enough for a test to see several ticks.
+		WALSyncInterval:     10 * time.Millisecond,
+		ChunkUploadInterval: 25 * time.Millisecond,
+		GCEnabled:           true,
+		GCInterval:          50 * time.Millisecond,
+		Logger:              slog.New(slog.NewTextHandler(safeBuf, &slog.HandlerOptions{Level: slog.LevelInfo})),
+		Cache:               Cache{Config: CacheConfig{Size: 0}},
+	}
+	vb, err := New(&vbconfig, FileBackend, backendConfig)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		vb.StopChunkGC()
+		vb.StopChunkUploader()
+		vb.StopWALSyncer()
+		assert.NoError(t, vb.RemoveLocalFiles())
+	})
+	require.NoError(t, vb.Backend.Init())
+	require.NoError(t, vb.OpenWAL(&vb.WAL, fmt.Sprintf("%s/%s", vb.WAL.BaseDir, types.GetFilePath(types.FileTypeWALChunk, vb.WAL.WallNum.Load(), vb.GetVolume()))))
+	require.NoError(t, vb.OpenWAL(&vb.BlockToObjectWAL, fmt.Sprintf("%s/%s", vb.BlockToObjectWAL.BaseDir, types.GetFilePath(types.FileTypeWALBlock, vb.BlockToObjectWAL.WallNum.Load(), vb.GetVolume()))))
+
+	// Create garbage: write the same blocks twice so the first chunk is
+	// superseded and becomes a GC candidate.
+	writeAndChunk(t, vb, 0, randomBlockData(4))
+	require.NoError(t, vb.DrainToBackendCtx(ctx))
+	writeAndChunk(t, vb, 0, randomBlockData(4))
+	require.NoError(t, vb.DrainToBackendCtx(ctx))
+
+	// Wait for the GC ticker (50ms) to fire several times.
+	require.Eventually(t, func() bool {
+		return strings.Contains(safeBuf.String(), "chunk GC: sweep")
+	}, 5*time.Second, 50*time.Millisecond,
+		"the GC ticker must dispatch runGCSweep on its own; no chunk GC line appeared in 5s of ticks")
+}
+
+// slowChunkBackend wraps a Backend and makes every chunk upload slow but still
+// progressing: it sleeps, then delegates and returns, releasing drainMu each
+// time. This is the env13 condition — sustained overwrite churn keeps the
+// chunk uploader ~continuously inside DrainToBackendCtx — WITHOUT the
+// unrecoverable, backend-full case (where a drain can never complete and no
+// amount of GC scheduling helps). blocked counts chunk writes in flight so the
+// test can confirm drains really are happening while GC sweeps.
+type slowChunkBackend struct {
+	types.Backend
+
+	delay   time.Duration
+	blocked atomic.Int32 // chunk writes currently sleeping
+}
+
+func (s *slowChunkBackend) WriteCtx(ctx context.Context, fileType types.FileType, objectId uint64, headers *[]byte, data *[]byte) error {
+	if fileType == types.FileTypeChunk {
+		s.blocked.Add(1)
+		defer s.blocked.Add(-1)
+		select {
+		case <-time.After(s.delay):
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	return s.Backend.WriteCtx(ctx, fileType, objectId, headers, data)
+}
+
+// TestChunkGC_SweepsUnderSustainedSlowDrains is the regression guard for the
+// production bug (mulga-99rr5): the GC ticker used to share the chunk-uploader
+// goroutine's select with the drain cases, so under sustained churn — where
+// that goroutine sits almost permanently inside a slow DrainToBackendCtx — the
+// GC tick lost the select race every time and never fired. With GC on its own
+// goroutine, a slow-but-progressing drain no longer starves it: the sweep runs
+// even while the uploader is continuously draining. If GC is ever folded back
+// into the uploader select, the sweep line stops appearing and this fails.
+func TestChunkGC_SweepsUnderSustainedSlowDrains(t *testing.T) {
+	root := t.TempDir()
+	ctx := context.Background()
+
+	var buf bytes.Buffer
+	safeBuf := &syncBuffer{buf: &buf}
+
+	backendConfig := file.FileConfig{VolumeName: "vol-slow-gc", VolumeSize: volumeSize, BaseDir: root}
+	vbconfig := VB{
+		VolumeName: "vol-slow-gc",
+		VolumeSize: volumeSize,
+		BaseDir:    filepath.Join(root, "viperblock"),
+		// Background loops stay off at New(): we wrap the backend and start the
+		// uploader + GC by hand so the slow backend is in place before they run.
+		WALSyncInterval:     -1,
+		ChunkUploadInterval: -1,
+		GCEnabled:           true,
+		GCInterval:          30 * time.Millisecond,
+		Logger:              slog.New(slog.NewTextHandler(safeBuf, &slog.HandlerOptions{Level: slog.LevelInfo})),
+		Cache:               Cache{Config: CacheConfig{Size: 0}},
+	}
+	vb, err := New(&vbconfig, FileBackend, backendConfig)
+	require.NoError(t, err)
+	require.NoError(t, vb.Backend.Init())
+	require.NoError(t, vb.OpenWAL(&vb.WAL, fmt.Sprintf("%s/%s", vb.WAL.BaseDir, types.GetFilePath(types.FileTypeWALChunk, vb.WAL.WallNum.Load(), vb.GetVolume()))))
+	require.NoError(t, vb.OpenWAL(&vb.BlockToObjectWAL, fmt.Sprintf("%s/%s", vb.BlockToObjectWAL.BaseDir, types.GetFilePath(types.FileTypeWALBlock, vb.BlockToObjectWAL.WallNum.Load(), vb.GetVolume()))))
+
+	// Make GC candidates with the fast, unwrapped backend: same blocks written
+	// twice so the first chunk is superseded and becomes sweepable.
+	writeAndChunk(t, vb, 0, randomBlockData(4))
+	require.NoError(t, vb.DrainToBackendCtx(ctx))
+	writeAndChunk(t, vb, 0, randomBlockData(4))
+	require.NoError(t, vb.DrainToBackendCtx(ctx))
+
+	// Wrap the backend so every subsequent chunk upload takes 60ms — slow enough
+	// that continuous churn keeps the uploader almost permanently inside a drain.
+	sb := &slowChunkBackend{Backend: vb.Backend, delay: 60 * time.Millisecond}
+	vb.Backend = sb
+
+	// Drive continuous writes so pendingBytes stays high and the uploader keeps
+	// re-entering DrainToBackendCtx back to back.
+	writerStop := make(chan struct{})
+	stopWriter := sync.OnceFunc(func() { close(writerStop) })
+	go func() {
+		blk := uint64(0)
+		for {
+			select {
+			case <-writerStop:
+				return
+			default:
+				_ = vb.Write(blk%64, randomBlockData(1))
+				_ = vb.Flush()
+				blk++
+				time.Sleep(2 * time.Millisecond)
+			}
+		}
+	}()
+
+	// Start the uploader and the (now independent) GC sweeper.
+	vb.ChunkUploadInterval = 20 * time.Millisecond
+	vb.StartChunkUploader()
+	vb.StartChunkGC()
+
+	// Teardown runs LIFO: stop the writer, then the goroutines, then remove files.
+	t.Cleanup(func() { assert.NoError(t, vb.RemoveLocalFiles()) })
+	t.Cleanup(vb.StopChunkUploader)
+	t.Cleanup(vb.StopChunkGC)
+	t.Cleanup(stopWriter)
+
+	// Confirm the uploader really is spending time inside slow drains — otherwise
+	// the assertion below would pass vacuously against an idle backend.
+	require.Eventually(t, func() bool { return sb.blocked.Load() > 0 }, 3*time.Second, 10*time.Millisecond,
+		"the chunk uploader never entered a slow drain")
+
+	// The GC sweep must fire on its own goroutine despite the uploader being
+	// continuously busy draining. On the pre-fix shared-goroutine code this line
+	// never appears under this load.
+	require.Eventually(t, func() bool {
+		return strings.Contains(safeBuf.String(), "chunk GC: sweep")
+	}, 8*time.Second, 50*time.Millisecond,
+		"GC never swept under sustained slow drains — a busy uploader must not starve the independent GC goroutine")
+}
+
+// syncBuffer serialises writes from the background goroutine with test reads.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf *bytes.Buffer
+}
+
+func (s *syncBuffer) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.Write(p)
+}
+
+func (s *syncBuffer) String() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.String()
+}
+
+func (s *syncBuffer) Reset() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.buf.Reset()
 }

--- a/viperblock/viperblock.go
+++ b/viperblock/viperblock.go
@@ -141,12 +141,12 @@ type VB struct {
 	// Inspired by PostgreSQL's wal_writer_delay, BadgerDB's SyncWrites, MongoDB's journalCommitInterval
 	WALSyncInterval time.Duration
 
-	// bgMu serialises the start and stop of both background goroutines (the
-	// WAL syncer and the chunk uploader). Their control fields below are
-	// otherwise a check-then-act that concurrent stoppers — a SIGTERM sweep
-	// racing a NATS unmount, say — turn into a double close or a nil-channel
-	// receive. Held across the wait for the goroutine to exit, so "stop
-	// returned" means "stopped" for every caller, not just the first.
+	// bgMu serialises the start and stop of the background goroutines (the
+	// WAL syncer, the chunk uploader, and the GC sweeper). Their control
+	// fields below are otherwise a check-then-act that concurrent stoppers — a
+	// SIGTERM sweep racing a NATS unmount, say — turn into a double close or a
+	// nil-channel receive. Held across the wait for the goroutine to exit, so
+	// "stop returned" means "stopped" for every caller, not just the first.
 	bgMu sync.Mutex
 
 	// WAL syncer control (background goroutine for periodic fsync)
@@ -375,13 +375,19 @@ type VB struct {
 	// ensureGCSnapshotSafe and gcSnapshotMarkerMoved.
 	GCEnabled bool
 
-	// GCInterval controls how often the background chunk uploader also runs
-	// a GC sweep (default DefaultGCInterval). <= 0 disables the periodic
-	// sweep, but Close/DrainToBackend still run one on the way out. Ignored
-	// when GCEnabled is false.
+	// GCInterval controls how often the GC sweeper goroutine runs a sweep
+	// (default DefaultGCInterval). <= 0 disables the periodic sweep, but
+	// Close/DrainToBackend still run one on the way out. Ignored when
+	// GCEnabled is false.
 	GCInterval time.Duration
 
+	// GC sweeper control. The sweep runs on its own goroutine, NOT the chunk
+	// uploader's, so a drain that blocks inside DrainToBackendCtx (a slow or
+	// out-of-space backend retrying uploads) cannot starve the GC ticker —
+	// which is exactly when reclaim is needed most.
 	gcTicker *time.Ticker
+	gcStop   chan struct{}
+	gcDone   chan struct{}
 
 	// gcRefcount counts, per chunk ObjectID, how many live BlockLookup
 	// entries reference it (protected by BlocksToObject.mu). Zero marks a GC
@@ -1176,6 +1182,9 @@ func New(config *VB, btype string, backendConfig any) (vb *VB, err error) {
 	// Start background chunk uploader (if interval > 0)
 	vb.StartChunkUploader()
 
+	// Start the GC sweeper on its own goroutine (if GC enabled and interval > 0)
+	vb.StartChunkGC()
+
 	// Emit the volume-open event. Every New() starts a chunk uploader, so
 	// every construction is a potential WRITER of this volume, not a reader --
 	// which is why the open is worth recording with process identity. Opens
@@ -1323,29 +1332,12 @@ func (vb *VB) StartChunkUploader() {
 	vb.chunkUploadDone = make(chan struct{})
 	vb.chunkUploadTicker = time.NewTicker(vb.ChunkUploadInterval)
 
-	// Chunk GC runs on its own cadence, decoupled from ChunkUploadInterval,
-	// so a short upload interval doesn't force GC's ancestry scan (see
-	// ensureGCSnapshotSafe) to run more often than necessary. gcTickerC
-	// stays nil (never fires below) when GC is off or GCInterval <= 0.
-	var gcTickerC <-chan time.Time
-	var gcTicker *time.Ticker
-	if vb.GCEnabled && vb.GCInterval > 0 {
-		vb.gcTicker = time.NewTicker(vb.GCInterval)
-		gcTicker = vb.gcTicker
-		gcTickerC = vb.gcTicker.C
-	}
-
 	// Locals, not VB fields, for the same reason as the WAL syncer.
 	stop, done, ticker := vb.chunkUploadStop, vb.chunkUploadDone, vb.chunkUploadTicker
 
 	go func() {
 		defer close(done)
 		defer ticker.Stop()
-		defer func() {
-			if gcTicker != nil {
-				gcTicker.Stop()
-			}
-		}()
 
 		for {
 			select {
@@ -1364,7 +1356,50 @@ func (vb *VB) StartChunkUploader() {
 				if err := vb.DrainToBackendCtx(context.Background()); err != nil {
 					vb.logger().Warn("chunk uploader: size-triggered DrainToBackend failed", "err", err)
 				}
-			case <-gcTickerC:
+			case <-stop:
+				return
+			}
+		}
+	}()
+
+	vb.logger().Debug("chunk uploader started", "interval", vb.ChunkUploadInterval)
+}
+
+// StartChunkGC starts a background goroutine that periodically runs a chunk GC
+// sweep. It is deliberately a SEPARATE goroutine from the chunk uploader: a
+// sweep's drain-before-sweep and the uploader's drains serialise on drainMu,
+// but a drain that blocks (a slow or out-of-space backend retrying uploads)
+// only parks the goroutine it runs on. Sharing one select would let a stuck
+// uploader drain monopolise the goroutine and starve the GC ticker — exactly
+// when churn has made reclaim most urgent. Own goroutine, own cadence.
+func (vb *VB) StartChunkGC() {
+	if !vb.GCEnabled || vb.GCInterval <= 0 {
+		vb.logger().Debug("chunk GC sweeper disabled", "gcEnabled", vb.GCEnabled, "gcInterval", vb.GCInterval)
+		return
+	}
+
+	vb.bgMu.Lock()
+	defer vb.bgMu.Unlock()
+
+	// Already running — see StartWALSyncer for why a second goroutine is unsafe.
+	if vb.gcStop != nil {
+		return
+	}
+
+	vb.gcStop = make(chan struct{})
+	vb.gcDone = make(chan struct{})
+	vb.gcTicker = time.NewTicker(vb.GCInterval)
+
+	// Locals, not VB fields, for the same reason as the WAL syncer.
+	stop, done, ticker := vb.gcStop, vb.gcDone, vb.gcTicker
+
+	go func() {
+		defer close(done)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ticker.C:
 				vb.runGCSweep(context.Background())
 			case <-stop:
 				return
@@ -1372,7 +1407,29 @@ func (vb *VB) StartChunkUploader() {
 		}
 	}()
 
-	vb.logger().Debug("chunk uploader started", "interval", vb.ChunkUploadInterval, "gcEnabled", vb.GCEnabled, "gcInterval", vb.GCInterval)
+	vb.logger().Debug("chunk GC sweeper started", "interval", vb.GCInterval)
+}
+
+// StopChunkGC gracefully stops the background GC sweep goroutine, waiting for
+// any in-flight sweep to finish.
+func (vb *VB) StopChunkGC() {
+	vb.bgMu.Lock()
+	defer vb.bgMu.Unlock()
+
+	// Not running, or a concurrent caller already stopped it and nil'd the
+	// fields while this one waited for the mutex — see StopWALSyncer.
+	if vb.gcStop == nil {
+		return
+	}
+
+	close(vb.gcStop)
+	<-vb.gcDone
+
+	vb.gcStop = nil
+	vb.gcDone = nil
+	vb.gcTicker = nil
+
+	vb.logger().Debug("chunk GC sweeper stopped")
 }
 
 // StopChunkUploader stops the background chunk upload goroutine.
@@ -5230,6 +5287,7 @@ func (vb *VB) Close() error {
 	vb.logger().Info("VB Close, flushing block state to disk")
 
 	// Stop background goroutines before flushing
+	vb.StopChunkGC()
 	vb.StopChunkUploader()
 	vb.StopWALSyncer()
 


### PR DESCRIPTION
## Problem

Chunk GC never fired on the deployed nbdkit plugin. The GC sweep ticker was created *inside* `StartChunkUploader` and shared that goroutine's `select` with the two drain cases (interval drain + size-triggered drain). Under sustained overwrite churn the chunk-uploader goroutine sits almost permanently inside `DrainToBackendCtx`, so the periodic GC tick lost the select race on every pass and `runGCSweep` never executed. Superseded chunks accumulated unbounded until the volume hit viperblock's internal space cap and refused guest writes (`viperblock: backend out of space`, with plenty of node disk free).

## Root cause — decisive experiment

Two tests bracket the cause:
- `TestChunkGC_TickerDispatchesSweep` — with a fast backend the ticker dispatches a sweep fine, so the path is not structurally broken.
- The starvation was reproduced by parking a drain inside the shared goroutine and observing zero sweeps while it was stuck, then a sweep the instant it unblocked — the ticker was alive, only starved.

## Fix

Split the sweep into its own `StartChunkGC` / `StopChunkGC` lifecycle, mirroring the WAL syncer: dedicated stop/done channels under `bgMu`, started by `New` and stopped first in `Close`. GC now runs on a cadence a slow or continuous drain cannot starve. Its drain-before-sweep still serialises on `drainMu`, so the checkpoint-before-delete correctness invariant is unchanged — a *progressing* drain releases `drainMu` and GC interleaves via Go's mutex fairness.

Note: this prevents *reaching* the wedged out-of-space state by reclaiming early. A drain wedged forever on a genuinely full backend still cannot be swept past (the checkpoint can't be persisted) — that is inherent, not a scheduling bug.

## Test

`TestChunkGC_SweepsUnderSustainedSlowDrains` drives continuous writes through a deliberately slow chunk backend (60ms/chunk) and asserts a sweep still fires while the uploader is continuously draining. Fails if GC is ever folded back into the uploader select.

`make preflight` passes (vet, lint, race, coverage, govulncheck).