### PR TITLE
fix: treat predastore 503 SlowDown as transient, not out-of-space

### DIFF
--- a/viperblock/backends/s3/s3.go
+++ b/viperblock/backends/s3/s3.go
@@ -30,7 +30,7 @@ import (
 
 // poolPressureHeader is the response header predastore sets on a successful
 // PutObject once its storage pool nears FULL (FULL itself is instead
-// signalled via HTTP 507/503, see classifyWriteErr).
+// signalled via HTTP 507, see classifyWriteErr).
 const poolPressureHeader = "X-Predastore-Pool-Pressure"
 
 // poolPressureNearFull is the only header value this backend acts on.
@@ -78,10 +78,19 @@ func wrapNotFound(err error) error {
 	return err
 }
 
-// classifyWriteErr maps a PutObject error into types.ErrNoSpace when the HTTP
-// status is 507 (Insufficient Storage) or 503 (Service Unavailable) --
-// predastore's two signals for "out of space". Any other error passes
+// classifyWriteErr maps a PutObject error into types.ErrNoSpace ONLY when the
+// HTTP status is 507 (Insufficient Storage) -- predastore's single signal that
+// the store is genuinely full. Every other error, including 503, passes
 // through unchanged.
+//
+// 503 must NOT be treated as out-of-space: predastore returns 503 SlowDown
+// from its PutObject rate limiter, which is transient backpressure ("retry
+// with backoff"), not a full store. Mapping it to ErrNoSpace latched the
+// backendFull flag, and since every retry re-tripped the rate limit the latch
+// never cleared -- wedging the volume permanently under sustained churn. Left
+// as an ordinary error, a persistent 503 surfaces as a failed drain the
+// uploader retries on its next tick while write backpressure throttles the
+// guest, so the volume self-throttles instead of failing.
 func classifyWriteErr(err error) error {
 	if err == nil {
 		return nil
@@ -89,8 +98,7 @@ func classifyWriteErr(err error) error {
 
 	var respErr *smithyhttp.ResponseError
 	if errors.As(err, &respErr) {
-		switch respErr.HTTPStatusCode() {
-		case http.StatusInsufficientStorage, http.StatusServiceUnavailable:
+		if respErr.HTTPStatusCode() == http.StatusInsufficientStorage {
 			return fmt.Errorf("%w: %w", types.ErrNoSpace, err)
 		}
 	}

--- a/viperblock/backends/s3/s3_test.go
+++ b/viperblock/backends/s3/s3_test.go
@@ -151,9 +151,10 @@ func TestWrapNotFound(t *testing.T) {
 	}
 }
 
-// TestClassifyWriteErr pins that only HTTP 507 and 503 classify as
-// types.ErrNoSpace; every other status, or an error with no HTTP response
-// attached, must pass through unchanged.
+// TestClassifyWriteErr pins that ONLY HTTP 507 classifies as types.ErrNoSpace.
+// 503 is predastore's transient SlowDown (rate limit) and must pass through as
+// an ordinary error, never out-of-space; every other status, or an error with
+// no HTTP response attached, also passes through unchanged.
 func TestClassifyWriteErr(t *testing.T) {
 	cases := []struct {
 		name        string
@@ -171,9 +172,12 @@ func TestClassifyWriteErr(t *testing.T) {
 			wantNoSpace: true,
 		},
 		{
-			name:        "503_service_unavailable_maps_to_no_space",
+			// 503 SlowDown is transient rate-limit backpressure, not a full
+			// store — it must stay an ordinary (retryable) error so the
+			// backendFull latch never trips on it.
+			name:        "503_slowdown_stays_unclassified",
 			in:          newResponseError(http.StatusServiceUnavailable),
-			wantNoSpace: true,
+			wantNoSpace: false,
 		},
 		{
 			name:        "500_internal_error_stays_unclassified",


### PR DESCRIPTION
## Problem

Sustained overwrite churn wedged a viperblock volume permanently at `viperblock: backend out of space`, even with ~20 GiB of real disk free — root cause of the env13 GC re-verify failure (mulga-v54g7).

`classifyWriteErr` mapped **both** HTTP 507 and 503 to `types.ErrNoSpace`. But predastore uses those codes for two different things:
- **507 InsufficientStorage** — the store is genuinely full (`store.ErrStoreFull`, past the 5% free watermark).
- **503 SlowDown** — the PutObject **rate limiter** tripped (`[ratelimit] burst=500`). This is transient backpressure meaning "retry with backoff", not a full store.

Under churn the drain's PutObject rate exceeded predastore's limit → 503 SlowDown → viperblock latched `backendFull` → `WriteAtCtx` failed every guest write fast with `ErrNoSpace` → nbdkit ENOSPC → guest wedged. The latch clears only on a *successful* drain, but every retry re-tripped the rate limit, so it **never cleared** — a permanent wedge (env13: at 4m16s).

## Fix

Map **only 507** to `ErrNoSpace`. A persistent 503 now stays an ordinary error: the drain fails, the chunk uploader retries on its next tick, and write backpressure (`MaxPendingBytes`) throttles the guest — so the volume self-throttles against a rate-limited backend instead of failing.

## Test

`TestClassifyWriteErr` updated: 507 → `ErrNoSpace`; 503 SlowDown → ordinary (retryable) error, must NOT set out-of-space. `make preflight` passes.

## Scope

Independent of the chunk-GC-goroutine fix (#49) — that was real but orthogonal; this is the actual env13 blocker. Follow-ups tracked separately: QEMU/QMP whole-VM wedge on `ErrNoSpace` (mulga-xwsm7), viperblock plugin slog not reaching any sink (mulga-aqbx0), and predastore not logging its 503s (owned by the predastore dev).