### PR TITLE
feat: log backendFull latch transitions on drain

### DIFF
--- a/viperblock/enospc_test.go
+++ b/viperblock/enospc_test.go
@@ -1,9 +1,12 @@
 package viperblock
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -277,6 +280,59 @@ func TestWriteAtCtxGateIsLoadBearing(t *testing.T) {
 	vb.pendingBytes.Add(-int64(blockSize))
 	backend.full.Store(false)
 	require.NoError(t, vb.DrainToBackendCtx(context.Background()))
+}
+
+// TestBackendFullLatchLogsTransitionsOnce pins that the backendFull latch logs
+// one line per edge: a Warn when a drain latches the backend out-of-space, an
+// Info when a later clean drain clears it. Each line fires exactly once per
+// transition -- driving two full latch/recover cycles proves the Swap-based
+// edge detection logs again on a fresh edge but never re-logs while the latch
+// state is unchanged, so these lines cannot flood ES under sustained churn.
+// This transition is the signal that guest writes started (and later stopped)
+// failing fast, which was invisible during the env RCA.
+func TestBackendFullLatchLogsTransitionsOnce(t *testing.T) {
+	vb, backend := newEnospcTestVB(t)
+	var buf bytes.Buffer
+	vb.log = slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	blockSize := uint64(vb.BlockSize)
+
+	// latchOnce writes a block, latches the backend full, and drains: the
+	// false->true edge must fire. The write must precede the latch because
+	// WriteAtCtx fails fast once backendFull is set.
+	latchOnce := func(off uint64) {
+		require.NoError(t, vb.WriteAt(off, make([]byte, blockSize)))
+		backend.full.Store(true)
+		require.Error(t, vb.DrainToBackendCtx(context.Background()))
+		require.True(t, vb.backendFull.Load())
+	}
+	// recoverOnce clears the backend and drains clean: the true->false edge fires.
+	recoverOnce := func() {
+		backend.full.Store(false)
+		require.NoError(t, vb.DrainToBackendCtx(context.Background()))
+		require.False(t, vb.backendFull.Load())
+	}
+
+	// Match the unique message substrings, not "backend out of space" -- the
+	// backend's own rejection error carries that same phrase, so it would
+	// over-count.
+	latchLine, recoverLine := "latching writes off", "backend space recovered"
+
+	latchOnce(0)
+	assert.Equal(t, 1, strings.Count(buf.String(), latchLine), "first false->true edge logs once")
+
+	recoverOnce()
+	assert.Equal(t, 1, strings.Count(buf.String(), recoverLine), "first true->false edge logs once")
+
+	// A second clean drain leaves the latch already-clear: no new recovery line.
+	require.NoError(t, vb.DrainToBackendCtx(context.Background()))
+	assert.Equal(t, 1, strings.Count(buf.String(), recoverLine), "a no-op drain must not re-log recovery")
+
+	// Second cycle: a fresh edge in each direction logs again, exactly once more.
+	latchOnce(blockSize)
+	assert.Equal(t, 2, strings.Count(buf.String(), latchLine), "a fresh false->true edge logs again")
+
+	recoverOnce()
+	assert.Equal(t, 2, strings.Count(buf.String(), recoverLine), "a fresh true->false edge logs again")
 }
 
 // TestErrNoSpaceIsTypesErrNoSpace pins that ErrNoSpace re-exports

--- a/viperblock/viperblock.go
+++ b/viperblock/viperblock.go
@@ -2077,11 +2077,19 @@ func (vb *VB) DrainToBackendCtx(ctx context.Context) (err error) {
 	defer func() {
 		if err != nil {
 			if errors.Is(err, ErrNoSpace) {
-				vb.backendFull.Store(true)
+				// Log only the false→true edge (Swap returns the prior value) so a
+				// persistently full backend does not repeat the line on every drain
+				// attempt. This is the signal that guest writes are now failing fast.
+				if !vb.backendFull.Swap(true) {
+					vb.logger().Warn("backend out of space: latching writes off until a drain succeeds", "err", err)
+				}
 			}
 			return
 		}
-		vb.backendFull.Store(false)
+		// A clean drain clears the latch; log only the true→false recovery edge.
+		if vb.backendFull.Swap(false) {
+			vb.logger().Info("backend space recovered: drain succeeded, writes re-enabled")
+		}
 	}()
 
 	if err = vb.Flush(); err != nil {


### PR DESCRIPTION
## Summary

The nbdkit-viperblock plugin's structured logs already reach Elasticsearch: the process inherits `OTEL_EXPORTER_OTLP_ENDPOINT`, `telemetry.Init` wires the OTLP log exporter, and drain-failure, backpressure-retry and chunk-GC lines land in `logs-apm.app.viperblockd` tagged by volume. The one path with no log at all was the `backendFull` latch itself.

`DrainToBackendCtx` set `backendFull` on an `ErrNoSpace` drain error and cleared it on a clean drain via bare `atomic.Store`, so the transition that matters most for diagnosing a wedged volume — guest writes starting, then later stopping, to fail fast with `ErrNoSpace` — produced no line in journald or ES. During an env RCA this left the "backend marked full, writes failing" state invisible.

## Change

- In `DrainToBackendCtx`'s latch defer, replace `backendFull.Store(true/false)` with `Swap`, and log only the edge:
  - **Warn** on the false→true transition: `backend out of space: latching writes off until a drain succeeds`.
  - **Info** on the true→false recovery: `backend space recovered: drain succeeded, writes re-enabled`.
- Both go through `vb.logger()`, so they carry the volume attribute and flow to the OTLP pipeline alongside the existing drain/backpressure/GC lines. A persistently full backend logs the warning once, not on every drain.

## Testing

- `TestBackendFullLatchLogsTransitionsOnce` drives two full latch/recover cycles against the `enospcBackend` fake, asserting each edge logs exactly once per transition and never repeats while the latch state is unchanged.
- `make preflight` passes (race + vet + lint + coverage).