### PR TITLE
test: reproducible image-import flush benchmarks (file + predastore)

### DIFF
--- a/tests/benchmarks/README.md
+++ b/tests/benchmarks/README.md
@@ -1,0 +1,47 @@
+# Viperblock benchmarks
+
+## Flush / image-import benchmarks
+
+`viperblock/import_flush_bench_test.go` reproduces the spinifex image-import-and-flush-to-disk path (`v_utils.ImportDiskImage`) so flush performance can be compared across commits:
+
+- `BenchmarkImportImage_SpinifexStyle` — file backend. Isolates viperblock's WAL->chunk flush to local disk, no network in the path.
+- `BenchmarkImportImage_Predastore` — S3 backend against the predastore test server started in `TestMain`. The real production path: each flush uploads 4 MiB chunk objects that predastore erasure-codes and replicates over raft, so it captures upload cost (the likely end-to-end bottleneck).
+- `BenchmarkFlush_LegacyWAL` / `BenchmarkFlush_ShardedParallel` — flush micro-benchmarks in `sharded_wal_bench_test.go`.
+
+`VB_IMPORT_MB` sets the synthetic image size in MiB (default 256).
+
+Point `TMPDIR` at real disk (not tmpfs) so flushes hit an actual device; otherwise the file backend measures RAM throughput.
+
+```bash
+# Single run
+VB_IMPORT_MB=128 TMPDIR=/var/tmp \
+  go test -run='^$' -bench='BenchmarkImportImage|BenchmarkFlush' \
+  -benchtime=1x -count=10 ./viperblock
+```
+
+## Comparing two commits
+
+Use throwaway worktrees so each commit builds against its own source, then `benchstat`. `GOWORK=off` isolates each worktree from the repo's `go.work`.
+
+```bash
+git worktree add --detach /tmp/vb-old <old-commit>
+git worktree add --detach /tmp/vb-new <new-commit>
+
+# Copy the benchmark file into the old worktree if it predates this commit:
+cp viperblock/import_flush_bench_test.go /tmp/vb-old/viperblock/
+
+for wt in /tmp/vb-old /tmp/vb-new; do
+  ( cd "$wt/viperblock" && GOWORK=off VB_IMPORT_MB=128 TMPDIR=/var/tmp \
+    go test -run='^$' -bench='BenchmarkImportImage_SpinifexStyle' \
+    -benchtime=1x -count=10 . ) \
+    | grep -E '^(goos|goarch|pkg|cpu|Benchmark)' > "$(basename "$wt").txt"
+done
+
+benchstat vb-old.txt vb-new.txt
+git worktree remove /tmp/vb-old && git worktree remove /tmp/vb-new
+```
+
+Notes:
+
+- `TestMain` starts a predastore server that installs a JSON slog logger on the process default; benchmarks call `silenceVBLogs()` at start to stop it corrupting result lines. Keep that call when adding new benchmarks here.
+- The predastore variant leaves objects in the shared server's raft state under a unique per-iteration volume prefix; `TestMain` reclaims the data dir on teardown.

--- a/viperblock/import_flush_bench_test.go
+++ b/viperblock/import_flush_bench_test.go
@@ -1,0 +1,209 @@
+package viperblock
+
+import (
+	"fmt"
+	"log/slog"
+	"math/rand"
+	"os"
+	"strconv"
+	"sync/atomic"
+	"testing"
+
+	"github.com/mulgadc/viperblock/types"
+	"github.com/mulgadc/viperblock/viperblock/backends/file"
+	"github.com/mulgadc/viperblock/viperblock/backends/s3"
+	"github.com/stretchr/testify/require"
+)
+
+// These benchmarks reproduce the spinifex image-import-and-flush-to-disk path
+// (v_utils.ImportDiskImage) so flush performance can be compared across commits
+// with benchstat. Two variants are provided:
+//
+//   - BenchmarkImportImage_SpinifexStyle drives the file backend, isolating
+//     viperblock's WAL->chunk flush to local disk with no network in the path.
+//   - BenchmarkImportImage_Predastore drives the S3 backend against the shared
+//     predastore test server started in TestMain. This is the real production
+//     path: every flush uploads 4 MiB chunk objects that predastore then
+//     erasure-codes and replicates over raft, so it captures upload cost, which
+//     is the likely end-to-end bottleneck the file backend cannot see.
+//
+// Set VB_IMPORT_MB to tune the synthetic image size (default 256 MiB).
+
+// silenceVBLogs discards all slog output for the remainder of the process.
+// TestMain starts a predastore test server that installs a JSON logger on the
+// process-wide slog default; left in place it interleaves with and corrupts the
+// benchmark result lines on stdout. Re-asserting a discard handler at benchmark
+// start (after TestMain has run) suppresses it without touching measured work.
+func silenceVBLogs() {
+	slog.SetDefault(slog.New(slog.DiscardHandler))
+}
+
+// importVolumeSeq gives each import iteration a unique volume name so chunks and
+// state never collide, especially on the shared predastore server.
+var importVolumeSeq atomic.Uint64
+
+// importImageBytes is the synthetic raw-image size imported per iteration.
+// Defaults to 256 MiB (roughly a minimal cloud image expanded to raw); override
+// with VB_IMPORT_MB to model larger AMIs.
+func importImageBytes(b *testing.B) uint64 {
+	b.Helper()
+	mib := 256
+	if v := os.Getenv("VB_IMPORT_MB"); v != "" {
+		n, err := strconv.Atoi(v)
+		require.NoError(b, err)
+		require.Positive(b, n)
+		mib = n
+	}
+	return uint64(mib) * 1024 * 1024
+}
+
+// makeSyntheticImage returns a deterministic, fully non-zero raw image. A fixed
+// seed keeps the payload identical across the two compared commits, and
+// non-zero content means every block is flushed (no zero-block skipping) so the
+// benchmark measures the flush path at maximum load.
+func makeSyntheticImage(size uint64) []byte {
+	img := make([]byte, size)
+	r := rand.New(rand.NewSource(1))
+	_, _ = r.Read(img)
+	return img
+}
+
+// openImportWALs opens the chunk and block WALs the way ImportDiskImage does
+// before its write loop. Shared by both backend variants.
+func openImportWALs(b *testing.B, vb *VB) {
+	b.Helper()
+
+	walPath := fmt.Sprintf("%s/%s", vb.WAL.BaseDir, types.GetFilePath(types.FileTypeWALChunk, vb.WAL.WallNum.Load(), vb.GetVolume()))
+	require.NoError(b, vb.OpenWAL(&vb.WAL, walPath))
+
+	blockWALPath := fmt.Sprintf("%s/%s", vb.BlockToObjectWAL.BaseDir, types.GetFilePath(types.FileTypeWALBlock, vb.BlockToObjectWAL.WallNum.Load(), vb.GetVolume()))
+	require.NoError(b, vb.OpenWAL(&vb.BlockToObjectWAL, blockWALPath))
+}
+
+// newImportVBFile builds a fresh file-backed volume under dir.
+func newImportVBFile(b *testing.B, dir string, size uint64) *VB {
+	b.Helper()
+
+	vol := fmt.Sprintf("import_vol_%d", importVolumeSeq.Add(1))
+	volSize := size + 64*1024*1024 // headroom past the image
+
+	vbconfig := VB{
+		VolumeName:      vol,
+		VolumeSize:      volSize,
+		BaseDir:         fmt.Sprintf("%s/viperblock", dir),
+		WALSyncInterval: -1, // disable the async syncer; the import loop flushes explicitly
+		Cache:           Cache{Config: CacheConfig{Size: 0}},
+	}
+
+	vb, err := New(&vbconfig, "file", file.FileConfig{
+		VolumeName: vol,
+		VolumeSize: volSize,
+		BaseDir:    dir,
+	})
+	require.NoError(b, err)
+	require.NoError(b, vb.Backend.Init())
+
+	openImportWALs(b, vb)
+	return vb
+}
+
+// newImportVBPredastore builds a fresh S3-backed volume against the shared
+// predastore test server. The WAL is still staged on local disk (dir); Flush +
+// WriteWALToChunk upload the sealed chunks to predastore.
+func newImportVBPredastore(b *testing.B, dir string, size uint64) *VB {
+	b.Helper()
+
+	if sharedServerHost == "" {
+		b.Skip("predastore test server not started (sharedServerHost empty)")
+	}
+
+	vol := fmt.Sprintf("import_vol_%d", importVolumeSeq.Add(1))
+	volSize := size + 64*1024*1024
+
+	vbconfig := VB{
+		VolumeName:      vol,
+		VolumeSize:      volSize,
+		BaseDir:         fmt.Sprintf("%s/viperblock", dir),
+		WALSyncInterval: -1,
+		Cache:           Cache{Config: CacheConfig{Size: 0}},
+	}
+
+	vb, err := New(&vbconfig, "s3", s3.S3Config{
+		VolumeName: vol,
+		VolumeSize: volSize,
+		Region:     "ap-southeast-2",
+		Bucket:     sharedBucket,
+		AccessKey:  AccessKey,
+		SecretKey:  SecretKey,
+		Host:       fmt.Sprintf("https://%s", sharedServerHost),
+		HTTPClient: testHTTPClient,
+	})
+	require.NoError(b, err)
+	require.NoError(b, vb.Backend.Init())
+
+	openImportWALs(b, vb)
+	return vb
+}
+
+// importImage replays ImportDiskImage's core loop: sequential 4 KiB WriteAt,
+// then Flush + WriteWALToChunk every 4096 blocks, with a final flush for the
+// remainder. Zero blocks would be skipped by the real importer; the synthetic
+// image is fully non-zero, so every block is written and flushed.
+func importImage(b *testing.B, vb *VB, img []byte) {
+	b.Helper()
+
+	blockSize := uint64(vb.BlockSize)
+	nblocks := uint64(len(img)) / blockSize
+
+	for block := uint64(0); block < nblocks; block++ {
+		off := block * blockSize
+		require.NoError(b, vb.WriteAt(off, img[off:off+blockSize]))
+
+		// Flush every 4096 blocks, matching ImportDiskImage's cadence.
+		if (block+1)%uint64(vb.BlockSize) == 0 {
+			require.NoError(b, vb.Flush())
+			require.NoError(b, vb.WriteWALToChunk(true))
+		}
+	}
+
+	// Flush the trailing partial batch, completing the import.
+	require.NoError(b, vb.Flush())
+	require.NoError(b, vb.WriteWALToChunk(true))
+}
+
+// runImportBenchmark imports a full synthetic image into a fresh volume per
+// iteration, flushing to disk as spinifex does. newVB selects the backend.
+func runImportBenchmark(b *testing.B, newVB func(b *testing.B, dir string, size uint64) *VB) {
+	silenceVBLogs()
+	size := importImageBytes(b)
+	img := makeSyntheticImage(size)
+	b.SetBytes(int64(size))
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		dir, err := os.MkdirTemp("", "vbimport-*")
+		require.NoError(b, err)
+		vb := newVB(b, dir, size)
+		b.StartTimer()
+
+		importImage(b, vb, img)
+
+		b.StopTimer()
+		_ = vb.Close()
+		_ = os.RemoveAll(dir)
+		b.StartTimer()
+	}
+}
+
+// BenchmarkImportImage_SpinifexStyle measures the import-and-flush path on the
+// file backend, isolating viperblock's flush logic from the network.
+func BenchmarkImportImage_SpinifexStyle(b *testing.B) {
+	runImportBenchmark(b, newImportVBFile)
+}
+
+// BenchmarkImportImage_Predastore measures the real end-to-end import path,
+// including chunk upload to the predastore test cluster.
+func BenchmarkImportImage_Predastore(b *testing.B) {
+	runImportBenchmark(b, newImportVBPredastore)
+}

--- a/viperblock/sharded_wal_bench_test.go
+++ b/viperblock/sharded_wal_bench_test.go
@@ -134,6 +134,7 @@ func BenchmarkWrite_Concurrent8_ShardedWAL(b *testing.B) {
 }
 
 func BenchmarkFlush_LegacyWAL(b *testing.B) {
+	silenceVBLogs()
 	vb := setupBenchVB(b, false)
 
 	data := make([]byte, 4096)
@@ -149,6 +150,7 @@ func BenchmarkFlush_LegacyWAL(b *testing.B) {
 }
 
 func BenchmarkFlush_ShardedParallel(b *testing.B) {
+	silenceVBLogs()
 	vb := setupBenchVB(b, true)
 
 	data := make([]byte, 4096)


### PR DESCRIPTION
## Summary

Adds committed, reproducible benchmarks for the spinifex image-import-and-flush-to-disk path (`v_utils.ImportDiskImage`) so flush performance can be compared across commits with `benchstat`.

- `BenchmarkImportImage_SpinifexStyle` — file backend. Isolates viperblock's WAL->chunk flush to local disk; no network in the path.
- `BenchmarkImportImage_Predastore` — S3 backend against the `TestMain` predastore server. The real production path: each flush uploads 4 MiB chunk objects that predastore erasure-codes and replicates over raft, so it captures upload cost (the likely end-to-end bottleneck).
- `silenceVBLogs()` stops `TestMain`'s predastore JSON logger from corrupting benchmark result lines on stdout, wired into the existing `BenchmarkFlush_*` benchmarks too.
- `tests/benchmarks/README.md` documents the worktree + `benchstat` recipe.

`VB_IMPORT_MB` tunes the synthetic image size (default 256 MiB). Point `TMPDIR` at real disk so flushes hit an actual device.

## Benchmark results

Comparison that motivated this work: `25f4273` (old) vs `a977b1b` (current dev tip at the time). 128 MiB synthetic image, file backend, ext4 real disk, `-benchtime=1x -count=10`, 8-core Xeon 6148.

```
                            │ import_target.txt │           import_dev.txt            │
                            │      sec/op       │   sec/op     vs base                │
ImportImage_SpinifexStyle-8        1021.7m ± 8%   891.5m ± 2%  -12.74% (p=0.001 n=10)

                            │ import_target.txt │            import_dev.txt            │
                            │        B/s        │     B/s       vs base                │
ImportImage_SpinifexStyle-8        125.3Mi ± 8%   143.6Mi ± 2%  +14.60% (p=0.001 n=10)
```

Dev is ~13% faster / ~15% higher throughput on the import-and-flush path, and notably more consistent (±2% vs ±8%).

### File backend vs predastore end-to-end

The file backend caps at local-disk speed and cannot see upload cost. Same box, 16 MiB image, single shot:

| Variant | Throughput |
|---|---|
| `ImportImage_SpinifexStyle` (file) | ~82 MiB/s |
| `ImportImage_Predastore` (S3 + predastore erasure-coding + raft) | ~52 MiB/s |

Confirms the predastore upload is a real, distinct cost — the end-to-end variant is the one to watch for production import performance.