### PR TITLE
perf(telemetry): remove per-call allocation from the per-block cache instrument

### DIFF
--- a/telemetry/metrics.go
+++ b/telemetry/metrics.go
@@ -31,11 +31,13 @@ var (
 	rmwConflicts metric.Int64Counter
 	volumeOpens  metric.Int64Counter
 
-	// cacheHitOpt/cacheMissOpt are pre-built so the per-block cache lookup
-	// path (inside the read hot loop) allocates nothing beyond the record
-	// call itself.
-	cacheHitOpt  metric.AddOption
-	cacheMissOpt metric.AddOption
+	// cacheHitOpts/cacheMissOpts are pre-built as slices, not bare options, so
+	// the per-block cache lookup path (inside the read hot loop) allocates
+	// nothing at all. Passing a bare AddOption to the variadic Add still heap-
+	// allocates the 16-byte backing slice on every call; passing a pre-built
+	// slice with ... reuses it.
+	cacheHitOpts  []metric.AddOption
+	cacheMissOpts []metric.AddOption
 )
 
 // instruments lazily creates the shared instruments. The global meter
@@ -89,8 +91,12 @@ func instruments() {
 			otel.Handle(err)
 		}
 
-		cacheHitOpt = metric.WithAttributeSet(attribute.NewSet(attribute.String("result", "hit")))
-		cacheMissOpt = metric.WithAttributeSet(attribute.NewSet(attribute.String("result", "miss")))
+		cacheHitOpts = []metric.AddOption{
+			metric.WithAttributeSet(attribute.NewSet(attribute.String("result", "hit"))),
+		}
+		cacheMissOpts = []metric.AddOption{
+			metric.WithAttributeSet(attribute.NewSet(attribute.String("result", "miss"))),
+		}
 
 		rmwConflicts, err = m.Int64Counter("viperblock.write.rmw_conflicts",
 			metric.WithDescription("Partial writes that found another write already rebuilding the same block. Non-zero means guest I/O produces same-block write concurrency."),
@@ -205,16 +211,16 @@ func RecordWALOp(ctx context.Context, phase, volume, outcome string, elapsed tim
 }
 
 // RecordCacheLookup records one block-cache lookup outcome ("hit"/"miss").
-// Hot path: called per block in the read loop, so it uses a pre-built
-// AddOption rather than allocating an attribute set per call.
+// Hot path: called per block in the read loop, so it passes a pre-built option
+// slice rather than allocating an attribute set or a variadic slice per call.
 func RecordCacheLookup(ctx context.Context, hit bool) {
 	instruments()
 	if cacheLookups == nil {
 		return
 	}
 	if hit {
-		cacheLookups.Add(ctx, 1, cacheHitOpt)
+		cacheLookups.Add(ctx, 1, cacheHitOpts...)
 		return
 	}
-	cacheLookups.Add(ctx, 1, cacheMissOpt)
+	cacheLookups.Add(ctx, 1, cacheMissOpts...)
 }

--- a/telemetry/metrics_bench_test.go
+++ b/telemetry/metrics_bench_test.go
@@ -1,0 +1,103 @@
+package telemetry
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/metric/noop"
+)
+
+// withNoopProvider pins an explicit no-op MeterProvider, matching the state of
+// a process where Init found no OTLP endpoint and left the globals alone. This
+// is the baseline the export-enabled benchmarks are compared against: the
+// difference between the two is the cost of turning telemetry on.
+func withNoopProvider(b *testing.B) {
+	b.Helper()
+	prev := otel.GetMeterProvider()
+	otel.SetMeterProvider(noop.NewMeterProvider())
+	instrumentsOnce = sync.Once{}
+	b.Cleanup(func() {
+		otel.SetMeterProvider(prev)
+		instrumentsOnce = sync.Once{}
+	})
+}
+
+// BenchmarkRecordCacheLookup measures the only instrument on a per-4KB-block
+// path (the read loop in viperblock.Read). At 4KB blocks a 1 GB/s read issues
+// ~262k of these per second, so this is the one Record* call whose per-call
+// cost is visible in data-path throughput. cacheHitOpt/cacheMissOpt are
+// pre-built precisely so this allocates nothing; ReportAllocs holds that.
+func BenchmarkRecordCacheLookup(b *testing.B) {
+	ctx := context.Background()
+
+	b.Run("noop", func(b *testing.B) {
+		withNoopProvider(b)
+		instruments()
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			RecordCacheLookup(ctx, i%2 == 0)
+		}
+	})
+
+	b.Run("sdk", func(b *testing.B) {
+		withManualReader(b)
+		instruments()
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			RecordCacheLookup(ctx, i%2 == 0)
+		}
+	})
+}
+
+// BenchmarkRecordCacheLookupParallel measures the same call under contention.
+// Concurrent guest reads land in the same sum aggregator, so the shared
+// attribute-set map and its lock are the scaling limit, not the Add itself.
+func BenchmarkRecordCacheLookupParallel(b *testing.B) {
+	ctx := context.Background()
+	withManualReader(b)
+	instruments()
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		hit := true
+		for pb.Next() {
+			RecordCacheLookup(ctx, hit)
+			hit = !hit
+		}
+	})
+}
+
+// BenchmarkRecordBackendIO measures the per-chunk-object instrument. It builds
+// a fresh attribute.NewSet of 4 KeyValues per call and drives three counters,
+// so it is materially more expensive than RecordCacheLookup — but it fires
+// once per 4MB object rather than once per 4KB block, which is the reason that
+// cost is acceptable. The allocs/op figure quantifies the attribute set.
+func BenchmarkRecordBackendIO(b *testing.B) {
+	ctx := context.Background()
+	const elapsed = 250 * time.Microsecond
+
+	b.Run("noop", func(b *testing.B) {
+		withNoopProvider(b)
+		instruments()
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			RecordBackendIO(ctx, "read", "s3", "vol-bench", "success", 4<<20, elapsed)
+		}
+	})
+
+	b.Run("sdk", func(b *testing.B) {
+		withManualReader(b)
+		instruments()
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			RecordBackendIO(ctx, "read", "s3", "vol-bench", "success", 4<<20, elapsed)
+		}
+	})
+}

--- a/telemetry/metrics_test.go
+++ b/telemetry/metrics_test.go
@@ -18,7 +18,7 @@ import (
 // create fresh instruments bound to the manual reader — otherwise the
 // package-level Once fired by an earlier test would keep pointing at
 // whatever provider was live when it first ran.
-func withManualReader(t *testing.T) *sdkmetric.ManualReader {
+func withManualReader(t testing.TB) *sdkmetric.ManualReader {
 	t.Helper()
 	reader := sdkmetric.NewManualReader()
 	prev := otel.GetMeterProvider()


### PR DESCRIPTION
## Summary

Benchmarks the two viperblock OTel instruments closest to the data path, and fixes a per-call
allocation the benchmark exposed on the per-block read path.

`RecordCacheLookup` fires once per 4KB block inside the read loop
(`viperblock/viperblock.go:5603,5608`), unlike every other instrument here, which fires once per
4MB chunk object or once per WAL operation. It is therefore the only instrument whose per-call
cost shows up in data-path throughput, and it had never been measured.

## The bug the benchmark found

`metrics.go` claimed the per-block path "allocates nothing beyond the record call itself".
It allocated 16 B / 1 alloc on every call. `cacheHitOpt`/`cacheMissOpt` were pre-built as bare
`metric.AddOption` values, so the pre-built attribute set removed the *attribute set* allocation
— but passing a bare option to the variadic `Add(ctx, incr, ...AddOption)` still heap-allocates
the backing slice each call.

Pre-building the option *slice* and passing it with `...` lets Go reuse the backing array, so
nothing is allocated.

## Results

Xeon Gold 6148 @ 2.40GHz, before → after:

| Benchmark | Before | After |
|---|---|---|
| `RecordCacheLookup/noop` | 56.71 ns/op, 16 B, 1 alloc | **5.42 ns/op, 0 B, 0 allocs** |
| `RecordCacheLookup/sdk` | 137.5 ns/op, 16 B, 1 alloc | **81.19 ns/op, 0 B, 0 allocs** |
| `RecordCacheLookupParallel` | 83.04 ns/op, 16 B, 1 alloc | **87.97 ns/op, 0 B, 0 allocs** |
| `RecordBackendIO/noop` | 1108 ns/op, 712 B, 6 allocs | 772.4 ns/op, 712 B, 6 allocs |
| `RecordBackendIO/sdk` | 1811 ns/op, 712 B, 6 allocs | 1069 ns/op, 712 B, 6 allocs |

10x faster with export disabled, 41% faster with export enabled. At 1 GB/s of 4KB reads that is
~262k calls/s, so it also stops ~4 MB/s of garbage.

## What the numbers mean for a storage node

With export enabled `RecordCacheLookup` costs 81 ns/op, so a sustained 1 GB/s read stream spends
~21 ms/s on it — about 2% of one core, down from ~3.6%.

`RecordBackendIO` is ~1 µs/op but fires once per 4MB object, so at the same throughput that is
~256 calls/s, under 0.03% of a core. Its 6 allocs/op are the `attribute.NewSet`; left as-is
deliberately, since the call rate makes it irrelevant and the `volume.name` attribute is wanted.

## Benchmark design

Each instrument is measured under both a no-op `MeterProvider` (the state when `Init` finds no
OTLP endpoint and leaves the globals alone) and a real `sdk/metric` provider with a
`ManualReader`. The difference between the two is the cost of turning telemetry on, which is the
question a storage operator actually has. `b.ReportAllocs()` throughout, so a regression back to
a per-call allocation on the hot path fails visibly.

`withManualReader` in `metrics_test.go` is widened from `*testing.T` to `testing.TB` so the
benchmarks can reuse it — no behaviour change.

## Testing

- `go test ./telemetry/` passes.
- `go test -run '^$' -bench=. -benchmem ./telemetry/` produces the table above.
- `make preflight` passes (golangci-lint 0 issues, govulncheck clean, tests + race).
