### PR TITLE
fix(telemetry): log JSON to stderr so nbdkit plugin lines reach journald

### DIFF
--- a/telemetry/slog.go
+++ b/telemetry/slog.go
@@ -5,6 +5,7 @@ package telemetry
 import (
 	"context"
 	"errors"
+	"io"
 	"log/slog"
 	"os"
 
@@ -14,26 +15,31 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-// NewJSONLogger builds a *slog.Logger that writes JSON to stdout at the
+// logDest is where NewJSONLogger writes its JSON lines. Stderr, not stdout:
+// nbdkit repoints a plugin's fd 1 at /dev/null but leaves fd 2 on the parent's
+// journald socket, so a stdout logger discards everything the plugin emits.
+var logDest io.Writer = os.Stderr
+
+// NewJSONLogger builds a *slog.Logger that writes JSON to stderr at the
 // given level, with trace_id/span_id stamping. If Init already installed a
 // real OTLP LoggerProvider, the logger also fans out to it. Unlike
 // SetDefaultJSONLogger this never touches slog.SetDefault, so it is safe to
 // call from library code that only wants its own scoped logger.
 func NewJSONLogger(serviceName string, level slog.Level) *slog.Logger {
-	stdout := NewSlogHandler(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+	stderr := NewSlogHandler(slog.NewJSONHandler(logDest, &slog.HandlerOptions{
 		Level: level,
 	}))
 
 	lp, ok := loggerglobal.GetLoggerProvider().(*sdklog.LoggerProvider)
 	if !ok {
-		return slog.New(stdout)
+		return slog.New(stderr)
 	}
 	bridge := otelslog.NewHandler(serviceName, otelslog.WithLoggerProvider(lp))
-	return slog.New(newFanoutHandler(stdout, bridge))
+	return slog.New(newFanoutHandler(stderr, bridge))
 }
 
 // SetDefaultJSONLogger installs the process-wide slog default built by
-// NewJSONLogger. Repeated calls re-establish stdout-at-level without ever
+// NewJSONLogger. Repeated calls re-establish stderr-at-level without ever
 // clobbering the OTLP bridge. Callers must invoke this explicitly
 // (standalone entrypoints only) — never from a constructor an embedder might
 // call, or it silently hijacks the host process's own logger.

--- a/telemetry/slog_test.go
+++ b/telemetry/slog_test.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"io"
 	"log/slog"
+	"os"
 	"sync"
 	"testing"
 
@@ -75,12 +77,12 @@ func TestSlogHandlerPreservesWrapperThroughWithAttrs(t *testing.T) {
 	}
 }
 
-// TestSetDefaultJSONLoggerNoLoggerProviderIsStdoutOnly is the no-op
+// TestSetDefaultJSONLoggerNoLoggerProviderIsStderrOnly is the no-op
 // guarantee: with no real LoggerProvider installed (Init did not run, or
 // ran without an OTLP endpoint), SetDefaultJSONLogger must produce a
-// stdout-only default and never wrap it in a fanoutHandler — standalone
+// stderr-only default and never wrap it in a fanoutHandler — standalone
 // logging behavior stays unchanged with OTLP unconfigured.
-func TestSetDefaultJSONLoggerNoLoggerProviderIsStdoutOnly(t *testing.T) {
+func TestSetDefaultJSONLoggerNoLoggerProviderIsStderrOnly(t *testing.T) {
 	prevLP := loggerglobal.GetLoggerProvider()
 	defer loggerglobal.SetLoggerProvider(prevLP)
 	loggerglobal.SetLoggerProvider(lognoop.NewLoggerProvider())
@@ -91,7 +93,34 @@ func TestSetDefaultJSONLoggerNoLoggerProviderIsStdoutOnly(t *testing.T) {
 	SetDefaultJSONLogger("viperblockd", slog.LevelInfo)
 
 	if _, ok := slog.Default().Handler().(*fanoutHandler); ok {
-		t.Error("expected stdout-only handler without a real LoggerProvider, got fanoutHandler")
+		t.Error("expected stderr-only handler without a real LoggerProvider, got fanoutHandler")
+	}
+}
+
+// TestLogDestIsStderr pins the stream choice. nbdkit repoints a plugin's fd 1
+// at /dev/null while leaving fd 2 on the parent's journald socket, so a stdout
+// logger discards every line the plugin emits — including the volume seal path.
+func TestLogDestIsStderr(t *testing.T) {
+	if logDest != io.Writer(os.Stderr) {
+		t.Errorf("logDest = %v, want os.Stderr; nbdkit sends a plugin's stdout to /dev/null", logDest)
+	}
+	if logDest == io.Writer(os.Stdout) {
+		t.Error("logDest is os.Stdout, which the nbdkit plugin cannot write to")
+	}
+}
+
+// TestNewJSONLoggerWritesToLogDest proves the handler actually emits to
+// logDest, so TestLogDestIsStderr is asserting about the live destination.
+func TestNewJSONLoggerWritesToLogDest(t *testing.T) {
+	var buf bytes.Buffer
+	prev := logDest
+	logDest = &buf
+	defer func() { logDest = prev }()
+
+	NewJSONLogger("viperblockd", slog.LevelInfo).Info("seal probe")
+
+	if !bytes.Contains(buf.Bytes(), []byte("seal probe")) {
+		t.Errorf("log line missing from logDest: %s", buf.String())
 	}
 }
 


### PR DESCRIPTION
## Problem

The viperblock nbdkit plugin's logs never reached journald. `NewJSONLogger` wrote to `os.Stdout`, and nbdkit repoints a plugin's fd 1 at `/dev/null` while leaving fd 2 on the parent's journald socket.

Verified live on env12:

```
/proc/<nbdkit>/fd/1 -> /dev/null
/proc/<nbdkit>/fd/2 -> socket:[5774]     # journald, same socket as viperblockd's own fd 1 and 2
```

The OTLP fan-out hid this in steady state — plugin lines do reach Elasticsearch, 213 hits for a plugin-only message on env12. It stops hiding it during host shutdown: the observability agent stops before the graceful drain, so the volume seal ran with no live OTLP endpoint and no journald fallback. The seal window produced two documents in ES, neither from the seal.

So the seal path was observable in normal operation and blind during the only event it exists for. That cost a full investigation into a graceful-shutdown seal that turned out to be working.

## Change

Route the JSON handler through a `logDest` var defaulting to `os.Stderr`.

`logDest` is a var rather than a direct `os.Stderr` reference because the `reassign` linter forbids reassigning `os.Stdout` in a test, which is what a pipe-swap assertion would have required.

## Verified on env12

Built the plugin from this branch and installed it on a live node.

Before: zero plugin-origin lines in the journal. After, on the same node:

```
14:18:32 spx[5545]: {"level":"INFO","msg":"Close, flushing block state to disk"}
14:18:32 spx[5545]: {"level":"INFO","msg":"VB Close, flushing block state to disk"}
14:18:32 spx[5545]: {"level":"INFO","msg":"Removing local files","path":".../vol-f2e3c1e729be45cd3-efi"}
14:18:49 spx[5538]: {"level":"ERROR","msg":"Unload: otel shutdown failed","err":"... dial tcp 127.0.0.1:4317: connect: connection refused ..."}
14:18:49 spx[1440]: {"level":"WARN","msg":"ebs.unmount: no local viperblock state for volume, skipping seal"}
```

The whole seal path is now legible on the host, including the `Removing local files` call that deletes the state directory before viperblockd checks for it. The `Unload: otel shutdown failed` line is self-demonstrating: without this change, the error proving OTLP was dead would itself have been unloggable.

## Scope: this does not by itself get the seal into Elasticsearch

An earlier draft of this description claimed journald replay would ship the shutdown lines to ES on the next boot. That is wrong, and measurement disproved it — seal lines present in journald, zero in ES.

Alloy's `journal_bridged_dedup` filter drops journal records from `spinifex-viperblock.service`, on the assumption that the service self-exports via OTLP. During shutdown that assumption is false, because Alloy has already stopped. The journal copy is dropped and the direct copy was never sent.

Closing that needs a systemd stop-ordering change in the `obs-agent` Ansible role, so Alloy outlives the drain. Tracked separately; it does not affect the correctness of this change, which is what makes the path legible on the host at all.

## Tests

- `TestLogDestIsStderr` pins the destination, with the nbdkit reasoning in the comment.
- `TestNewJSONLoggerWritesToLogDest` proves the handler emits to `logDest`, so the first test asserts about the live destination rather than an unused var.
- Confirmed the pair fails when the writer is switched back to `os.Stdout`.

`make preflight` passes.

## Follow-ups

The plugin's `serviceName` is `viperblockd`, identical to the daemon, so ES still cannot attribute a line to either. Not addressed here.