### PR TITLE
fix(viperblock): keep local files when Close cannot upload the WAL

### DIFF
--- a/viperblock/close_local_files_test.go
+++ b/viperblock/close_local_files_test.go
@@ -1,0 +1,144 @@
+package viperblock
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/mulgadc/viperblock/types"
+	"github.com/mulgadc/viperblock/viperblock/backends/file"
+	"github.com/stretchr/testify/require"
+)
+
+// errChunkWrite stands in for a backend that rejects a chunk upload — a full
+// or unreachable predastore, say — without needing a real one to fail.
+var errChunkWrite = errors.New("simulated chunk write rejection")
+
+// chunkFailBackend fails FileTypeChunk writes only, leaving config and
+// checkpoint writes working. That is the case Close has to survive: the WAL
+// never reaches the backend while both state saves report success.
+type chunkFailBackend struct {
+	types.Backend
+
+	failChunks atomic.Bool
+}
+
+func (b *chunkFailBackend) Write(fileType types.FileType, objectId uint64, headers *[]byte, data *[]byte) error {
+	if fileType == types.FileTypeChunk && b.failChunks.Load() {
+		return errChunkWrite
+	}
+	return b.Backend.Write(fileType, objectId, headers, data)
+}
+
+func (b *chunkFailBackend) WriteCtx(ctx context.Context, fileType types.FileType, objectId uint64, headers *[]byte, data *[]byte) error {
+	if fileType == types.FileTypeChunk && b.failChunks.Load() {
+		return errChunkWrite
+	}
+	return b.Backend.WriteCtx(ctx, fileType, objectId, headers, data)
+}
+
+func newChunkFailTestVB(t *testing.T) (*VB, *chunkFailBackend) {
+	t.Helper()
+
+	tmpDir := t.TempDir()
+	testVol := fmt.Sprintf("test_closewal_%d", time.Now().UnixNano())
+
+	backendConfig := file.FileConfig{
+		VolumeName: testVol,
+		VolumeSize: 64 * 1024 * 1024,
+		BaseDir:    tmpDir,
+	}
+
+	vbconfig := VB{
+		VolumeName: testVol,
+		VolumeSize: 64 * 1024 * 1024,
+		BaseDir:    fmt.Sprintf("%s/%s", tmpDir, "viperblock"),
+		// Deterministic: no background WAL fsync or ticker-driven chunk upload
+		// racing Close, which is the only thing under test here.
+		WALSyncInterval:     -1,
+		ChunkUploadInterval: -1,
+		Cache: Cache{
+			Config: CacheConfig{Size: 0},
+		},
+	}
+
+	vb, err := New(&vbconfig, FileBackend, backendConfig)
+	require.NoError(t, err)
+	require.NotNil(t, vb)
+
+	vb.UseShardedWAL = false
+	vb.ShardedWAL = nil
+
+	require.NoError(t, vb.Backend.Init())
+	backend := &chunkFailBackend{Backend: vb.Backend}
+	vb.Backend = backend
+
+	require.NoError(t, vb.OpenWAL(&vb.WAL, fmt.Sprintf("%s/%s", vb.WAL.BaseDir, types.GetFilePath(types.FileTypeWALChunk, vb.WAL.WallNum.Load(), vb.GetVolume()))))
+	require.NoError(t, vb.OpenWAL(&vb.BlockToObjectWAL, fmt.Sprintf("%s/%s", vb.BlockToObjectWAL.BaseDir, types.GetFilePath(types.FileTypeWALBlock, vb.BlockToObjectWAL.WallNum.Load(), vb.GetVolume()))))
+
+	return vb, backend
+}
+
+// TestCloseKeepsLocalFilesWhenChunkUploadFails is the durability guarantee: if
+// the WAL never reached the backend, the local copy is the only one left, so
+// Close must not delete it however well the state saves went.
+func TestCloseKeepsLocalFilesWhenChunkUploadFails(t *testing.T) {
+	vb, backend := newChunkFailTestVB(t)
+
+	blockSize := int(vb.BlockSize)
+	require.NoError(t, vb.WriteAt(0, make([]byte, blockSize)))
+
+	localPath := filepath.Join(vb.BaseDir, vb.GetVolume())
+	require.DirExists(t, localPath, "local state should exist before Close")
+
+	backend.failChunks.Store(true)
+
+	err := vb.Close()
+	require.Error(t, err, "Close must report the failed chunk upload")
+	require.ErrorIs(t, err, errChunkWrite)
+
+	require.DirExists(t, localPath, "Close deleted the only copy of the un-uploaded writes")
+}
+
+// TestCloseRemovesLocalFilesOnSuccess pins the other half: a clean Close still
+// reclaims the local files, so the test above is proving the failure gate and
+// not merely that removal never happens.
+func TestCloseRemovesLocalFilesOnSuccess(t *testing.T) {
+	vb, _ := newChunkFailTestVB(t)
+
+	blockSize := int(vb.BlockSize)
+	require.NoError(t, vb.WriteAt(0, make([]byte, blockSize)))
+
+	localPath := filepath.Join(vb.BaseDir, vb.GetVolume())
+	require.DirExists(t, localPath, "local state should exist before Close")
+
+	require.NoError(t, vb.Close())
+
+	_, statErr := os.Stat(localPath)
+	require.True(t, os.IsNotExist(statErr), "clean Close should remove local files, stat gave %v", statErr)
+}
+
+// TestCloseKeepsLocalFilesWhenFlushFails covers the other ungated failure: a
+// partial flush leaves writes only in memory and in the local WAL.
+func TestCloseKeepsLocalFilesWhenFlushFails(t *testing.T) {
+	vb, _ := newChunkFailTestVB(t)
+
+	localPath := filepath.Join(vb.BaseDir, vb.GetVolume())
+	require.DirExists(t, localPath, "local state should exist before Close")
+
+	// Stage a hot write, then close the WAL file underneath it so the flush
+	// inside Close fails on write — a WAL that can no longer be appended to.
+	vb.Writes.Blocks = append(vb.Writes.Blocks, Block{SeqNum: 1, Block: 0, Len: uint64(vb.BlockSize), Data: make([]byte, int(vb.BlockSize))})
+	require.NotEmpty(t, vb.WAL.DB)
+	require.NoError(t, vb.WAL.DB[len(vb.WAL.DB)-1].Close())
+
+	err := vb.Close()
+	require.Error(t, err, "Close must report the failed flush")
+
+	require.DirExists(t, localPath, "Close deleted the local WAL after a failed flush")
+}

--- a/viperblock/viperblock.go
+++ b/viperblock/viperblock.go
@@ -5311,8 +5311,9 @@ func (vb *VB) Close() error {
 	vb.StopChunkUploader()
 	vb.StopWALSyncer()
 
-	if err := vb.Flush(); err != nil {
-		vb.logger().Error("failed to flush during Close", "error", err)
+	flushErr := vb.Flush()
+	if flushErr != nil {
+		vb.logger().Error("failed to flush during Close", "error", flushErr)
 	}
 
 	var walErr error
@@ -5345,12 +5346,20 @@ func (vb *VB) Close() error {
 
 	vb.logger().Debug("Saving Close state to", "path", path)
 
-	var firstErr error
+	// Whatever the flush and WAL upload above failed to move to the backend
+	// still exists only in the local files, so those failures have to survive
+	// to the RemoveLocalFiles gate below.
+	firstErr := flushErr
+	if firstErr == nil {
+		firstErr = walErr
+	}
 
 	// Upload the state to the backend
 	if err := vb.SaveState(); err != nil {
 		vb.logger().Error("Could not save state", "err", err)
-		firstErr = err
+		if firstErr == nil {
+			firstErr = err
+		}
 	}
 
 	// Always attempt to save the block checkpoint even if SaveState or WAL
@@ -5363,7 +5372,10 @@ func (vb *VB) Close() error {
 		}
 	}
 
+	// Deleting now would destroy the only copy of the un-uploaded writes. Keep
+	// the files so the next Open recovers them from the local WAL.
 	if firstErr != nil {
+		vb.logger().Error("Close failed, keeping local files for recovery", "err", firstErr)
 		return firstErr
 	}
 
@@ -5373,9 +5385,6 @@ func (vb *VB) Close() error {
 		vb.logger().Error("Failed to remove local files", "err", err)
 	}
 
-	if walErr != nil {
-		return walErr
-	}
 	return nil
 }
 


### PR DESCRIPTION
## Problem

`VB.Close()` logged and then discarded the errors from `Flush()` and `WriteWALToChunk(true)`, and went on to call `RemoveLocalFiles()` anyway. If the backend rejected the chunk upload — full or unreachable predastore, expired credentials — the writes existed only in the local WAL, and `Close()` deleted it. The volume came back on the next `Open()` missing every write that had not already reached the backend, with nothing on disk to recover from.

Only `SaveState()` and `SaveBlockState()` were gated. The two failures that actually mean "data has not reached the backend" were not.

## Change

`flushErr` and `walErr` now feed the same `firstErr` gate as the state saves. Behaviour on failure:

- both state saves are still attempted, since in-memory `BlockLookup` may hold successfully flushed writes from earlier `Flush` calls
- `RemoveLocalFiles()` is skipped
- the first error is returned, so the caller sees the failed drain and the next `Open()` recovers from the local WAL

A clean `Close()` is unchanged: files are still removed and `nil` returned.

## Tests

New `viperblock/close_local_files_test.go`, with a backend that fails `FileTypeChunk` writes only so the WAL upload fails while the config and checkpoint writes succeed:

- `TestCloseKeepsLocalFilesWhenChunkUploadFails` — WAL upload fails, state saves succeed, local files survive, error returned
- `TestCloseKeepsLocalFilesWhenFlushFails` — the WAL file is closed underneath a staged hot write so the flush fails, local files survive
- `TestCloseRemovesLocalFilesOnSuccess` — clean close still reclaims the local files, so the two above are proving the gate rather than the absence of removal

Verified the two failure tests fail on `dev` and pass with the change, while the success test passes on both. Full `viperblock/...` package tests and `make preflight` pass.