### PR TITLE
fix(viperblock): retry WAL generations stranded by a failed chunk upload

### DIFF
--- a/viperblock/stranded_wal_test.go
+++ b/viperblock/stranded_wal_test.go
@@ -1,0 +1,113 @@
+package viperblock
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// pendingWALChunksLen reads vb.pendingWALChunks under its mutex, so tests
+// don't reach into the field without the lock the production code requires.
+func pendingWALChunksLen(vb *VB) int {
+	vb.pendingWALMu.Lock()
+	defer vb.pendingWALMu.Unlock()
+	return len(vb.pendingWALChunks)
+}
+
+// TestRetryPendingWALChunksUploadsStrandedGeneration pins the core fix: a WAL
+// generation rotated out by a drain whose chunk upload failed is not lost --
+// it is retried by a later drain, actually lands in the backend, and its
+// data reads back correctly.
+func TestRetryPendingWALChunksUploadsStrandedGeneration(t *testing.T) {
+	vb, backend := newEnospcTestVB(t)
+	blockSize := uint64(vb.BlockSize)
+	data := bytes.Repeat([]byte{0xAB}, int(blockSize))
+
+	require.NoError(t, vb.WriteAt(0, data))
+
+	backend.full.Store(true)
+	err := vb.DrainToBackendCtx(context.Background())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrNoSpace, "drain error must classify as ErrNoSpace")
+	require.True(t, vb.backendFull.Load())
+
+	require.Equal(t, 1, pendingWALChunksLen(vb), "the generation whose upload failed must be tracked for retry")
+
+	// Not yet resolvable via BlockLookup -- the chunk never reached the
+	// backend, so nothing but the in-memory pending-writes buffer has it.
+	_, _, _, lookupErr := vb.LookupBlockToObject(0)
+	assert.ErrorIs(t, lookupErr, ErrZeroBlock, "block must not resolve via BlockLookup until its chunk actually lands")
+
+	backend.full.Store(false)
+	require.NoError(t, vb.DrainToBackendCtx(context.Background()), "drain must retry and land the stranded generation now the backend has recovered")
+
+	assert.Zero(t, pendingWALChunksLen(vb), "pendingWALChunks must be drained once the retry succeeds")
+
+	_, _, _, lookupErr = vb.LookupBlockToObject(0)
+	assert.NoError(t, lookupErr, "block must resolve via BlockLookup once the stranded chunk lands")
+
+	readBack, err := vb.ReadAt(0, blockSize)
+	require.NoError(t, err)
+	assert.Equal(t, data, readBack, "data from the stranded generation must read back correctly")
+}
+
+// TestBackendFullLatchHoldsAcrossEmptyRetryDrain pins that the backendFull
+// latch does not flap while a stranded generation still fails: a second
+// drain against a still-full backend, with no new guest writes, must retry
+// the stranded generation and fail again -- not spuriously succeed because
+// the freshly rotated current generation happens to be empty.
+func TestBackendFullLatchHoldsAcrossEmptyRetryDrain(t *testing.T) {
+	vb, backend := newEnospcTestVB(t)
+	blockSize := uint64(vb.BlockSize)
+
+	require.NoError(t, vb.WriteAt(0, make([]byte, blockSize)))
+
+	backend.full.Store(true)
+	require.Error(t, vb.DrainToBackendCtx(context.Background()))
+	require.True(t, vb.backendFull.Load())
+	require.Equal(t, 1, pendingWALChunksLen(vb))
+
+	err := vb.DrainToBackendCtx(context.Background())
+	require.Error(t, err, "a drain with no new writes must still retry the stranded generation and fail")
+	assert.ErrorIs(t, err, ErrNoSpace)
+	assert.True(t, vb.backendFull.Load(), "backendFull must stay latched while the stranded generation still fails")
+	assert.Equal(t, 1, pendingWALChunksLen(vb), "the stranded generation must remain pending after a failed retry")
+}
+
+// TestBackendFullLatchClearsOnlyAfterStrandedGenerationLands pins that the
+// latch clears only once the previously stranded generation actually
+// reaches the backend, not on an intervening empty drain.
+func TestBackendFullLatchClearsOnlyAfterStrandedGenerationLands(t *testing.T) {
+	vb, backend := newEnospcTestVB(t)
+	blockSize := uint64(vb.BlockSize)
+
+	require.NoError(t, vb.WriteAt(0, make([]byte, blockSize)))
+
+	backend.full.Store(true)
+	require.Error(t, vb.DrainToBackendCtx(context.Background()))
+	require.True(t, vb.backendFull.Load())
+
+	require.Error(t, vb.DrainToBackendCtx(context.Background()), "a second drain against a still-full backend must fail too")
+	require.True(t, vb.backendFull.Load(), "latch must still be set before the backend recovers")
+
+	backend.full.Store(false)
+	require.NoError(t, vb.DrainToBackendCtx(context.Background()), "drain must succeed once the backend recovers and the stranded generation lands")
+	assert.False(t, vb.backendFull.Load(), "latch must clear once the stranded generation actually lands")
+	assert.Zero(t, pendingWALChunksLen(vb), "pendingWALChunks must be empty once the recovery drain succeeds")
+}
+
+// TestPendingWALChunksEmptyOnCleanDrain pins the no-regression case: a drain
+// that never hits a backend failure must never populate pendingWALChunks.
+func TestPendingWALChunksEmptyOnCleanDrain(t *testing.T) {
+	vb, _ := newEnospcTestVB(t)
+	blockSize := uint64(vb.BlockSize)
+
+	require.NoError(t, vb.WriteAt(0, make([]byte, blockSize)))
+	require.NoError(t, vb.DrainToBackendCtx(context.Background()))
+
+	assert.Zero(t, pendingWALChunksLen(vb), "a successful drain must never populate pendingWALChunks")
+	assert.False(t, vb.backendFull.Load())
+}

--- a/viperblock/viperblock.go
+++ b/viperblock/viperblock.go
@@ -206,6 +206,12 @@ type VB struct {
 	// successful drain.
 	backendFull atomic.Bool
 
+	// pendingWALChunks holds WAL generations that were rotated out but whose
+	// chunk upload failed. Retried at the head of the next consolidation so
+	// the data is not stranded in-process until the next restart.
+	pendingWALChunks []uint64
+	pendingWALMu     sync.Mutex
+
 	// drainMu serializes DrainToBackendCtx across all its triggers. Two
 	// concurrent drains would rotate to different WAL segments and race in
 	// createChunkFile, where an older segment landing last can clobber a
@@ -2678,6 +2684,13 @@ func (vb *VB) WriteShardedWALToChunkCtx(ctx context.Context, force bool) error {
 		return fmt.Errorf("ShardedWAL not initialized")
 	}
 
+	// Retry any generation stranded by an earlier failed upload before
+	// rotating in a new one, so the uploader ticker keeps retrying without
+	// waiting for a forced drain.
+	if err := vb.retryPendingWALChunks(ctx, vb.consolidateShardedWALGeneration); err != nil {
+		return err
+	}
+
 	// If no shard files are open, this VB instance doesn't own the WAL.
 	// Skip consolidation (matches legacy WriteWALToChunk empty-DB guard).
 	hasOpenShards := false
@@ -2775,6 +2788,24 @@ func (vb *VB) WriteShardedWALToChunkCtx(ctx context.Context, force bool) error {
 		sw.Shards[i].mu.Unlock()
 	}
 
+	if err := vb.consolidateShardedWALGeneration(ctx, currentWALNum); err != nil {
+		vb.pendingWALMu.Lock()
+		vb.pendingWALChunks = append(vb.pendingWALChunks, currentWALNum)
+		vb.pendingWALMu.Unlock()
+		return err
+	}
+
+	return nil
+}
+
+// consolidateShardedWALGeneration reads generation walNum's closed shard
+// files in parallel, dedupes, sorts, and uploads chunks to the backend.
+// walNum must already be rotated out (its shard files closed) before
+// calling; this touches neither WallNum nor open shard files, so it is safe
+// to call on a generation that was rotated out by an earlier attempt.
+func (vb *VB) consolidateShardedWALGeneration(ctx context.Context, walNum uint64) error {
+	sw := vb.ShardedWAL
+
 	// Read closed shard files in parallel
 	type shardResult struct {
 		blocks []Block
@@ -2790,7 +2821,7 @@ func (vb *VB) WriteShardedWALToChunkCtx(ctx context.Context, force bool) error {
 			defer wg.Done()
 
 			filename := filepath.Join(sw.BaseDir,
-				types.GetShardedWALPath(vb.GetVolume(), currentWALNum, shardID))
+				types.GetShardedWALPath(vb.GetVolume(), walNum, shardID))
 
 			file, err := os.OpenFile(filename, os.O_RDONLY, 0600)
 			if err != nil {
@@ -2881,7 +2912,7 @@ func (vb *VB) WriteShardedWALToChunkCtx(ctx context.Context, force bool) error {
 	chunkBuffer := make([]byte, 0, vb.ObjBlockSize)
 	matchedBlocks := make([]Block, 0)
 
-	up, _ := vb.newParallelUploader(ctx, currentWALNum)
+	up, _ := vb.newParallelUploader(ctx, walNum)
 
 	for _, block := range sortedBlocks {
 		chunkBuffer = append(chunkBuffer, block.Data...)
@@ -2913,6 +2944,35 @@ func (vb *VB) WriteWALToChunk(force bool) error {
 	return vb.WriteWALToChunkCtx(context.Background(), force)
 }
 
+// retryPendingWALChunks retries WAL generations that were rotated out by an
+// earlier consolidation but whose chunk upload failed, oldest first. Each
+// entry is dropped only once its consolidation succeeds; the first failure
+// stops the retry immediately and is returned so the caller's drain still
+// reports it (and, on ErrNoSpace, keeps the backendFull latch set).
+func (vb *VB) retryPendingWALChunks(ctx context.Context, consolidate func(context.Context, uint64) error) error {
+	for {
+		vb.pendingWALMu.Lock()
+		if len(vb.pendingWALChunks) == 0 {
+			vb.pendingWALMu.Unlock()
+			return nil
+		}
+		walNum := vb.pendingWALChunks[0]
+		vb.pendingWALMu.Unlock()
+
+		if err := consolidate(ctx, walNum); err != nil {
+			return err
+		}
+
+		// Drop the entry only after a successful consolidation. Re-check the
+		// head in case a concurrent caller already removed it.
+		vb.pendingWALMu.Lock()
+		if len(vb.pendingWALChunks) > 0 && vb.pendingWALChunks[0] == walNum {
+			vb.pendingWALChunks = vb.pendingWALChunks[1:]
+		}
+		vb.pendingWALMu.Unlock()
+	}
+}
+
 // WriteWALToChunkCtx is WriteWALToChunk with a caller-supplied context
 // threaded through the chunk uploads. Consolidates the WAL (or dispatches to
 // the sharded WAL) into a durable chunk object on the backend.
@@ -2929,6 +2989,13 @@ func (vb *VB) WriteWALToChunkCtx(ctx context.Context, force bool) (err error) {
 	// Dispatch to sharded implementation when enabled
 	if vb.UseShardedWAL {
 		return vb.WriteShardedWALToChunkCtx(ctx, force)
+	}
+
+	// Retry any generation stranded by an earlier failed upload before
+	// rotating in a new one, so the uploader ticker keeps retrying without
+	// waiting for a forced drain.
+	if err := vb.retryPendingWALChunks(ctx, vb.consolidateWALGeneration); err != nil {
+		return err
 	}
 
 	// First, lock, and close the current WAL file
@@ -2973,8 +3040,23 @@ func (vb *VB) WriteWALToChunkCtx(ctx context.Context, force bool) (err error) {
 		return err
 	}
 
-	filename := fmt.Sprintf("%s/%s", vb.WAL.BaseDir, types.GetFilePath(types.FileTypeWALChunk, currentWALNum, vb.GetVolume()))
-	//filename := fmt.Sprintf("%s/%s/wal/chunks/wal.%08d.bin", vb.WAL.BaseDir, vb.GetVolume(), currentWALNum)
+	if err := vb.consolidateWALGeneration(ctx, currentWALNum); err != nil {
+		vb.pendingWALMu.Lock()
+		vb.pendingWALChunks = append(vb.pendingWALChunks, currentWALNum)
+		vb.pendingWALMu.Unlock()
+		return err
+	}
+
+	return nil
+}
+
+// consolidateWALGeneration reads, dedupes, and uploads WAL generation walNum's
+// blocks to the backend as chunk objects. walNum must already be rotated out
+// of vb.WAL.DB (its file closed) before calling; this touches neither
+// WallNum nor open file handles, so it is safe to call on a generation that
+// was rotated out by an earlier consolidation attempt.
+func (vb *VB) consolidateWALGeneration(ctx context.Context, walNum uint64) error {
+	filename := fmt.Sprintf("%s/%s", vb.WAL.BaseDir, types.GetFilePath(types.FileTypeWALChunk, walNum, vb.GetVolume()))
 	pendingWAL2, err := os.OpenFile(filename, os.O_RDWR, 0600)
 	if err != nil {
 		return err
@@ -3101,7 +3183,7 @@ func (vb *VB) WriteWALToChunkCtx(ctx context.Context, force bool) (err error) {
 	var chunkBuffer = make([]byte, 0, vb.ObjBlockSize)
 	var matchedBlocks = make([]Block, 0)
 
-	up, ctx := vb.newParallelUploader(ctx, currentWALNum)
+	up, ctx := vb.newParallelUploader(ctx, walNum)
 
 	for _, block := range sortedBlocks {
 		chunkBuffer = append(chunkBuffer, block.Data...)


### PR DESCRIPTION
Part of the viperblock durability batch (`mulga-8bplk`) — merges to `dev` now, spinifex is repinned once when the batch closes. Closes `mulga-bs473`.

## Problem

`WriteWALToChunkCtx` commits the WAL rotation before the upload can fail:

1. sync + close the current WAL file
2. `WallNum.Add(1)`, open the next generation so writers proceed
3. reopen generation N by name, read and dedupe
4. upload the chunks
5. return the uploader's error

When step 4 fails, generation N's file is still on disk but nothing in the process refers to it again — every consolidation reads `vb.WAL.DB[len(vb.WAL.DB)-1]`, which is now generation N+1. The chunk is recovered only by WAL replay on the next process start, never retried in-process.

Worse, the next drain consolidates the freshly opened, empty generation: no blocks, no chunk submitted, `up.wait()` returns nil, drain succeeds. `DrainToBackendCtx`'s deferred handler reads that as recovery and clears `backendFull`, so `WriteAtCtx` stops failing fast while the chunk has never reached the backend. Against a sustained-full backend the latch flaps — set by the failing drain, cleared by the next empty one — instead of holding.

`WriteShardedWALToChunkCtx` has the same ordering and the same defect. Sharded WAL is off by default and refused alongside encryption, so it is not the production path today, but it is fixed here rather than left to diverge.

Durability across a clean restart was never at risk: the on-disk WAL is not deleted and replay recovers it. The bug is in-process — no retry, and a premature latch clear.

One correction to the bead's premise: `openWALLocked` appends to `vb.WAL.DB` and the slice is never truncated, so the old entry is not dropped and the `len(vb.WAL.DB) == 0` guard is not what the next drain hits. The consequence is identical, because only the last entry is ever consolidated.

## Change

- `pendingWALChunks []uint64` + `pendingWALMu` on `VB`. Its own mutex, not `drainMu`: consolidation is also driven from `Close` and the uploader ticker, neither of which holds `drainMu`.
- The "consolidate generation N" half of each entry point is extracted into `consolidateWALGeneration` / `consolidateShardedWALGeneration`. Neither touches `WallNum` or open handles, so both are safe to call on an already-rotated-out generation.
- Both entry points retry pending generations oldest-first before rotating a new one, dropping an entry only once its consolidation succeeds. The retry sits ahead of the `!force` size check, so the 30s uploader ticker drives retries without waiting for a forced drain.
- A failed upload of the current generation records it as pending before returning the error.

Latch correctness falls out: with a pending generation, a drain cannot reach the "nothing to upload, success" path, so `backendFull` stays latched and clears only once the chunk lands.

### Known limitation

A part-way-failed generation is retried whole, so chunks that did land are re-uploaded under fresh object IDs and the originals become garbage for chunk GC. Wasteful but correct — `BlockLookup` ends up on the newest copy. Per-chunk retry would need the uploader to report which submissions succeeded, which is not worth it for a path that only runs when the backend is already failing.

## Tests

New `viperblock/stranded_wal_test.go`, on the existing `newEnospcTestVB` scaffolding:

- `TestRetryPendingWALChunksUploadsStrandedGeneration` — fail-drain, recover the backend, drain again; the stranded generation lands, `BlockLookup` resolves, data reads back
- `TestBackendFullLatchHoldsAcrossEmptyRetryDrain` — a second drain with no new writes still retries and fails; the latch does not flap
- `TestBackendFullLatchClearsOnlyAfterStrandedGenerationLands` — latch clears only once the chunk actually lands
- `TestPendingWALChunksEmptyOnCleanDrain` — clean path never populates the queue

Load-bearing check: with the retry hook and the failure-record neutralised (everything else intact, so it still compiles and reproduces the pre-fix control flow), the first three FAIL and the clean-path test still PASSES.

Full `./viperblock/...` and `make preflight` pass.