### PR TITLE
fix(viperblock): bound the nbdkit plugin's shutdown drain

### DIFF
--- a/nbd/viperblock.go
+++ b/nbd/viperblock.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"path/filepath"
 	"syscall"
+	"time"
 
 	"github.com/mulgadc/predastore/pkg/masterkey"
 	"github.com/mulgadc/viperblock/telemetry"
@@ -32,6 +33,11 @@ var pluginName = "viperblock"
 // to the otelslog bridge, matching the metrics-apm.app.<name> data stream
 // dashboards are built against.
 const serviceName = "viperblockd"
+
+// shutdownDrainTimeout bounds the backend half of connection close and plugin
+// unload. An aborted drain is safe: committed writes are in the fsync'd local
+// WAL and replay on the next attach.
+const shutdownDrainTimeout = 20 * time.Second
 
 // otelShutdown flushes the OTLP exporters on Unload, if telemetry.Init
 // configured real ones. nil (a no-op) when OTLP export is not configured.
@@ -502,13 +508,19 @@ func (c *ViperBlockConnection) Close() {
 
 	stopSnapshotListener()
 
+	// One budget for the drain and the close together, not one each: systemd's
+	// TimeoutStopSec backstops this, and two full budgets in series would
+	// overrun it and turn the backstop into a SIGKILL.
+	ctx, cancel := context.WithTimeout(context.Background(), shutdownDrainTimeout)
+	defer cancel()
+
 	// DrainToBackend before Close so the live checkpoint is current. Close
 	// will also flush WAL chunks, but does not save the live checkpoint.
-	if err := c.vb.DrainToBackend(); err != nil {
+	if err := c.vb.DrainToBackendCtx(ctx); err != nil {
 		slog.Error("Close: DrainToBackend failed", "err", err)
 	}
 
-	if err := c.vb.Close(); err != nil {
+	if err := c.vb.CloseCtx(ctx); err != nil {
 		slog.Error("Could not close VB", "err", err)
 	}
 	activeVB = nil
@@ -534,10 +546,14 @@ func (p *ViperBlockPlugin) Unload() {
 	}
 	slog.Info("Unload: Close was not called, flushing block state now")
 	stopSnapshotListener()
-	if err := activeVB.DrainToBackend(); err != nil {
+
+	ctx, cancel := context.WithTimeout(context.Background(), shutdownDrainTimeout)
+	defer cancel()
+
+	if err := activeVB.DrainToBackendCtx(ctx); err != nil {
 		slog.Error("Unload: DrainToBackend failed", "err", err)
 	}
-	if err := activeVB.Close(); err != nil {
+	if err := activeVB.CloseCtx(ctx); err != nil {
 		slog.Error("Unload: could not close VB", "err", err)
 	}
 	activeVB = nil

--- a/viperblock/close_ctx_test.go
+++ b/viperblock/close_ctx_test.go
@@ -1,0 +1,180 @@
+package viperblock
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/mulgadc/viperblock/types"
+	"github.com/mulgadc/viperblock/viperblock/backends/file"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// blockingBackend wraps a real types.Backend and makes every WriteCtx call
+// block until its context is done, then return ctx.Err(). It stands in for a
+// predastore that has stopped responding, so CloseCtx's own bound is what
+// unwedges the caller instead of the backend ever completing the write.
+type blockingBackend struct {
+	types.Backend
+}
+
+func (b *blockingBackend) WriteCtx(ctx context.Context, fileType types.FileType, objectId uint64, headers *[]byte, data *[]byte) error {
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+// newCloseCtxTestVB builds a minimal file-backed VB, modeled on
+// newEnospcTestVB (enospc_test.go): background WAL fsync and chunk upload are
+// disabled so DrainToBackendCtx/CloseCtx are the only things touching the
+// backend. Its Backend starts out real and unwrapped so setup (Init, WriteAt)
+// never blocks; callers wrap vb.Backend in blockingBackend afterward.
+func newCloseCtxTestVB(t *testing.T, root, volumeName string) (*VB, file.FileConfig) {
+	t.Helper()
+
+	backendConfig := file.FileConfig{
+		VolumeName: volumeName,
+		VolumeSize: 64 * 1024 * 1024,
+		BaseDir:    root,
+	}
+
+	vbconfig := VB{
+		VolumeName:          volumeName,
+		VolumeSize:          64 * 1024 * 1024,
+		BaseDir:             fmt.Sprintf("%s/%s", root, "viperblock"),
+		WALSyncInterval:     -1,
+		ChunkUploadInterval: -1,
+		Cache: Cache{
+			Config: CacheConfig{Size: 0},
+		},
+	}
+
+	vb, err := New(&vbconfig, FileBackend, backendConfig)
+	require.NoError(t, err)
+	require.NotNil(t, vb)
+
+	vb.UseShardedWAL = false
+	vb.ShardedWAL = nil
+
+	require.NoError(t, vb.Backend.Init())
+	require.NoError(t, vb.OpenWAL(&vb.WAL, fmt.Sprintf("%s/%s", vb.WAL.BaseDir, types.GetFilePath(types.FileTypeWALChunk, vb.WAL.WallNum.Load(), vb.GetVolume()))))
+	require.NoError(t, vb.OpenWAL(&vb.BlockToObjectWAL, fmt.Sprintf("%s/%s", vb.BlockToObjectWAL.BaseDir, types.GetFilePath(types.FileTypeWALBlock, vb.BlockToObjectWAL.WallNum.Load(), vb.GetVolume()))))
+
+	return vb, backendConfig
+}
+
+// TestCloseCtxExpiredContextReturnsPromptlyAndKeepsLocalFiles pins the first
+// half of the shutdown-drain bound: CloseCtx given an already-expired context
+// must not attempt to wait on the backend at all, and the #58 firstErr gate
+// must keep the local WAL/state files since nothing reached the backend.
+func TestCloseCtxExpiredContextReturnsPromptlyAndKeepsLocalFiles(t *testing.T) {
+	root := t.TempDir()
+	const vol = "vol-closectx-expired"
+
+	vb, _ := newCloseCtxTestVB(t, root, vol)
+	blockSize := int(vb.BlockSize)
+	require.NoError(t, vb.WriteAt(0, make([]byte, blockSize)))
+
+	// Wrap only after setup so New/Init/WriteAt above never touch the
+	// blocking backend.
+	vb.Backend = &blockingBackend{Backend: vb.Backend}
+
+	localPath := filepath.Join(vb.BaseDir, vb.GetVolume())
+	require.DirExists(t, localPath, "local state should exist before CloseCtx")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	start := time.Now()
+	err := vb.CloseCtx(ctx)
+	elapsed := time.Since(start)
+
+	require.Error(t, err, "CloseCtx must report the context error")
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Less(t, elapsed, time.Second,
+		"CloseCtx must return promptly on an already-done context, not attempt any backend I/O")
+
+	require.DirExists(t, localPath, "CloseCtx deleted the only copy of the un-uploaded writes")
+}
+
+// TestCloseCtxLiveContextHealthyBackendCompletes pins the other half: against
+// a backend that actually completes writes, a live (non-expired) context must
+// not change CloseCtx's clean-path behavior, including removing local files.
+func TestCloseCtxLiveContextHealthyBackendCompletes(t *testing.T) {
+	root := t.TempDir()
+	const vol = "vol-closectx-healthy"
+
+	vb, _ := newCloseCtxTestVB(t, root, vol)
+	blockSize := int(vb.BlockSize)
+	require.NoError(t, vb.WriteAt(0, make([]byte, blockSize)))
+
+	localPath := filepath.Join(vb.BaseDir, vb.GetVolume())
+	require.DirExists(t, localPath, "local state should exist before CloseCtx")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	require.NoError(t, vb.CloseCtx(ctx))
+
+	_, statErr := os.Stat(localPath)
+	require.True(t, os.IsNotExist(statErr), "a clean CloseCtx should remove local files, stat gave %v", statErr)
+}
+
+// TestCloseCtxDeadlineAbortLeavesWALRecoverable is the property the whole
+// bound rests on: a CloseCtx aborted by its deadline must leave the write
+// recoverable from the local WAL. It reopens a fresh VB over the same
+// BaseDir/backend, replaying the production boot order (LoadState ->
+// LoadLiveCheckpoint -> RecoverLocalWALs -> OpenWAL, matching
+// nbd/viperblock.go's connection-open sequence), and reads the data back.
+func TestCloseCtxDeadlineAbortLeavesWALRecoverable(t *testing.T) {
+	root := t.TempDir()
+	const vol = "vol-closectx-deadline-abort"
+
+	vb, backendConfig := newCloseCtxTestVB(t, root, vol)
+	blockSize := int(vb.BlockSize)
+	want := bytes.Repeat([]byte{0x7B}, blockSize)
+	require.NoError(t, vb.WriteAt(0, append([]byte(nil), want...)))
+
+	vb.Backend = &blockingBackend{Backend: vb.Backend}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	err := vb.CloseCtx(ctx)
+	elapsed := time.Since(start)
+
+	require.Error(t, err, "CloseCtx must report the deadline that aborted the backend chunk upload")
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.Less(t, elapsed, 5*time.Second, "CloseCtx must return once its deadline fires, not hang")
+
+	localPath := filepath.Join(vb.BaseDir, vb.GetVolume())
+	require.DirExists(t, localPath, "aborted CloseCtx must keep local files for recovery")
+
+	reopenConfig := VB{
+		VolumeName:      vol,
+		VolumeSize:      64 * 1024 * 1024,
+		BaseDir:         vb.BaseDir,
+		WALSyncInterval: -1,
+		Cache: Cache{
+			Config: CacheConfig{Size: 0},
+		},
+	}
+	reopened, err := New(&reopenConfig, FileBackend, backendConfig)
+	require.NoError(t, err)
+	require.NoError(t, reopened.Backend.Init())
+	require.NoError(t, reopened.LoadState())
+	require.NoError(t, reopened.LoadLiveCheckpoint())
+	require.NoError(t, reopened.RecoverLocalWALs())
+	require.NoError(t, reopened.OpenWAL(&reopened.WAL, fmt.Sprintf("%s/%s", reopened.WAL.BaseDir, types.GetFilePath(types.FileTypeWALChunk, reopened.WAL.WallNum.Load(), reopened.GetVolume()))))
+	require.NoError(t, reopened.OpenWAL(&reopened.BlockToObjectWAL, fmt.Sprintf("%s/%s", reopened.BlockToObjectWAL.BaseDir, types.GetFilePath(types.FileTypeWALBlock, reopened.BlockToObjectWAL.WallNum.Load(), reopened.GetVolume()))))
+	t.Cleanup(func() { assert.NoError(t, reopened.RemoveLocalFiles()) })
+
+	got, err := reopened.ReadAt(0, uint64(blockSize))
+	require.NoError(t, err)
+	assert.Equal(t, want, got, "the aborted CloseCtx must not lose the write: WAL replay must reproduce it byte-for-byte")
+}

--- a/viperblock/close_local_files_test.go
+++ b/viperblock/close_local_files_test.go
@@ -1,0 +1,144 @@
+package viperblock
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/mulgadc/viperblock/types"
+	"github.com/mulgadc/viperblock/viperblock/backends/file"
+	"github.com/stretchr/testify/require"
+)
+
+// errChunkWrite stands in for a backend that rejects a chunk upload — a full
+// or unreachable predastore, say — without needing a real one to fail.
+var errChunkWrite = errors.New("simulated chunk write rejection")
+
+// chunkFailBackend fails FileTypeChunk writes only, leaving config and
+// checkpoint writes working. That is the case Close has to survive: the WAL
+// never reaches the backend while both state saves report success.
+type chunkFailBackend struct {
+	types.Backend
+
+	failChunks atomic.Bool
+}
+
+func (b *chunkFailBackend) Write(fileType types.FileType, objectId uint64, headers *[]byte, data *[]byte) error {
+	if fileType == types.FileTypeChunk && b.failChunks.Load() {
+		return errChunkWrite
+	}
+	return b.Backend.Write(fileType, objectId, headers, data)
+}
+
+func (b *chunkFailBackend) WriteCtx(ctx context.Context, fileType types.FileType, objectId uint64, headers *[]byte, data *[]byte) error {
+	if fileType == types.FileTypeChunk && b.failChunks.Load() {
+		return errChunkWrite
+	}
+	return b.Backend.WriteCtx(ctx, fileType, objectId, headers, data)
+}
+
+func newChunkFailTestVB(t *testing.T) (*VB, *chunkFailBackend) {
+	t.Helper()
+
+	tmpDir := t.TempDir()
+	testVol := fmt.Sprintf("test_closewal_%d", time.Now().UnixNano())
+
+	backendConfig := file.FileConfig{
+		VolumeName: testVol,
+		VolumeSize: 64 * 1024 * 1024,
+		BaseDir:    tmpDir,
+	}
+
+	vbconfig := VB{
+		VolumeName: testVol,
+		VolumeSize: 64 * 1024 * 1024,
+		BaseDir:    fmt.Sprintf("%s/%s", tmpDir, "viperblock"),
+		// Deterministic: no background WAL fsync or ticker-driven chunk upload
+		// racing Close, which is the only thing under test here.
+		WALSyncInterval:     -1,
+		ChunkUploadInterval: -1,
+		Cache: Cache{
+			Config: CacheConfig{Size: 0},
+		},
+	}
+
+	vb, err := New(&vbconfig, FileBackend, backendConfig)
+	require.NoError(t, err)
+	require.NotNil(t, vb)
+
+	vb.UseShardedWAL = false
+	vb.ShardedWAL = nil
+
+	require.NoError(t, vb.Backend.Init())
+	backend := &chunkFailBackend{Backend: vb.Backend}
+	vb.Backend = backend
+
+	require.NoError(t, vb.OpenWAL(&vb.WAL, fmt.Sprintf("%s/%s", vb.WAL.BaseDir, types.GetFilePath(types.FileTypeWALChunk, vb.WAL.WallNum.Load(), vb.GetVolume()))))
+	require.NoError(t, vb.OpenWAL(&vb.BlockToObjectWAL, fmt.Sprintf("%s/%s", vb.BlockToObjectWAL.BaseDir, types.GetFilePath(types.FileTypeWALBlock, vb.BlockToObjectWAL.WallNum.Load(), vb.GetVolume()))))
+
+	return vb, backend
+}
+
+// TestCloseKeepsLocalFilesWhenChunkUploadFails is the durability guarantee: if
+// the WAL never reached the backend, the local copy is the only one left, so
+// Close must not delete it however well the state saves went.
+func TestCloseKeepsLocalFilesWhenChunkUploadFails(t *testing.T) {
+	vb, backend := newChunkFailTestVB(t)
+
+	blockSize := int(vb.BlockSize)
+	require.NoError(t, vb.WriteAt(0, make([]byte, blockSize)))
+
+	localPath := filepath.Join(vb.BaseDir, vb.GetVolume())
+	require.DirExists(t, localPath, "local state should exist before Close")
+
+	backend.failChunks.Store(true)
+
+	err := vb.Close()
+	require.Error(t, err, "Close must report the failed chunk upload")
+	require.ErrorIs(t, err, errChunkWrite)
+
+	require.DirExists(t, localPath, "Close deleted the only copy of the un-uploaded writes")
+}
+
+// TestCloseRemovesLocalFilesOnSuccess pins the other half: a clean Close still
+// reclaims the local files, so the test above is proving the failure gate and
+// not merely that removal never happens.
+func TestCloseRemovesLocalFilesOnSuccess(t *testing.T) {
+	vb, _ := newChunkFailTestVB(t)
+
+	blockSize := int(vb.BlockSize)
+	require.NoError(t, vb.WriteAt(0, make([]byte, blockSize)))
+
+	localPath := filepath.Join(vb.BaseDir, vb.GetVolume())
+	require.DirExists(t, localPath, "local state should exist before Close")
+
+	require.NoError(t, vb.Close())
+
+	_, statErr := os.Stat(localPath)
+	require.True(t, os.IsNotExist(statErr), "clean Close should remove local files, stat gave %v", statErr)
+}
+
+// TestCloseKeepsLocalFilesWhenFlushFails covers the other ungated failure: a
+// partial flush leaves writes only in memory and in the local WAL.
+func TestCloseKeepsLocalFilesWhenFlushFails(t *testing.T) {
+	vb, _ := newChunkFailTestVB(t)
+
+	localPath := filepath.Join(vb.BaseDir, vb.GetVolume())
+	require.DirExists(t, localPath, "local state should exist before Close")
+
+	// Stage a hot write, then close the WAL file underneath it so the flush
+	// inside Close fails on write — a WAL that can no longer be appended to.
+	vb.Writes.Blocks = append(vb.Writes.Blocks, Block{SeqNum: 1, Block: 0, Len: uint64(vb.BlockSize), Data: make([]byte, int(vb.BlockSize))})
+	require.NotEmpty(t, vb.WAL.DB)
+	require.NoError(t, vb.WAL.DB[len(vb.WAL.DB)-1].Close())
+
+	err := vb.Close()
+	require.Error(t, err, "Close must report the failed flush")
+
+	require.DirExists(t, localPath, "Close deleted the local WAL after a failed flush")
+}

--- a/viperblock/viperblock.go
+++ b/viperblock/viperblock.go
@@ -5311,8 +5311,9 @@ func (vb *VB) Close() error {
 	vb.StopChunkUploader()
 	vb.StopWALSyncer()
 
-	if err := vb.Flush(); err != nil {
-		vb.logger().Error("failed to flush during Close", "error", err)
+	flushErr := vb.Flush()
+	if flushErr != nil {
+		vb.logger().Error("failed to flush during Close", "error", flushErr)
 	}
 
 	var walErr error
@@ -5345,12 +5346,20 @@ func (vb *VB) Close() error {
 
 	vb.logger().Debug("Saving Close state to", "path", path)
 
-	var firstErr error
+	// Whatever the flush and WAL upload above failed to move to the backend
+	// still exists only in the local files, so those failures have to survive
+	// to the RemoveLocalFiles gate below.
+	firstErr := flushErr
+	if firstErr == nil {
+		firstErr = walErr
+	}
 
 	// Upload the state to the backend
 	if err := vb.SaveState(); err != nil {
 		vb.logger().Error("Could not save state", "err", err)
-		firstErr = err
+		if firstErr == nil {
+			firstErr = err
+		}
 	}
 
 	// Always attempt to save the block checkpoint even if SaveState or WAL
@@ -5363,7 +5372,10 @@ func (vb *VB) Close() error {
 		}
 	}
 
+	// Deleting now would destroy the only copy of the un-uploaded writes. Keep
+	// the files so the next Open recovers them from the local WAL.
 	if firstErr != nil {
+		vb.logger().Error("Close failed, keeping local files for recovery", "err", firstErr)
 		return firstErr
 	}
 
@@ -5373,9 +5385,6 @@ func (vb *VB) Close() error {
 		vb.logger().Error("Failed to remove local files", "err", err)
 	}
 
-	if walErr != nil {
-		return walErr
-	}
 	return nil
 }
 

--- a/viperblock/viperblock.go
+++ b/viperblock/viperblock.go
@@ -5303,7 +5303,17 @@ func (vb *VB) ReadAtCtx(ctx context.Context, offset uint64, length uint64) ([]by
 	return fullData[innerOffset : innerOffset+length], err
 }
 
+// Close runs CloseCtx with a background context, so every non-shutdown
+// caller keeps its existing unbounded behaviour.
 func (vb *VB) Close() error {
+	return vb.CloseCtx(context.Background())
+}
+
+// CloseCtx is Close with a caller-supplied context threaded through the
+// backend WAL upload, checkpoint sweep and state saves. Flush and
+// RemoveLocalFiles stay context-free: the local WAL fsync must never be
+// cancellable, since it is what makes an aborted CloseCtx safe to recover from.
+func (vb *VB) CloseCtx(ctx context.Context) error {
 	vb.logger().Info("VB Close, flushing block state to disk")
 
 	// Stop background goroutines before flushing
@@ -5318,9 +5328,9 @@ func (vb *VB) Close() error {
 
 	var walErr error
 	if vb.UseShardedWAL {
-		walErr = vb.WriteShardedWALToChunk(true)
+		walErr = vb.WriteShardedWALToChunkCtx(ctx, true)
 	} else {
-		walErr = vb.WriteWALToChunk(true)
+		walErr = vb.WriteWALToChunkCtx(ctx, true)
 	}
 	if walErr != nil {
 		vb.logger().Error("Could not Write WAL to Chunk during Close, proceeding to save block state", "err", walErr)
@@ -5331,14 +5341,14 @@ func (vb *VB) Close() error {
 		// preferred over the numbered checkpoint saved below) reflects the
 		// chunks just uploaded during this Close. Non-fatal: SaveBlockState
 		// below still persists the same map to the numbered checkpoint.
-		if cpErr := vb.SaveLiveCheckpoint(); cpErr != nil {
+		if cpErr := vb.SaveLiveCheckpointCtx(ctx); cpErr != nil {
 			vb.logger().Warn("Close: SaveLiveCheckpoint failed", "err", cpErr)
 		} else {
 			// One last sweep, now that the live checkpoint durably excludes
 			// every zero-refcount chunk. Run before SaveBlockState so
 			// ensureGCFloor still sees the checkpoint from before this
 			// Close, not the one SaveBlockState is about to write.
-			vb.sweepChunks(context.Background())
+			vb.sweepChunks(ctx)
 		}
 	}
 
@@ -5355,7 +5365,7 @@ func (vb *VB) Close() error {
 	}
 
 	// Upload the state to the backend
-	if err := vb.SaveState(); err != nil {
+	if err := vb.SaveStateCtx(ctx); err != nil {
 		vb.logger().Error("Could not save state", "err", err)
 		if firstErr == nil {
 			firstErr = err
@@ -5365,7 +5375,7 @@ func (vb *VB) Close() error {
 	// Always attempt to save the block checkpoint even if SaveState or WAL
 	// flush failed — in-memory BlockLookup may reflect successfully flushed
 	// writes from earlier Flush calls and must not be lost.
-	if err := vb.SaveBlockState(); err != nil {
+	if err := vb.SaveBlockStateCtx(ctx); err != nil {
 		vb.logger().Error("Could not save block state", "err", err)
 		if firstErr == nil {
 			firstErr = err


### PR DESCRIPTION
**Stacked on #58** — base it there, so review only the second commit (`4ad956e`). Retarget to `dev` once #58 merges. Part of the viperblock durability batch (`mulga-8bplk`); the systemd half of the bead is a separate spinifex PR. Closes `mulga-wtvw5` together with that one.

## Problem

`KillMode=control-group` SIGTERMs every process in the `spinifex-viperblock` cgroup, including the in-use nbdkit children viperblockd deliberately leaves alive. Each runs `ViperBlockConnection.Close` or `ViperBlockPlugin.Unload`, and both did `DrainToBackend()` then `vb.Close()` on `context.Background()` — every S3 PUT, the WAL consolidation and both state saves able to block indefinitely. A slow or unreachable predastore therefore made systemd wait out `TimeoutStopSec` (90s default) and SIGKILL, stalling the whole target-stop transaction.

Root cause is the nbd **plugin**, not viperblockd's SIGTERM handler: `shutdownVolumes` only does a local WAL fsync and kills idle nbdkit.

## Change

- `shutdownDrainTimeout = 20 * time.Second` in the plugin. `Close` and `Unload` each build **one** context covering the drain and the close together. Two budgets in series would exceed the systemd backstop and turn it back into a SIGKILL, which is the thing being fixed.
- `CloseCtx(ctx)` carries the `Close` body with the context threaded into `WriteWALToChunkCtx` / `WriteShardedWALToChunkCtx`, `SaveLiveCheckpointCtx`, `sweepChunks` and both state saves. `Close()` delegates with a background context, so every non-shutdown caller is unchanged.
- Bounding only the drain would have moved the stall into `vb.Close()`, which does its own consolidation and two state saves against the same backend — hence `CloseCtx` rather than the drain alone.

## Why this is safe

WAL recovery backstops an aborted drain: committed writes are in the fsync'd local WAL and replay on the next attach, so the synchronous drain is an optimisation, not a correctness requirement. Two specifics were checked rather than assumed:

- **State saves cannot tear.** `saveStateWithHighWater` runs `persistStateLocal` — no context, writes via `writeFileAtomic` (tmp + fsync + rename + fsync parent) — and only then `pushStateToBackend(ctx)`. A deadline aborts the backend push, never the local file.
- **The local WAL fsync is never bounded.** `Flush` and `RemoveLocalFiles` stay context-free by design.

An aborted close returns an error, and #58's gate then keeps the local files for recovery — exactly what an aborted shutdown needs.

## Tests

New `viperblock/close_ctx_test.go`, against a backend whose `WriteCtx` blocks until its context is done:

- `TestCloseCtxExpiredContextReturnsPromptlyAndKeepsLocalFiles` — already-cancelled context returns in <1s with `context.Canceled`, local state dir survives
- `TestCloseCtxLiveContextHealthyBackendCompletes` — clean path still completes and removes the local files
- `TestCloseCtxDeadlineAbortLeavesWALRecoverable` — after a 100ms-deadline abort, a fresh VB over the same BaseDir replaying the production boot order (`LoadState → LoadLiveCheckpoint → RecoverLocalWALs → OpenWAL`) reads the aborted write back byte-for-byte

Load-bearing check: with `CloseCtx` reverted to the non-context variants, the suite hangs on the blocking backend and dies at `panic: test timed out after 45s` — the pre-fix behaviour, exactly.

`make preflight` passes, and the plugin `.so` builds (`GOFIPS140=v1.0.0 go build -buildmode=c-shared nbd/viperblock.go`).

## Verification still outstanding

Live verification is deferred to the end of the batch, when env12 runs every member together: reproduce the stop, capture the cgroup at the stall, then confirm the stop completes inside `TimeoutStopSec` without SIGKILL, the guest volume reconnects via qemu NBD, and no AEAD/superblock regression.