### PR TITLE
feat(viperblock): leave a seal receipt after a clean shutdown seal

### DIFF
--- a/nbd/viperblock.go
+++ b/nbd/viperblock.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"path/filepath"
 	"syscall"
+	"time"
 
 	"github.com/mulgadc/predastore/pkg/masterkey"
 	"github.com/mulgadc/viperblock/telemetry"
@@ -32,6 +33,11 @@ var pluginName = "viperblock"
 // to the otelslog bridge, matching the metrics-apm.app.<name> data stream
 // dashboards are built against.
 const serviceName = "viperblockd"
+
+// shutdownDrainTimeout bounds the backend half of connection close and plugin
+// unload. An aborted drain is safe: committed writes are in the fsync'd local
+// WAL and replay on the next attach.
+const shutdownDrainTimeout = 20 * time.Second
 
 // otelShutdown flushes the OTLP exporters on Unload, if telemetry.Init
 // configured real ones. nil (a no-op) when OTLP export is not configured.
@@ -502,13 +508,19 @@ func (c *ViperBlockConnection) Close() {
 
 	stopSnapshotListener()
 
+	// One budget for the drain and the close together, not one each: systemd's
+	// TimeoutStopSec backstops this, and two full budgets in series would
+	// overrun it and turn the backstop into a SIGKILL.
+	ctx, cancel := context.WithTimeout(context.Background(), shutdownDrainTimeout)
+	defer cancel()
+
 	// DrainToBackend before Close so the live checkpoint is current. Close
 	// will also flush WAL chunks, but does not save the live checkpoint.
-	if err := c.vb.DrainToBackend(); err != nil {
+	if err := c.vb.DrainToBackendCtx(ctx); err != nil {
 		slog.Error("Close: DrainToBackend failed", "err", err)
 	}
 
-	if err := c.vb.Close(); err != nil {
+	if err := c.vb.CloseCtx(ctx); err != nil {
 		slog.Error("Could not close VB", "err", err)
 	}
 	activeVB = nil
@@ -534,10 +546,14 @@ func (p *ViperBlockPlugin) Unload() {
 	}
 	slog.Info("Unload: Close was not called, flushing block state now")
 	stopSnapshotListener()
-	if err := activeVB.DrainToBackend(); err != nil {
+
+	ctx, cancel := context.WithTimeout(context.Background(), shutdownDrainTimeout)
+	defer cancel()
+
+	if err := activeVB.DrainToBackendCtx(ctx); err != nil {
 		slog.Error("Unload: DrainToBackend failed", "err", err)
 	}
-	if err := activeVB.Close(); err != nil {
+	if err := activeVB.CloseCtx(ctx); err != nil {
 		slog.Error("Unload: could not close VB", "err", err)
 	}
 	activeVB = nil

--- a/nbd/viperblock.go
+++ b/nbd/viperblock.go
@@ -522,6 +522,10 @@ func (c *ViperBlockConnection) Close() {
 
 	if err := c.vb.CloseCtx(ctx); err != nil {
 		slog.Error("Could not close VB", "err", err)
+	} else if err := viperblock.WriteSealReceipt(base_dir, volume); err != nil {
+		// Best effort: the seal already succeeded, so a missing receipt only
+		// costs the consumer a WARN it would otherwise have skipped.
+		slog.Error("Close: could not write seal receipt", "err", err)
 	}
 	activeVB = nil
 }
@@ -555,6 +559,10 @@ func (p *ViperBlockPlugin) Unload() {
 	}
 	if err := activeVB.CloseCtx(ctx); err != nil {
 		slog.Error("Unload: could not close VB", "err", err)
+	} else if err := viperblock.WriteSealReceipt(base_dir, volume); err != nil {
+		// Best effort: the seal already succeeded, so a missing receipt only
+		// costs the consumer a WARN it would otherwise have skipped.
+		slog.Error("Unload: could not write seal receipt", "err", err)
 	}
 	activeVB = nil
 }

--- a/viperblock/close_ctx_test.go
+++ b/viperblock/close_ctx_test.go
@@ -1,0 +1,180 @@
+package viperblock
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/mulgadc/viperblock/types"
+	"github.com/mulgadc/viperblock/viperblock/backends/file"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// blockingBackend wraps a real types.Backend and makes every WriteCtx call
+// block until its context is done, then return ctx.Err(). It stands in for a
+// predastore that has stopped responding, so CloseCtx's own bound is what
+// unwedges the caller instead of the backend ever completing the write.
+type blockingBackend struct {
+	types.Backend
+}
+
+func (b *blockingBackend) WriteCtx(ctx context.Context, fileType types.FileType, objectId uint64, headers *[]byte, data *[]byte) error {
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+// newCloseCtxTestVB builds a minimal file-backed VB, modeled on
+// newEnospcTestVB (enospc_test.go): background WAL fsync and chunk upload are
+// disabled so DrainToBackendCtx/CloseCtx are the only things touching the
+// backend. Its Backend starts out real and unwrapped so setup (Init, WriteAt)
+// never blocks; callers wrap vb.Backend in blockingBackend afterward.
+func newCloseCtxTestVB(t *testing.T, root, volumeName string) (*VB, file.FileConfig) {
+	t.Helper()
+
+	backendConfig := file.FileConfig{
+		VolumeName: volumeName,
+		VolumeSize: 64 * 1024 * 1024,
+		BaseDir:    root,
+	}
+
+	vbconfig := VB{
+		VolumeName:          volumeName,
+		VolumeSize:          64 * 1024 * 1024,
+		BaseDir:             fmt.Sprintf("%s/%s", root, "viperblock"),
+		WALSyncInterval:     -1,
+		ChunkUploadInterval: -1,
+		Cache: Cache{
+			Config: CacheConfig{Size: 0},
+		},
+	}
+
+	vb, err := New(&vbconfig, FileBackend, backendConfig)
+	require.NoError(t, err)
+	require.NotNil(t, vb)
+
+	vb.UseShardedWAL = false
+	vb.ShardedWAL = nil
+
+	require.NoError(t, vb.Backend.Init())
+	require.NoError(t, vb.OpenWAL(&vb.WAL, fmt.Sprintf("%s/%s", vb.WAL.BaseDir, types.GetFilePath(types.FileTypeWALChunk, vb.WAL.WallNum.Load(), vb.GetVolume()))))
+	require.NoError(t, vb.OpenWAL(&vb.BlockToObjectWAL, fmt.Sprintf("%s/%s", vb.BlockToObjectWAL.BaseDir, types.GetFilePath(types.FileTypeWALBlock, vb.BlockToObjectWAL.WallNum.Load(), vb.GetVolume()))))
+
+	return vb, backendConfig
+}
+
+// TestCloseCtxExpiredContextReturnsPromptlyAndKeepsLocalFiles pins the first
+// half of the shutdown-drain bound: CloseCtx given an already-expired context
+// must not attempt to wait on the backend at all, and the #58 firstErr gate
+// must keep the local WAL/state files since nothing reached the backend.
+func TestCloseCtxExpiredContextReturnsPromptlyAndKeepsLocalFiles(t *testing.T) {
+	root := t.TempDir()
+	const vol = "vol-closectx-expired"
+
+	vb, _ := newCloseCtxTestVB(t, root, vol)
+	blockSize := int(vb.BlockSize)
+	require.NoError(t, vb.WriteAt(0, make([]byte, blockSize)))
+
+	// Wrap only after setup so New/Init/WriteAt above never touch the
+	// blocking backend.
+	vb.Backend = &blockingBackend{Backend: vb.Backend}
+
+	localPath := filepath.Join(vb.BaseDir, vb.GetVolume())
+	require.DirExists(t, localPath, "local state should exist before CloseCtx")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	start := time.Now()
+	err := vb.CloseCtx(ctx)
+	elapsed := time.Since(start)
+
+	require.Error(t, err, "CloseCtx must report the context error")
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Less(t, elapsed, time.Second,
+		"CloseCtx must return promptly on an already-done context, not attempt any backend I/O")
+
+	require.DirExists(t, localPath, "CloseCtx deleted the only copy of the un-uploaded writes")
+}
+
+// TestCloseCtxLiveContextHealthyBackendCompletes pins the other half: against
+// a backend that actually completes writes, a live (non-expired) context must
+// not change CloseCtx's clean-path behavior, including removing local files.
+func TestCloseCtxLiveContextHealthyBackendCompletes(t *testing.T) {
+	root := t.TempDir()
+	const vol = "vol-closectx-healthy"
+
+	vb, _ := newCloseCtxTestVB(t, root, vol)
+	blockSize := int(vb.BlockSize)
+	require.NoError(t, vb.WriteAt(0, make([]byte, blockSize)))
+
+	localPath := filepath.Join(vb.BaseDir, vb.GetVolume())
+	require.DirExists(t, localPath, "local state should exist before CloseCtx")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	require.NoError(t, vb.CloseCtx(ctx))
+
+	_, statErr := os.Stat(localPath)
+	require.True(t, os.IsNotExist(statErr), "a clean CloseCtx should remove local files, stat gave %v", statErr)
+}
+
+// TestCloseCtxDeadlineAbortLeavesWALRecoverable is the property the whole
+// bound rests on: a CloseCtx aborted by its deadline must leave the write
+// recoverable from the local WAL. It reopens a fresh VB over the same
+// BaseDir/backend, replaying the production boot order (LoadState ->
+// LoadLiveCheckpoint -> RecoverLocalWALs -> OpenWAL, matching
+// nbd/viperblock.go's connection-open sequence), and reads the data back.
+func TestCloseCtxDeadlineAbortLeavesWALRecoverable(t *testing.T) {
+	root := t.TempDir()
+	const vol = "vol-closectx-deadline-abort"
+
+	vb, backendConfig := newCloseCtxTestVB(t, root, vol)
+	blockSize := int(vb.BlockSize)
+	want := bytes.Repeat([]byte{0x7B}, blockSize)
+	require.NoError(t, vb.WriteAt(0, append([]byte(nil), want...)))
+
+	vb.Backend = &blockingBackend{Backend: vb.Backend}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	err := vb.CloseCtx(ctx)
+	elapsed := time.Since(start)
+
+	require.Error(t, err, "CloseCtx must report the deadline that aborted the backend chunk upload")
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.Less(t, elapsed, 5*time.Second, "CloseCtx must return once its deadline fires, not hang")
+
+	localPath := filepath.Join(vb.BaseDir, vb.GetVolume())
+	require.DirExists(t, localPath, "aborted CloseCtx must keep local files for recovery")
+
+	reopenConfig := VB{
+		VolumeName:      vol,
+		VolumeSize:      64 * 1024 * 1024,
+		BaseDir:         vb.BaseDir,
+		WALSyncInterval: -1,
+		Cache: Cache{
+			Config: CacheConfig{Size: 0},
+		},
+	}
+	reopened, err := New(&reopenConfig, FileBackend, backendConfig)
+	require.NoError(t, err)
+	require.NoError(t, reopened.Backend.Init())
+	require.NoError(t, reopened.LoadState())
+	require.NoError(t, reopened.LoadLiveCheckpoint())
+	require.NoError(t, reopened.RecoverLocalWALs())
+	require.NoError(t, reopened.OpenWAL(&reopened.WAL, fmt.Sprintf("%s/%s", reopened.WAL.BaseDir, types.GetFilePath(types.FileTypeWALChunk, reopened.WAL.WallNum.Load(), reopened.GetVolume()))))
+	require.NoError(t, reopened.OpenWAL(&reopened.BlockToObjectWAL, fmt.Sprintf("%s/%s", reopened.BlockToObjectWAL.BaseDir, types.GetFilePath(types.FileTypeWALBlock, reopened.BlockToObjectWAL.WallNum.Load(), reopened.GetVolume()))))
+	t.Cleanup(func() { assert.NoError(t, reopened.RemoveLocalFiles()) })
+
+	got, err := reopened.ReadAt(0, uint64(blockSize))
+	require.NoError(t, err)
+	assert.Equal(t, want, got, "the aborted CloseCtx must not lose the write: WAL replay must reproduce it byte-for-byte")
+}

--- a/viperblock/close_local_files_test.go
+++ b/viperblock/close_local_files_test.go
@@ -1,0 +1,144 @@
+package viperblock
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/mulgadc/viperblock/types"
+	"github.com/mulgadc/viperblock/viperblock/backends/file"
+	"github.com/stretchr/testify/require"
+)
+
+// errChunkWrite stands in for a backend that rejects a chunk upload — a full
+// or unreachable predastore, say — without needing a real one to fail.
+var errChunkWrite = errors.New("simulated chunk write rejection")
+
+// chunkFailBackend fails FileTypeChunk writes only, leaving config and
+// checkpoint writes working. That is the case Close has to survive: the WAL
+// never reaches the backend while both state saves report success.
+type chunkFailBackend struct {
+	types.Backend
+
+	failChunks atomic.Bool
+}
+
+func (b *chunkFailBackend) Write(fileType types.FileType, objectId uint64, headers *[]byte, data *[]byte) error {
+	if fileType == types.FileTypeChunk && b.failChunks.Load() {
+		return errChunkWrite
+	}
+	return b.Backend.Write(fileType, objectId, headers, data)
+}
+
+func (b *chunkFailBackend) WriteCtx(ctx context.Context, fileType types.FileType, objectId uint64, headers *[]byte, data *[]byte) error {
+	if fileType == types.FileTypeChunk && b.failChunks.Load() {
+		return errChunkWrite
+	}
+	return b.Backend.WriteCtx(ctx, fileType, objectId, headers, data)
+}
+
+func newChunkFailTestVB(t *testing.T) (*VB, *chunkFailBackend) {
+	t.Helper()
+
+	tmpDir := t.TempDir()
+	testVol := fmt.Sprintf("test_closewal_%d", time.Now().UnixNano())
+
+	backendConfig := file.FileConfig{
+		VolumeName: testVol,
+		VolumeSize: 64 * 1024 * 1024,
+		BaseDir:    tmpDir,
+	}
+
+	vbconfig := VB{
+		VolumeName: testVol,
+		VolumeSize: 64 * 1024 * 1024,
+		BaseDir:    fmt.Sprintf("%s/%s", tmpDir, "viperblock"),
+		// Deterministic: no background WAL fsync or ticker-driven chunk upload
+		// racing Close, which is the only thing under test here.
+		WALSyncInterval:     -1,
+		ChunkUploadInterval: -1,
+		Cache: Cache{
+			Config: CacheConfig{Size: 0},
+		},
+	}
+
+	vb, err := New(&vbconfig, FileBackend, backendConfig)
+	require.NoError(t, err)
+	require.NotNil(t, vb)
+
+	vb.UseShardedWAL = false
+	vb.ShardedWAL = nil
+
+	require.NoError(t, vb.Backend.Init())
+	backend := &chunkFailBackend{Backend: vb.Backend}
+	vb.Backend = backend
+
+	require.NoError(t, vb.OpenWAL(&vb.WAL, fmt.Sprintf("%s/%s", vb.WAL.BaseDir, types.GetFilePath(types.FileTypeWALChunk, vb.WAL.WallNum.Load(), vb.GetVolume()))))
+	require.NoError(t, vb.OpenWAL(&vb.BlockToObjectWAL, fmt.Sprintf("%s/%s", vb.BlockToObjectWAL.BaseDir, types.GetFilePath(types.FileTypeWALBlock, vb.BlockToObjectWAL.WallNum.Load(), vb.GetVolume()))))
+
+	return vb, backend
+}
+
+// TestCloseKeepsLocalFilesWhenChunkUploadFails is the durability guarantee: if
+// the WAL never reached the backend, the local copy is the only one left, so
+// Close must not delete it however well the state saves went.
+func TestCloseKeepsLocalFilesWhenChunkUploadFails(t *testing.T) {
+	vb, backend := newChunkFailTestVB(t)
+
+	blockSize := int(vb.BlockSize)
+	require.NoError(t, vb.WriteAt(0, make([]byte, blockSize)))
+
+	localPath := filepath.Join(vb.BaseDir, vb.GetVolume())
+	require.DirExists(t, localPath, "local state should exist before Close")
+
+	backend.failChunks.Store(true)
+
+	err := vb.Close()
+	require.Error(t, err, "Close must report the failed chunk upload")
+	require.ErrorIs(t, err, errChunkWrite)
+
+	require.DirExists(t, localPath, "Close deleted the only copy of the un-uploaded writes")
+}
+
+// TestCloseRemovesLocalFilesOnSuccess pins the other half: a clean Close still
+// reclaims the local files, so the test above is proving the failure gate and
+// not merely that removal never happens.
+func TestCloseRemovesLocalFilesOnSuccess(t *testing.T) {
+	vb, _ := newChunkFailTestVB(t)
+
+	blockSize := int(vb.BlockSize)
+	require.NoError(t, vb.WriteAt(0, make([]byte, blockSize)))
+
+	localPath := filepath.Join(vb.BaseDir, vb.GetVolume())
+	require.DirExists(t, localPath, "local state should exist before Close")
+
+	require.NoError(t, vb.Close())
+
+	_, statErr := os.Stat(localPath)
+	require.True(t, os.IsNotExist(statErr), "clean Close should remove local files, stat gave %v", statErr)
+}
+
+// TestCloseKeepsLocalFilesWhenFlushFails covers the other ungated failure: a
+// partial flush leaves writes only in memory and in the local WAL.
+func TestCloseKeepsLocalFilesWhenFlushFails(t *testing.T) {
+	vb, _ := newChunkFailTestVB(t)
+
+	localPath := filepath.Join(vb.BaseDir, vb.GetVolume())
+	require.DirExists(t, localPath, "local state should exist before Close")
+
+	// Stage a hot write, then close the WAL file underneath it so the flush
+	// inside Close fails on write — a WAL that can no longer be appended to.
+	vb.Writes.Blocks = append(vb.Writes.Blocks, Block{SeqNum: 1, Block: 0, Len: uint64(vb.BlockSize), Data: make([]byte, int(vb.BlockSize))})
+	require.NotEmpty(t, vb.WAL.DB)
+	require.NoError(t, vb.WAL.DB[len(vb.WAL.DB)-1].Close())
+
+	err := vb.Close()
+	require.Error(t, err, "Close must report the failed flush")
+
+	require.DirExists(t, localPath, "Close deleted the local WAL after a failed flush")
+}

--- a/viperblock/seal_receipt.go
+++ b/viperblock/seal_receipt.go
@@ -1,0 +1,42 @@
+package viperblock
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// sealReceipt is the on-disk shape written by WriteSealReceipt. Field names
+// are part of the contract with the consumer that parses this file.
+type sealReceipt struct {
+	Volume   string `json:"volume"`
+	PID      int    `json:"pid"`
+	SealedAt string `json:"sealed_at"`
+}
+
+// WriteSealReceipt records that this process sealed volume and removed its
+// local state, so the caller that killed it can tell a clean seal from a
+// volume that never held state on this node. The receipt is written to
+// <baseDir>/<volume>.sealed, a sibling of the state directory removed by
+// RemoveLocalFiles, so cleanup never takes it with them.
+func WriteSealReceipt(baseDir, volume string) error {
+	receipt := sealReceipt{
+		Volume:   volume,
+		PID:      os.Getpid(),
+		SealedAt: time.Now().UTC().Format("2006-01-02T15:04:05.000Z07:00"),
+	}
+
+	data, err := json.Marshal(receipt)
+	if err != nil {
+		return fmt.Errorf("marshal seal receipt: %w", err)
+	}
+
+	path := filepath.Join(baseDir, volume+".sealed")
+	if err := writeFileAtomic(path, data, 0640); err != nil {
+		return fmt.Errorf("write seal receipt: %w", err)
+	}
+
+	return nil
+}

--- a/viperblock/seal_receipt_test.go
+++ b/viperblock/seal_receipt_test.go
@@ -1,0 +1,70 @@
+package viperblock
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteSealReceipt_ValidJSON(t *testing.T) {
+	baseDir := t.TempDir()
+	volume := "vol-abc123"
+
+	require.NoError(t, WriteSealReceipt(baseDir, volume))
+
+	path := filepath.Join(baseDir, volume+".sealed")
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	var got sealReceipt
+	require.NoError(t, json.Unmarshal(data, &got))
+
+	assert.Equal(t, volume, got.Volume)
+	assert.Equal(t, os.Getpid(), got.PID)
+
+	sealedAt, err := time.Parse(time.RFC3339, got.SealedAt)
+	require.NoError(t, err)
+	assert.WithinDuration(t, time.Now().UTC(), sealedAt.UTC(), time.Minute)
+
+	t.Logf("seal receipt JSON: %s", data)
+}
+
+func TestWriteSealReceipt_SiblingOfStateDir(t *testing.T) {
+	baseDir := t.TempDir()
+	volume := "vol-sibling"
+
+	// A minimal VB with just the fields RemoveLocalFiles touches, so the
+	// state dir it owns exists at BaseDir/<volume> exactly as production has it.
+	vb := &VB{BaseDir: baseDir, VolumeName: volume}
+	stateDir := filepath.Join(vb.BaseDir, vb.GetVolume())
+	require.NoError(t, os.MkdirAll(stateDir, 0750))
+	require.NoError(t, os.WriteFile(filepath.Join(stateDir, "some.state"), []byte("x"), 0640))
+
+	require.NoError(t, WriteSealReceipt(baseDir, volume))
+	receiptPath := filepath.Join(baseDir, volume+".sealed")
+
+	// The receipt must not live under the state directory RemoveLocalFiles
+	// deletes, or it would be destroyed along with everything else.
+	require.NoError(t, vb.RemoveLocalFiles())
+
+	_, err := os.Stat(stateDir)
+	assert.True(t, os.IsNotExist(err), "state dir should be removed")
+
+	_, err = os.Stat(receiptPath)
+	assert.NoError(t, err, "seal receipt should survive RemoveLocalFiles")
+}
+
+func TestWriteSealReceipt_UnwritableBaseDir(t *testing.T) {
+	parent := t.TempDir()
+	baseDir := filepath.Join(parent, "sealed-dir")
+	require.NoError(t, os.MkdirAll(baseDir, 0500))
+	t.Cleanup(func() { _ = os.Chmod(baseDir, 0750) })
+
+	err := WriteSealReceipt(baseDir, "vol-noperm")
+	require.Error(t, err)
+}

--- a/viperblock/viperblock.go
+++ b/viperblock/viperblock.go
@@ -5311,8 +5311,9 @@ func (vb *VB) Close() error {
 	vb.StopChunkUploader()
 	vb.StopWALSyncer()
 
-	if err := vb.Flush(); err != nil {
-		vb.logger().Error("failed to flush during Close", "error", err)
+	flushErr := vb.Flush()
+	if flushErr != nil {
+		vb.logger().Error("failed to flush during Close", "error", flushErr)
 	}
 
 	var walErr error
@@ -5345,12 +5346,20 @@ func (vb *VB) Close() error {
 
 	vb.logger().Debug("Saving Close state to", "path", path)
 
-	var firstErr error
+	// Whatever the flush and WAL upload above failed to move to the backend
+	// still exists only in the local files, so those failures have to survive
+	// to the RemoveLocalFiles gate below.
+	firstErr := flushErr
+	if firstErr == nil {
+		firstErr = walErr
+	}
 
 	// Upload the state to the backend
 	if err := vb.SaveState(); err != nil {
 		vb.logger().Error("Could not save state", "err", err)
-		firstErr = err
+		if firstErr == nil {
+			firstErr = err
+		}
 	}
 
 	// Always attempt to save the block checkpoint even if SaveState or WAL
@@ -5363,7 +5372,10 @@ func (vb *VB) Close() error {
 		}
 	}
 
+	// Deleting now would destroy the only copy of the un-uploaded writes. Keep
+	// the files so the next Open recovers them from the local WAL.
 	if firstErr != nil {
+		vb.logger().Error("Close failed, keeping local files for recovery", "err", firstErr)
 		return firstErr
 	}
 
@@ -5373,9 +5385,6 @@ func (vb *VB) Close() error {
 		vb.logger().Error("Failed to remove local files", "err", err)
 	}
 
-	if walErr != nil {
-		return walErr
-	}
 	return nil
 }
 

--- a/viperblock/viperblock.go
+++ b/viperblock/viperblock.go
@@ -5303,7 +5303,17 @@ func (vb *VB) ReadAtCtx(ctx context.Context, offset uint64, length uint64) ([]by
 	return fullData[innerOffset : innerOffset+length], err
 }
 
+// Close runs CloseCtx with a background context, so every non-shutdown
+// caller keeps its existing unbounded behaviour.
 func (vb *VB) Close() error {
+	return vb.CloseCtx(context.Background())
+}
+
+// CloseCtx is Close with a caller-supplied context threaded through the
+// backend WAL upload, checkpoint sweep and state saves. Flush and
+// RemoveLocalFiles stay context-free: the local WAL fsync must never be
+// cancellable, since it is what makes an aborted CloseCtx safe to recover from.
+func (vb *VB) CloseCtx(ctx context.Context) error {
 	vb.logger().Info("VB Close, flushing block state to disk")
 
 	// Stop background goroutines before flushing
@@ -5318,9 +5328,9 @@ func (vb *VB) Close() error {
 
 	var walErr error
 	if vb.UseShardedWAL {
-		walErr = vb.WriteShardedWALToChunk(true)
+		walErr = vb.WriteShardedWALToChunkCtx(ctx, true)
 	} else {
-		walErr = vb.WriteWALToChunk(true)
+		walErr = vb.WriteWALToChunkCtx(ctx, true)
 	}
 	if walErr != nil {
 		vb.logger().Error("Could not Write WAL to Chunk during Close, proceeding to save block state", "err", walErr)
@@ -5331,14 +5341,14 @@ func (vb *VB) Close() error {
 		// preferred over the numbered checkpoint saved below) reflects the
 		// chunks just uploaded during this Close. Non-fatal: SaveBlockState
 		// below still persists the same map to the numbered checkpoint.
-		if cpErr := vb.SaveLiveCheckpoint(); cpErr != nil {
+		if cpErr := vb.SaveLiveCheckpointCtx(ctx); cpErr != nil {
 			vb.logger().Warn("Close: SaveLiveCheckpoint failed", "err", cpErr)
 		} else {
 			// One last sweep, now that the live checkpoint durably excludes
 			// every zero-refcount chunk. Run before SaveBlockState so
 			// ensureGCFloor still sees the checkpoint from before this
 			// Close, not the one SaveBlockState is about to write.
-			vb.sweepChunks(context.Background())
+			vb.sweepChunks(ctx)
 		}
 	}
 
@@ -5355,7 +5365,7 @@ func (vb *VB) Close() error {
 	}
 
 	// Upload the state to the backend
-	if err := vb.SaveState(); err != nil {
+	if err := vb.SaveStateCtx(ctx); err != nil {
 		vb.logger().Error("Could not save state", "err", err)
 		if firstErr == nil {
 			firstErr = err
@@ -5365,7 +5375,7 @@ func (vb *VB) Close() error {
 	// Always attempt to save the block checkpoint even if SaveState or WAL
 	// flush failed — in-memory BlockLookup may reflect successfully flushed
 	// writes from earlier Flush calls and must not be lost.
-	if err := vb.SaveBlockState(); err != nil {
+	if err := vb.SaveBlockStateCtx(ctx); err != nil {
 		vb.logger().Error("Could not save block state", "err", err)
 		if firstErr == nil {
 			firstErr = err


### PR DESCRIPTION
**Stacked on #61** (which is itself stacked on #58) — review only `8a2e244`. Retarget as the stack merges. Part of the viperblock durability batch (`mulga-8bplk`); the consumer is spinifex PR #620. Together they close `mulga-6scno`.

## Why

`viperblockd` decides whether to run its fallback seal by stat-ing `BaseDir/<volume>`. The plugin deletes exactly that directory as the last step of a successful seal, so on the healthy path the stat fails, the fallback is skipped, and a WARN fires claiming there was no local state — on every clean unmount. Verified on env12: two volumes, two warnings, both directories confirmed present minutes earlier.

Directory absence cannot distinguish "sealed and cleaned up" from "never held state here", which is the case the WARN was written for. That needs a positive signal, not more inference.

## Change

After `CloseCtx` returns **nil** in both `ViperBlockConnection.Close` and `ViperBlockPlugin.Unload`, write `<base_dir>/<volume>.sealed`:

```json
{"volume":"vol-abc123","pid":3883180,"sealed_at":"2026-07-31T12:23:26.347Z"}
```

- Only on success. A failed or deadline-aborted close keeps local state (#58's gate) and must leave no receipt, so the consumer runs its fallback seal.
- A sibling of the state directory, never inside it, so `RemoveLocalFiles` does not take it along.
- Written via the existing `writeFileAtomic` helper.
- Best effort: a failed receipt write is logged and ignored. The seal already succeeded; a missing receipt costs only a WARN downstream.
- `pid` is diagnostic only. Staleness is handled on the consumer side by clearing receipts at mount, so nothing depends on PID matching — which would be fragile if nbdkit ever re-execs between the pidfile write and plugin load.

## Tests

`viperblock/seal_receipt_test.go` — the field names are a cross-repo contract, so they are asserted directly:

- valid JSON at the expected path, with a parseable timestamp
- the receipt is not under `baseDir/<volume>/` and survives `RemoveLocalFiles()`
- an unwritable base dir returns an error rather than panicking

The plugin package is a cgo `main` module and is not unit-testable here, hence the logic living in a helper in the main module. `make preflight` passes and the plugin `.so` builds (`GOFIPS140=v1.0.0 go build -buildmode=c-shared nbd/viperblock.go`).