### PR TITLE
fix(viperblock): throttle on nearfull pressure instead of rejecting writes

### DIFF
--- a/viperblock/enospc_test.go
+++ b/viperblock/enospc_test.go
@@ -27,6 +27,11 @@ type enospcBackend struct {
 
 	full atomic.Bool
 
+	// nearFull stands in for predastore's X-Predastore-Pool-Pressure header,
+	// which rides on a SUCCESSFUL write, so this toggle deliberately does not
+	// make any write fail.
+	nearFull atomic.Bool
+
 	// genericFail, when true, makes every FileTypeBlockCheckpointLive write
 	// return a persistent, non-ErrNoSpace error, so tests can prove
 	// awaitBackpressure bounds consecutive drain failures instead of
@@ -110,6 +115,12 @@ func (b *enospcBackend) WriteCtx(ctx context.Context, fileType types.FileType, o
 		b.afterWrite(fileType, err)
 	}
 	return err
+}
+
+// NearFull satisfies backendNearFuller, which the file backend does not
+// implement on its own.
+func (b *enospcBackend) NearFull() bool {
+	return b.nearFull.Load()
 }
 
 // newEnospcTestVB builds a minimal file-backed VB with its Backend wrapped
@@ -333,6 +344,61 @@ func TestBackendFullLatchLogsTransitionsOnce(t *testing.T) {
 
 	recoverOnce()
 	assert.Equal(t, 2, strings.Count(buf.String(), recoverLine), "a fresh true->false edge logs again")
+}
+
+// TestNearFullBackendStillAcceptsWrites pins that pool-pressure alone does not
+// reject a write. Predastore keeps accepting PUTs in the nearfull band (it only
+// rejects below the full watermark), so rejecting here cost every pool the
+// capacity between the two watermarks and failed every attached guest at once.
+func TestNearFullBackendStillAcceptsWrites(t *testing.T) {
+	vb, backend := newEnospcTestVB(t)
+	blockSize := uint64(vb.BlockSize)
+
+	backend.nearFull.Store(true)
+
+	require.NoError(t, vb.WriteAt(0, make([]byte, blockSize)),
+		"a nearfull backend must throttle writes, not reject them")
+	assert.False(t, vb.backendFull.Load(), "nearfull pressure must not latch backendFull")
+	require.NoError(t, vb.DrainToBackendCtx(context.Background()),
+		"drains must keep flushing into the remaining headroom while nearfull")
+}
+
+// TestMaxPendingBytesShrinksWhileNearFull pins the throttle that replaces the
+// rejection: a nearfull backend makes writers block on synchronous drains
+// sooner, bounding how many acked writes are left dirty if it then goes full.
+func TestMaxPendingBytesShrinksWhileNearFull(t *testing.T) {
+	vb, backend := newEnospcTestVB(t)
+
+	assert.Equal(t, DefaultMaxPendingBytes, vb.maxPendingBytes(), "an unset window uses the default")
+
+	backend.nearFull.Store(true)
+	assert.Equal(t, DefaultMaxPendingBytes/nearFullPendingDivisor, vb.maxPendingBytes(),
+		"nearfull must shrink the default window")
+
+	vb.MaxPendingBytes = 64 * 1024 * 1024
+	assert.Equal(t, vb.MaxPendingBytes/nearFullPendingDivisor, vb.maxPendingBytes(),
+		"nearfull must shrink an explicitly configured window too")
+
+	backend.nearFull.Store(false)
+	assert.Equal(t, vb.MaxPendingBytes, vb.maxPendingBytes(), "the full window returns once pressure clears")
+}
+
+// TestNearFullThenFullStillFailsFast pins that relaxing the nearfull gate did
+// not relax the real one: a backend that goes on to reject a drain still
+// latches backendFull and fails the next write.
+func TestNearFullThenFullStillFailsFast(t *testing.T) {
+	vb, backend := newEnospcTestVB(t)
+	blockSize := uint64(vb.BlockSize)
+
+	backend.nearFull.Store(true)
+	require.NoError(t, vb.WriteAt(0, make([]byte, blockSize)))
+
+	backend.full.Store(true)
+	require.ErrorIs(t, vb.DrainToBackendCtx(context.Background()), ErrNoSpace)
+	require.True(t, vb.backendFull.Load())
+
+	assert.ErrorIs(t, vb.WriteAt(blockSize, make([]byte, blockSize)), ErrNoSpace,
+		"a genuinely full backend must still fail writes fast")
 }
 
 // TestErrNoSpaceIsTypesErrNoSpace pins that ErrNoSpace re-exports

--- a/viperblock/viperblock.go
+++ b/viperblock/viperblock.go
@@ -61,6 +61,11 @@ const DefaultCheckpointRetryBackoff time.Duration = time.Second
 // to backend ingest rate instead of ballooning unbounded anonymous memory.
 const DefaultMaxPendingBytes uint64 = 256 * 1024 * 1024
 
+// nearFullPendingDivisor shrinks the backpressure high-watermark while the
+// backend reports nearfull pressure. 8 takes the default 256MB window to 32MB,
+// still well above the 4MB chunk size so drains stay chunk-sized.
+const nearFullPendingDivisor uint64 = 8
+
 // DefaultUploadWorkers bounds the parallel chunk-upload worker pool used by
 // WriteWALToChunkCtx / WriteShardedWALToChunkCtx. 1 means fully serial.
 const DefaultUploadWorkers int = 16
@@ -1678,11 +1683,20 @@ func (vb *VB) PendingBytes() uint64 {
 
 // maxPendingBytes returns the configured high-watermark, or the default if
 // unset (covers VB values assembled without going through New).
+//
+// A nearfull backend shrinks the window instead of stopping writes: the
+// backend still accepts PUTs in that band, so the right response is to make
+// writers block on synchronous drains sooner. That also bounds how many acked
+// writes are left dirty if the backend goes on to reject outright.
 func (vb *VB) maxPendingBytes() uint64 {
-	if vb.MaxPendingBytes == 0 {
-		return DefaultMaxPendingBytes
+	high := vb.MaxPendingBytes
+	if high == 0 {
+		high = DefaultMaxPendingBytes
 	}
-	return vb.MaxPendingBytes
+	if vb.isBackendNearFull() {
+		high /= nearFullPendingDivisor
+	}
+	return high
 }
 
 // checkpointBackoff returns the configured first retry sleep, or the default if
@@ -1810,11 +1824,10 @@ func (vb *VB) WriteAtCtx(ctx context.Context, offset uint64, data []byte) error 
 	// Writes.Blocks — a write is acked before its chunk is PUT, so without
 	// this gate a full backend would keep accepting writes into memory.
 	//
-	// isBackendNearFull extends the fail-fast to the nearfull band: at FULL
-	// the backend also rejects drain PUTs, so already-acked dirty pages
-	// could never flush. DrainToBackendCtx stays ungated so buffered drains
-	// keep flushing into the remaining headroom.
-	if vb.backendFull.Load() || vb.isBackendNearFull() {
+	// Only backendFull qualifies, which is latched from a drain the backend
+	// actually rejected. Nearfull pressure rides on a SUCCESSFUL response and
+	// means "slow down", so it throttles via maxPendingBytes instead.
+	if vb.backendFull.Load() {
 		return ErrNoSpace
 	}
 


### PR DESCRIPTION
## Problem

Predastore's store has two free-space bands (`predastore/store/freespace.go`):

| band | predastore behaviour | viperblock behaviour before this change |
| --- | --- | --- |
| `< 0.15` free (nearfull) | kicks a compaction pass, **accepts** the write, sets `X-Predastore-Pool-Pressure: nearfull` on the 200 | `return ErrNoSpace` |
| `< 0.05` free (full) | `ErrStoreFull` -> 507 | `return ErrNoSpace` |

`WriteAtCtx` gated on `vb.backendFull.Load() || vb.isBackendNearFull()`, so the block layer rejected
every write the moment the backend reported pressure on a **successful** response. The capacity
between the two watermarks became unusable and every attached volume failed at the same instant.

On the dev host that meant a Windows AMI import aborting with
`failed to write block 1372160: viperblock: backend out of space` while 14.3 GB was still free.
Host metrics show free space crossing 15.45 GB (15% of 99 GB) exactly then, and no
`handlePUTShard: store full` log exists anywhere, so the 5% watermark was never reached.

## Change

`backendFull` — latched only from a drain the backend actually rejected — becomes the sole reason to
refuse a write.

Nearfull instead shrinks the backpressure high-watermark by `nearFullPendingDivisor` (8, taking the
default 256 MB window to 32 MB, still well above the 4 MB chunk size). `awaitBackpressure` is the
only consumer, so a nearfull backend makes writers block on synchronous drains far sooner and ingest
self-throttles to drain rate.

That also answers the concern the original gate was written for: fewer dirty pages are outstanding
if the backend does go on to reject outright, so fewer acked writes are stranded.

## Tests

- `TestNearFullBackendStillAcceptsWrites` — pressure alone does not reject, does not latch
  `backendFull`, and drains keep flushing into the remaining headroom.
- `TestMaxPendingBytesShrinksWhileNearFull` — the window shrinks for both the default and an
  explicitly configured `MaxPendingBytes`, and restores once pressure clears.
- `TestNearFullThenFullStillFailsFast` — a backend that goes on to reject a drain still latches and
  fails the next write, so the real ENOSPC path is unchanged.

`enospcBackend` gains a `nearFull` toggle and a `NearFull()` method satisfying `backendNearFuller`,
which the file backend does not implement on its own.

Preflight green: golangci-lint 0 issues, govulncheck clean, diff coverage 88.4%.