### PR TITLE
fix(viperblock): parallelise chunk reclaim, and record a pending AMI state during import

### DIFF
--- a/viperblock/chunk_gc_test.go
+++ b/viperblock/chunk_gc_test.go
@@ -1407,3 +1407,123 @@ func (s *syncBuffer) Reset() {
 	defer s.mu.Unlock()
 	s.buf.Reset()
 }
+
+// blockingDeleteBackend blocks every chunk DeleteCtx call until the test
+// closes release, tracking how many calls are blocked (in flight) at once.
+// This lets a test observe the delete worker pool's real concurrency
+// deterministically — no sleep, no wall-clock assertion — since the pass/fail
+// signal is peak concurrent call count, not elapsed time.
+type blockingDeleteBackend struct {
+	types.Backend
+
+	release  chan struct{}
+	inFlight atomic.Int32
+	peak     atomic.Int32
+}
+
+func (b *blockingDeleteBackend) DeleteCtx(ctx context.Context, fileType types.FileType, objectId uint64) error {
+	if fileType == types.FileTypeChunk {
+		n := b.inFlight.Add(1)
+		defer b.inFlight.Add(-1)
+		for {
+			p := b.peak.Load()
+			if n <= p || b.peak.CompareAndSwap(p, n) {
+				break
+			}
+		}
+		select {
+		case <-b.release:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	return b.Backend.DeleteCtx(ctx, fileType, objectId)
+}
+
+// TestChunkGC_DeleteChunkObjectsParallelizesAcrossWorkers is the regression
+// guard for the throughput mismatch between reclaim and ingest: the pre-fix
+// deleteChunkObjects issued one blocking DeleteCtx at a time, so a sustained
+// parallel writer could out-produce garbage faster than a serial sweep could
+// reclaim it, and the candidate list would only grow. This pins that deletes
+// now fan out across a bounded worker pool (mirroring UploadWorkers) instead
+// of running one at a time.
+//
+// The assertion is purely a concurrency count (peak in-flight deletes), never
+// wall-clock timing: the runners this suite executes on are demonstrably
+// CPU-starved and load-sensitive, so a "must complete within Xms" assertion
+// would be flaky by construction. require.Eventually below only waits for
+// goroutines that already exist to be scheduled — a generous, one-shot
+// synchronization bound, not a performance SLA — and the pass/fail signal is
+// the peak concurrent call count the backend observed.
+func TestChunkGC_DeleteChunkObjectsParallelizesAcrossWorkers(t *testing.T) {
+	root := t.TempDir()
+	vb := newGCTestVB(t, root, "vol-parallel-delete", true)
+
+	const workers = 4
+	const numCandidates = 12 // several multiples of workers
+	vb.UploadWorkers = workers
+
+	backend := &blockingDeleteBackend{Backend: vb.Backend, release: make(chan struct{})}
+	vb.Backend = backend
+
+	ids := make([]uint64, numCandidates)
+	vb.BlocksToObject.mu.Lock()
+	for i := range ids {
+		id := uint64(i + 1)
+		ids[i] = id
+		vb.gcRefcount[id] = 0
+	}
+	vb.BlocksToObject.mu.Unlock()
+
+	// A concurrent writer keeps mutating gcRefcount for the whole sweep (new,
+	// live entries that must never be deleted), so the worker pool's locking
+	// around gcRefcount is exercised under real contention, not just a single
+	// goroutine touching the map.
+	writerStop := make(chan struct{})
+	writerDone := make(chan struct{})
+	go func() {
+		defer close(writerDone)
+		next := uint64(numCandidates + 1)
+		for {
+			select {
+			case <-writerStop:
+				return
+			default:
+				vb.BlocksToObject.mu.Lock()
+				vb.gcRefcount[next] = 1 // referenced: never a delete candidate
+				vb.BlocksToObject.mu.Unlock()
+				next++
+			}
+		}
+	}()
+	t.Cleanup(func() { close(writerStop); <-writerDone })
+
+	done := make(chan int, 1)
+	go func() { done <- vb.deleteChunkObjects(context.Background(), ids) }()
+
+	// Every candidate blocks inside DeleteCtx until release is closed, so once
+	// the pool is fully occupied, in-flight sticks at exactly `workers` until
+	// then. On the pre-fix sequential loop this never exceeds 1.
+	require.Eventually(t, func() bool {
+		return backend.inFlight.Load() == int32(workers)
+	}, 5*time.Second, time.Millisecond,
+		"delete pool never reached its configured width of %d — deletes are not running in parallel", workers)
+
+	close(backend.release)
+
+	swept := <-done
+	assert.Equal(t, numCandidates, swept, "every candidate should have been swept")
+	assert.LessOrEqual(t, backend.peak.Load(), int32(workers), "pool exceeded its configured width")
+
+	// The candidate list must drain to zero, not merely shrink — every id
+	// handed to deleteChunkObjects is gone from gcRefcount once it returns.
+	vb.BlocksToObject.mu.Lock()
+	remaining := 0
+	for _, id := range ids {
+		if _, ok := vb.gcRefcount[id]; ok {
+			remaining++
+		}
+	}
+	vb.BlocksToObject.mu.Unlock()
+	assert.Equal(t, 0, remaining, "swept candidates must be removed from gcRefcount")
+}

--- a/viperblock/v_utils/v_utils.go
+++ b/viperblock/v_utils/v_utils.go
@@ -184,6 +184,13 @@ func ImportDiskImage(s3Config *s3.S3Config, vbConfig *viperblock.VB, filename st
 		return fmt.Errorf("failed to load block WAL: %w", err)
 	}
 
+	// Marks the AMI as in-progress before any data reaches the backend.
+	// Encrypted volumes persist this immediately below; unencrypted volumes
+	// carry it in memory until Close's own state save persists it.
+	if vbConfig.VolumeConfig.AMIMetadata.Name != "" {
+		vb.VolumeConfig.AMIMetadata.State = "pending"
+	}
+
 	// Encrypted volumes derive the AES-GCM nonce from VolumeUUID, which
 	// SaveState mints on first use. Mint it now, before the first chunk is
 	// sealed in the write loop, so every chunk and the AMI snapshot share one
@@ -270,6 +277,17 @@ func ImportDiskImage(s3Config *s3.S3Config, vbConfig *viperblock.VB, filename st
 	err = vb.Close()
 	if err != nil {
 		return fmt.Errorf("failed to close Viperblock store: %w", err)
+	}
+
+	// Only reached once Close has returned nil, confirming the flush, WAL
+	// upload and state save it runs internally all succeeded. Flipping the
+	// field any earlier would let Close's own state save persist "available"
+	// even when Close itself fails partway through.
+	if vbConfig.VolumeConfig.AMIMetadata.Name != "" {
+		vb.VolumeConfig.AMIMetadata.State = "available"
+		if err := vb.SaveState(); err != nil {
+			return fmt.Errorf("failed to persist final AMI state: %w", err)
+		}
 	}
 
 	return nil

--- a/viperblock/v_utils/v_utils_test.go
+++ b/viperblock/v_utils/v_utils_test.go
@@ -1,11 +1,23 @@
 package v_utils
 
 import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
+	"github.com/mulgadc/predastore/pkg/masterkey"
+	"github.com/mulgadc/viperblock/internal/predastoretest"
 	"github.com/mulgadc/viperblock/viperblock"
 	"github.com/mulgadc/viperblock/viperblock/backends/s3"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestImportDiskImage(t *testing.T) {
@@ -103,4 +115,236 @@ func TestProgressReporterNilTolerated(t *testing.T) {
 		zero.finish()
 	})
 	assert.False(t, called, "zero-total import reports nothing")
+}
+
+// Default test credentials for the local predastore test server started in
+// TestMain (matches the ones used across the parent viperblock package).
+const (
+	testAccessKey = "AKIAIOSFODNN7EXAMPLE"
+	testSecretKey = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+)
+
+// sharedServerHost / sharedBucket describe the predastore test server started
+// once in TestMain and shared by every test in this package.
+var (
+	sharedServerHost string
+	sharedBucket     string
+)
+
+// sharedHTTPClient skips TLS verification for the self-signed test server cert.
+var sharedHTTPClient = &http.Client{
+	Timeout: 60 * time.Second,
+	Transport: &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, // only for test
+	},
+}
+
+// TestMain starts one in-process predastore cluster for every test in this
+// package that needs a real S3 round trip (the AMI-state tests below): a
+// failed or partial ImportDiskImage is only observable by reading back
+// whatever actually landed in the backend, which a fake or stubbed client
+// cannot stand in for.
+func TestMain(m *testing.M) {
+	os.Exit(func() int {
+		dir, err := os.Getwd()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "failed to get working directory: %v\n", err)
+			return 1
+		}
+		repoRoot := filepath.Join(dir, "..", "..")
+
+		// predastore's internal s3db + QUIC clients verify TLS strictly against
+		// the OS trust store. Point SystemCertPool at our self-signed test cert
+		// so verify succeeds without installing the cert system-wide.
+		certPath := filepath.Join(repoRoot, "config", "server.pem")
+		if err := os.Setenv("SSL_CERT_FILE", certPath); err != nil {
+			fmt.Fprintf(os.Stderr, "failed to set SSL_CERT_FILE: %v\n", err)
+			return 1
+		}
+
+		runRoot, err := os.MkdirTemp("", "viperblock-vutils-predastore-*")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "failed to create temp dir: %v\n", err)
+			return 1
+		}
+		defer os.RemoveAll(runRoot)
+
+		dataDir := filepath.Join(runRoot, "predastore")
+		if err := os.MkdirAll(dataDir, 0o750); err != nil {
+			fmt.Fprintf(os.Stderr, "failed to create predastore data dir: %v\n", err)
+			return 1
+		}
+
+		srv, err := predastoretest.Start(predastoretest.Options{
+			DataDir:    dataDir,
+			CertPath:   certPath,
+			KeyPath:    filepath.Join(repoRoot, "config", "server.key"),
+			BucketName: "predastore",
+			AccessKey:  testAccessKey,
+			SecretKey:  testSecretKey,
+			AccountID:  "123456789012",
+			Region:     "ap-southeast-2",
+		})
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "failed to start predastore test cluster: %v\n", err)
+			return 1
+		}
+		defer func() {
+			shutdownCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			if shutdownErr := srv.Shutdown(shutdownCtx); shutdownErr != nil {
+				fmt.Fprintf(os.Stderr, "predastore shutdown error: %v\n", shutdownErr)
+			}
+		}()
+
+		sharedServerHost = srv.Endpoint
+		sharedBucket = srv.Bucket
+
+		return m.Run()
+	}())
+}
+
+// testMasterKey builds a random AES-GCM master key for encrypted-volume tests.
+func testMasterKey(t *testing.T) *masterkey.Key {
+	t.Helper()
+
+	var raw [masterkey.MasterKeySize]byte
+	_, err := rand.Read(raw[:])
+	require.NoError(t, err)
+
+	aead, err := masterkey.NewAEAD(raw[:])
+	require.NoError(t, err)
+
+	return &masterkey.Key{AEAD: aead, Fingerprint: masterkey.Fingerprint(raw[:])}
+}
+
+// loadPersistedAMIState opens a fresh VB against the same volume/backend
+// ImportDiskImage just wrote to, rooted at a brand-new local dir so LoadState
+// has no local copy to fall back on and must read what is actually durable in
+// the backend — the same view a separate process (e.g. spx describe-images)
+// would get.
+func loadPersistedAMIState(t *testing.T, volumeName string, volumeSize uint64, s3Config *s3.S3Config, key *masterkey.Key) string {
+	t.Helper()
+
+	readerConfig := &viperblock.VB{
+		VolumeName:        volumeName,
+		VolumeSize:        volumeSize,
+		BaseDir:           t.TempDir(),
+		WALSyncInterval:   -1,
+		EncryptionEnabled: key != nil,
+		MasterKey:         key,
+		Cache:             viperblock.Cache{Config: viperblock.CacheConfig{Size: 0}},
+	}
+
+	vb, err := viperblock.New(readerConfig, "s3", *s3Config)
+	require.NoError(t, err)
+	require.NoError(t, vb.Backend.Init())
+	require.NoError(t, vb.LoadState())
+
+	return vb.VolumeConfig.AMIMetadata.State
+}
+
+// makeRawImage writes a size-byte raw disk image filled with a non-zero
+// repeating byte (so ImportDiskImage's zero-block skip never triggers) to a
+// fresh file under dir and returns its path.
+func makeRawImage(t *testing.T, dir string, size uint64) string {
+	t.Helper()
+
+	path := filepath.Join(dir, "disk.raw")
+	img := bytes.Repeat([]byte{0xAB}, int(size))
+	require.NoError(t, os.WriteFile(path, img, 0o600))
+	return path
+}
+
+// TestImportDiskImage_FailedImportLeavesPendingState is the regression guard
+// for mulga-sn062: a failed admin AMI import used to leave the AMI registered
+// and, absent a state field, indistinguishable from a complete one.
+//
+// The volume is deliberately sized to one block while the source image is
+// three, so WriteAt fails with ErrRequestOutOfRange on the second block —
+// after the encrypted pre-loop SaveState has already registered "pending",
+// but before any chunk data or Close ever runs. That is the live path: AMI
+// imports are encrypted by default, and this is the earliest point at which
+// the AMI becomes visible in the backend at all.
+func TestImportDiskImage_FailedImportLeavesPendingState(t *testing.T) {
+	tmpDir := t.TempDir()
+	volumeName := fmt.Sprintf("vol-pending-%d", time.Now().UnixNano())
+	blockSize := uint64(viperblock.DefaultBlockSize)
+
+	imagePath := makeRawImage(t, tmpDir, 3*blockSize)
+	key := testMasterKey(t)
+
+	vbConfig := &viperblock.VB{
+		VolumeName:        volumeName,
+		VolumeSize:        blockSize, // one block: the second write overflows it
+		BaseDir:           filepath.Join(tmpDir, "viperblock"),
+		WALSyncInterval:   -1,
+		EncryptionEnabled: true,
+		MasterKey:         key,
+		Cache:             viperblock.Cache{Config: viperblock.CacheConfig{Size: 0}},
+		VolumeConfig: viperblock.VolumeConfig{
+			AMIMetadata: viperblock.AMIMetadata{Name: "pending-test-ami"},
+		},
+	}
+
+	s3Config := &s3.S3Config{
+		VolumeName: volumeName,
+		VolumeSize: blockSize,
+		Region:     "ap-southeast-2",
+		Bucket:     sharedBucket,
+		AccessKey:  testAccessKey,
+		SecretKey:  testSecretKey,
+		Host:       fmt.Sprintf("https://%s", sharedServerHost),
+		HTTPClient: sharedHTTPClient,
+	}
+
+	err := ImportDiskImage(s3Config, vbConfig, imagePath, nil)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "failed to write block")
+
+	state := loadPersistedAMIState(t, volumeName, blockSize, s3Config, key)
+	assert.Equal(t, "pending", state)
+}
+
+// TestImportDiskImage_CleanImportLeavesAvailableState is the companion pin: a
+// clean import must end with State: "available" durably persisted, not just
+// held in memory. This exercises the unencrypted path deliberately — nothing
+// registers the AMI before Close's own state save runs, so the "available"
+// flip and its follow-up SaveState after Close returns nil is the only thing
+// that ever persists a non-pending state for this path.
+func TestImportDiskImage_CleanImportLeavesAvailableState(t *testing.T) {
+	tmpDir := t.TempDir()
+	volumeName := fmt.Sprintf("vol-available-%d", time.Now().UnixNano())
+	blockSize := uint64(viperblock.DefaultBlockSize)
+	volumeSize := 2 * blockSize
+
+	imagePath := makeRawImage(t, tmpDir, volumeSize)
+
+	vbConfig := &viperblock.VB{
+		VolumeName:      volumeName,
+		VolumeSize:      volumeSize,
+		BaseDir:         filepath.Join(tmpDir, "viperblock"),
+		WALSyncInterval: -1,
+		Cache:           viperblock.Cache{Config: viperblock.CacheConfig{Size: 0}},
+		VolumeConfig: viperblock.VolumeConfig{
+			AMIMetadata: viperblock.AMIMetadata{Name: "available-test-ami"},
+		},
+	}
+
+	s3Config := &s3.S3Config{
+		VolumeName: volumeName,
+		VolumeSize: volumeSize,
+		Region:     "ap-southeast-2",
+		Bucket:     sharedBucket,
+		AccessKey:  testAccessKey,
+		SecretKey:  testSecretKey,
+		Host:       fmt.Sprintf("https://%s", sharedServerHost),
+		HTTPClient: sharedHTTPClient,
+	}
+
+	err := ImportDiskImage(s3Config, vbConfig, imagePath, nil)
+	require.NoError(t, err)
+
+	state := loadPersistedAMIState(t, volumeName, volumeSize, s3Config, nil)
+	assert.Equal(t, "available", state)
 }

--- a/viperblock/viperblock.go
+++ b/viperblock/viperblock.go
@@ -844,6 +844,7 @@ type AMIMetadata struct {
 	Distro          string            `json:"Distro,omitempty"`       // e.g. "debian", "ubuntu", "rocky", "alpine"; empty for AMIs registered before this field existed
 	DistroFamily    string            `json:"DistroFamily,omitempty"` // "debian" | "rhel" | "alpine"; drives cloud-init template branching. Empty defaults to debian-family rendering at launch time.
 	Tags            map[string]string `json:"Tags"`                   // Metadata tags
+	State           string            `json:"State,omitempty"`        // "pending" | "available"; empty for AMIs registered before this field existed, treated as available
 }
 
 // Error messages
@@ -4014,23 +4015,59 @@ func (vb *VB) sweepChunks(ctx context.Context) {
 		"volume", vb.VolumeName, "swept", swept, "candidates", len(candidates), "floor", floor, "watermark", watermark)
 }
 
-// deleteChunkObjects issues a DeleteObject call per chunk ObjectID and
-// returns how many were reclaimed (deleted or already gone). A delete that
-// fails otherwise is left in gcRefcount and out of the swept count, so the
-// next sweep retries it — under-collection (a leaked chunk) is preferred
-// over losing track of a candidate.
+// deleteChunkObjects issues DeleteObject calls across a bounded worker pool
+// (the same UploadWorkers count the write path uses) and returns how many
+// chunks were reclaimed (deleted or already gone). A delete that fails
+// otherwise is left in gcRefcount and out of the swept count, so the next
+// sweep retries it — under-collection (a leaked chunk) is preferred over
+// losing track of a candidate. Stops handing out new deletes once ctx is
+// done; deletes already in flight are allowed to finish.
 func (vb *VB) deleteChunkObjects(ctx context.Context, ids []uint64) (swept int) {
-	for _, id := range ids {
-		if err := vb.Backend.DeleteCtx(ctx, types.FileTypeChunk, id); err != nil && !errors.Is(err, os.ErrNotExist) {
-			vb.logger().Warn("chunk GC: delete failed, will retry next sweep", "objectID", id, "err", err)
-			continue
-		}
-		vb.BlocksToObject.mu.Lock()
-		delete(vb.gcRefcount, id)
-		vb.BlocksToObject.mu.Unlock()
-		swept++
+	if len(ids) == 0 {
+		return 0
 	}
-	return swept
+
+	workers := vb.UploadWorkers
+	if workers <= 0 {
+		workers = DefaultUploadWorkers
+	}
+	if workers > len(ids) {
+		workers = len(ids)
+	}
+
+	idChan := make(chan uint64)
+	var sweptCount atomic.Int64
+	var wg sync.WaitGroup
+
+	wg.Add(workers)
+	for range workers {
+		go func() {
+			defer wg.Done()
+			for id := range idChan {
+				if err := vb.Backend.DeleteCtx(ctx, types.FileTypeChunk, id); err != nil && !errors.Is(err, os.ErrNotExist) {
+					vb.logger().Warn("chunk GC: delete failed, will retry next sweep", "objectID", id, "err", err)
+					continue
+				}
+				vb.BlocksToObject.mu.Lock()
+				delete(vb.gcRefcount, id)
+				vb.BlocksToObject.mu.Unlock()
+				sweptCount.Add(1)
+			}
+		}()
+	}
+
+feed:
+	for _, id := range ids {
+		select {
+		case idChan <- id:
+		case <-ctx.Done():
+			break feed
+		}
+	}
+	close(idChan)
+	wg.Wait()
+
+	return int(sweptCount.Load())
 }
 
 // runGCSweep drains this VB to the backend -- persisting a live checkpoint


### PR DESCRIPTION
Two contained defects from the storage-exhaustion sweep cluster. Both bead descriptions named the wrong mechanism; the corrected root causes are recorded on the beads and in the plan doc.

Plan: `docs/development/bugs/chunk-gc-throughput-and-partial-ami-state.md`

## mulga-nad9v — chunk GC cannot catch a parallel writer

Not ticker starvation, as the bead described — `StartChunkGC` already runs the sweep on its own goroutine, and Go's `time.Ticker` buffers a tick and self-corrects, so the fix that followed from that reading would have been a no-op.

The real defect is a throughput mismatch: `deleteChunkObjects` was a sequential loop issuing one blocking `Backend.DeleteCtx` per chunk, while `sweepChunks` builds an unbounded candidate list each pass. Writes are parallel, deletes were not, so against a sustained parallel writer the candidate list grows faster than the loop drains it and reclaimed space never catches allocation.

Now a bounded worker pool sized from the existing `UploadWorkers` setting, rather than a second concurrency knob. Semantics preserved: `os.ErrNotExist` still counts as swept, any other error still logs and skips without dropping the refcount, the refcount delete stays under `BlocksToObject.mu`, and the feed loop stops handing out work once the context is done.

## mulga-sn062 — a failed image import stays `available`

`spx admin images import` against a full backend exits non-zero, but `describe-images` still listed the AMI as `available`, so a partial image was indistinguishable from a complete one.

Registration reaches predastore before the data does. For encrypted volumes — the default — `ImportDiskImage` calls `SaveState()` before the write loop in order to mint `VolumeUUID`, and that persists `AMIMetadata` along with the rest of `VolumeConfig`, before a single block flushes.

Note the earlier reading that `CloseCtx` swallowed the WAL error was wrong: it does return it, and the CLI does exit 1. The AMI was registered either way, and nothing downstream could express the failure because `AMIMetadata` had no state field at all.

This adds one. Import writes `pending` at that pre-loop save and flips to `available` only after `Close` returns nil, so a failure anywhere in between leaves an honest record that is safe to deregister. The unencrypted path carries the value in memory until `Close`'s own save persists it — the same timing it already had, now with a meaningful value.

The consumer half — projecting the field through `DescribeImages`, with empty treated as `available` so existing AMIs are unaffected — is a follow-up in spinifex, since it needs this commit pinned first.

## Testing

`make preflight` passes. New tests, each verified to fail before the change:

- the delete pool reaches its configured width, asserted on observed concurrency rather than wall-clock, so it does not become a load-sensitive flake
- a failed import leaves `State: "pending"`; a clean import leaves `"available"`

Closes mulga-nad9v. Progresses mulga-sn062 (spinifex follow-up required).