### PR TITLE
fix: clear the backendFull latch on write-triggered capacity recovery

### DIFF
--- a/viperblock/enospc_test.go
+++ b/viperblock/enospc_test.go
@@ -401,6 +401,108 @@ func TestNearFullThenFullStillFailsFast(t *testing.T) {
 		"a genuinely full backend must still fail writes fast")
 }
 
+// TestWriteAtRecoversBackendFullLatchWithoutPriorSuccessfulDrain pins the
+// capacity-recovery fix: once the backend genuinely has room again, a guest
+// write retried against the still-latched backendFull gate must succeed
+// immediately -- it must not need an operator-invisible successful drain to
+// have already happened first. Before the fix this looped forever, since the
+// up-front gate returned ErrNoSpace unconditionally while backendFull was
+// set and nothing else drove a fresh drain.
+func TestWriteAtRecoversBackendFullLatchWithoutPriorSuccessfulDrain(t *testing.T) {
+	vb, backend := newEnospcTestVB(t)
+	blockSize := uint64(vb.BlockSize)
+
+	require.NoError(t, vb.WriteAt(0, make([]byte, blockSize)))
+
+	backend.full.Store(true)
+	require.Error(t, vb.DrainToBackendCtx(context.Background()))
+	require.True(t, vb.backendFull.Load(), "latch must be set before we can test it clearing")
+
+	// Genuine capacity recovery, exactly as an operator freeing space would
+	// produce -- but deliberately WITHOUT calling DrainToBackendCtx directly
+	// first. The only trigger available to production code at this point is
+	// the guest's own retried write landing on the still-latched gate.
+	backend.full.Store(false)
+
+	err := vb.WriteAt(blockSize, make([]byte, blockSize))
+	assert.NoError(t, err, "a write against a recovered backend must succeed on the first retry, not require a second resume")
+	assert.False(t, vb.backendFull.Load(), "the latch must have cleared as a side effect of the recovered write, not stayed stuck")
+
+	require.NoError(t, vb.DrainToBackendCtx(context.Background()))
+}
+
+// TestWriteAtCtxDoesNotClearLatchWhileGenuinelyFull pins the regression that
+// matters most: a write landing on the gate while the backend is STILL full
+// must not clear the latch, must still fail fast with ErrNoSpace, and must
+// leave no side effects (no buffered bytes, no change to the stranded
+// generation waiting to be retried). A fix that clears the latch
+// optimistically (e.g. on any write, or on a timer) would fail this test.
+func TestWriteAtCtxDoesNotClearLatchWhileGenuinelyFull(t *testing.T) {
+	vb, backend := newEnospcTestVB(t)
+	blockSize := uint64(vb.BlockSize)
+
+	require.NoError(t, vb.WriteAt(0, make([]byte, blockSize)))
+
+	backend.full.Store(true)
+	require.Error(t, vb.DrainToBackendCtx(context.Background()))
+	require.True(t, vb.backendFull.Load())
+	require.Equal(t, 1, pendingWALChunksLen(vb), "the failed generation must be tracked for retry")
+
+	// Backend stays genuinely full -- no capacity has actually recovered.
+	pendingBefore := vb.PendingBytes()
+
+	err := vb.WriteAt(blockSize, make([]byte, blockSize))
+	assert.ErrorIs(t, err, ErrNoSpace, "a write against a still-full backend must fail fast with ErrNoSpace")
+	assert.True(t, vb.backendFull.Load(), "the latch must remain set -- capacity has not actually recovered")
+	assert.Equal(t, pendingBefore, vb.PendingBytes(),
+		"a fast-failed write must not have buffered anything, even though it drove a recovery probe")
+	assert.Equal(t, 1, pendingWALChunksLen(vb), "the stranded generation must still be pending after a failed probe")
+
+	// Repeat: a second still-failing write must behave identically, not flip
+	// the latch on some later attempt just because it retried again.
+	err = vb.WriteAt(blockSize, make([]byte, blockSize))
+	assert.ErrorIs(t, err, ErrNoSpace)
+	assert.True(t, vb.backendFull.Load(), "repeated writes against a still-full backend must never clear the latch")
+
+	backend.full.Store(false)
+	require.NoError(t, vb.DrainToBackendCtx(context.Background()))
+}
+
+// TestWriteAtRecoveryDoesNotFlapAcrossRepeatedWrites pins that once the
+// latch has cleared off the back of a recovered write, a burst of further
+// writes does not re-drive redundant probes or toggle the latch back and
+// forth. The recovery log line is edge-triggered (see
+// TestBackendFullLatchLogsTransitionsOnce), so if the fix reset or
+// re-evaluated backendFull on every write instead of gating on its current
+// value, this would log "backend space recovered" more than once.
+func TestWriteAtRecoveryDoesNotFlapAcrossRepeatedWrites(t *testing.T) {
+	vb, backend := newEnospcTestVB(t)
+	var buf bytes.Buffer
+	vb.log = slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	blockSize := uint64(vb.BlockSize)
+
+	require.NoError(t, vb.WriteAt(0, make([]byte, blockSize)))
+
+	backend.full.Store(true)
+	require.Error(t, vb.DrainToBackendCtx(context.Background()))
+	require.True(t, vb.backendFull.Load())
+
+	backend.full.Store(false)
+
+	for i := uint64(1); i <= 5; i++ {
+		err := vb.WriteAt(i*blockSize, make([]byte, blockSize))
+		require.NoError(t, err, "write %d against a recovered backend must succeed", i)
+		require.False(t, vb.backendFull.Load(), "latch must stay clear across repeated writes, not flap")
+	}
+
+	assert.Equal(t, 1, strings.Count(buf.String(), "backend space recovered"),
+		"recovery must log exactly once despite multiple writes landing after it")
+	assert.Equal(t, 1, strings.Count(buf.String(), "latching writes off"),
+		"the original latch trip must log exactly once; recovery writes must not re-trip it")
+
+	require.NoError(t, vb.DrainToBackendCtx(context.Background()))
+}
+
 // TestErrNoSpaceIsTypesErrNoSpace pins that ErrNoSpace re-exports
 // types.ErrNoSpace, and drain-path error wrapping doesn't break errors.Is
 // against either name.

--- a/viperblock/enospc_test.go
+++ b/viperblock/enospc_test.go
@@ -56,6 +56,11 @@ type enospcBackend struct {
 	// BlocksToObject.dirty after a scripted checkpoint success, standing in
 	// for a concurrent guest write that would otherwise dirty it again.
 	afterWrite func(fileType types.FileType, err error)
+
+	// blockUntilCancelled, when true, makes WriteCtx block on ctx.Done()
+	// instead of writing, standing in for a slow or unreachable backend
+	// whose call never returns on its own.
+	blockUntilCancelled atomic.Bool
 }
 
 // enospcErr mirrors what backends/s3 and backends/file return once
@@ -110,6 +115,10 @@ func (b *enospcBackend) Write(fileType types.FileType, objectId uint64, headers 
 }
 
 func (b *enospcBackend) WriteCtx(ctx context.Context, fileType types.FileType, objectId uint64, headers *[]byte, data *[]byte) error {
+	if b.blockUntilCancelled.Load() {
+		<-ctx.Done()
+		return ctx.Err()
+	}
 	err := b.dispatch(fileType, func() error { return b.Backend.WriteCtx(ctx, fileType, objectId, headers, data) })
 	if b.afterWrite != nil {
 		b.afterWrite(fileType, err)
@@ -531,6 +540,48 @@ func runBlockingWriteWithHangTimeout(t *testing.T, vb *VB, offset uint64, data [
 		t.Fatalf("WriteAt did not return within %s -- awaitBackpressure is hanging instead of bounding consecutive drain failures", timeout)
 		return nil // unreachable, t.Fatalf stops the goroutine
 	}
+}
+
+// TestWriteAtRecoveryProbeDoesNotHangAgainstUnresponsiveBackend pins that
+// the recovery probe cannot block a guest write indefinitely. WriteAt (the
+// guest write entrypoint) passes context.Background(), so without its own
+// deadline probeBackendRecovery would hang forever against a backend that
+// never responds, instead of failing fast with ErrNoSpace as it did before
+// the probe existed. backendRecoveryProbeTimeout is shrunk to a fixed,
+// non-sleeping bound so the probe's own deadline -- not a test sleep --
+// is what makes this deterministic.
+func TestWriteAtRecoveryProbeDoesNotHangAgainstUnresponsiveBackend(t *testing.T) {
+	vb, backend := newEnospcTestVB(t)
+	blockSize := uint64(vb.BlockSize)
+	vb.backendRecoveryProbeTimeout = time.Millisecond
+
+	require.NoError(t, vb.WriteAt(0, make([]byte, blockSize)))
+
+	backend.full.Store(true)
+	require.Error(t, vb.DrainToBackendCtx(context.Background()))
+	require.True(t, vb.backendFull.Load(), "latch must be set before we can test the probe against it")
+
+	// The backend now neither rejects nor accepts writes -- it just never
+	// responds, like an unreachable or badly overloaded backend.
+	backend.full.Store(false)
+	backend.blockUntilCancelled.Store(true)
+
+	// 5s is a generous hang detector, not the expected duration: the probe's
+	// own 1ms deadline is what should make this return, so this must not
+	// become a timing-flaky assertion on either bound.
+	err := runBlockingWriteWithHangTimeout(t, vb, blockSize, make([]byte, blockSize), 5*time.Second)
+	assert.ErrorIs(t, err, ErrNoSpace, "a write against an unresponsive backend must fail fast once the probe's own deadline expires, not hang")
+	assert.True(t, vb.backendFull.Load(), "a timed-out probe is not evidence of recovery -- the latch must remain set")
+	assert.False(t, vb.drainInFlight.Load(), "a timed-out probe must release drainInFlight, not leave it stuck true")
+
+	// Confirms drainInFlight was actually released above: a write that can
+	// win the CAS and observe real recovery must still succeed afterward.
+	backend.blockUntilCancelled.Store(false)
+	err = runBlockingWriteWithHangTimeout(t, vb, blockSize, make([]byte, blockSize), 5*time.Second)
+	assert.NoError(t, err, "once the backend actually responds, a later write must still be able to recover the latch")
+	assert.False(t, vb.backendFull.Load())
+
+	require.NoError(t, vb.DrainToBackendCtx(context.Background()))
 }
 
 // TestAwaitBackpressureBoundsConsecutiveNonNoSpaceFailures pins that a

--- a/viperblock/viperblock.go
+++ b/viperblock/viperblock.go
@@ -198,17 +198,20 @@ type VB struct {
 	pendingBytes atomic.Int64
 
 	// drainInFlight ensures at most one goroutine actively drives
-	// DrainToBackendCtx from inside awaitBackpressure at a time; concurrent
-	// blocked writers poll pendingBytes instead of each launching a
-	// redundant drain. Only an optimization for the backpressure path —
-	// drainMu below is the actual cross-trigger exclusion guarantee.
+	// DrainToBackendCtx from inside awaitBackpressure or probeBackendRecovery
+	// at a time; concurrent blocked writers poll pendingBytes (or, for the
+	// recovery probe, just fail fast) instead of each launching a redundant
+	// drain. Only an optimization for these write-path triggers — drainMu
+	// below is the actual cross-trigger exclusion guarantee.
 	drainInFlight atomic.Bool
 
 	// backendFull latches an out-of-space error from the backend (predastore
 	// 507/503, or local ENOSPC). Writes are acked before their chunk is PUT,
 	// so the error surfaces on a later drain; WriteAtCtx checks this latch
 	// up front and fails fast with ErrNoSpace while set. Cleared on the next
-	// successful drain.
+	// successful drain — including one driven synchronously by
+	// probeBackendRecovery, so a guest write retried after capacity is freed
+	// does not need a prior, otherwise-triggered successful drain first.
 	backendFull atomic.Bool
 
 	// pendingWALChunks holds WAL generations that were rotated out but whose
@@ -1818,6 +1821,32 @@ func (vb *VB) isBackendNearFull() bool {
 	return ok && nf.NearFull()
 }
 
+// probeBackendRecovery drives a real DrainToBackendCtx while backendFull is
+// latched and reports whether the latch is clear afterward. This is the
+// same capacity check DrainToBackendCtx already performs on every trigger
+// (ticker, size threshold, explicit drain) -- calling it here just adds the
+// write path as a trigger, so a guest write retried after the operator
+// frees space observes recovery immediately instead of waiting for the next
+// background drain.
+//
+// drainInFlight ensures only one write drives the probe at a time; a
+// concurrent write just fails fast rather than piling onto a backend that
+// is still full or unreachable, since DrainToBackendCtx's own drainMu would
+// otherwise queue them into redundant, possibly slow calls. Because the
+// clear is gated on an actual successful upload+checkpoint round trip (not
+// a cheap threshold read), it cannot flap on its own: it reports exactly
+// what the backend just did, and repeated calls while backendFull is
+// already clear skip the probe entirely (see the caller's gate).
+func (vb *VB) probeBackendRecovery(ctx context.Context) bool {
+	if !vb.drainInFlight.CompareAndSwap(false, true) {
+		return false
+	}
+	defer vb.drainInFlight.Store(false)
+
+	_ = vb.DrainToBackendCtx(ctx)
+	return !vb.backendFull.Load()
+}
+
 // WriteAtCtx is WriteAt with a caller-supplied context that flows through any
 // read-modify-write backend fetches for trace propagation.
 func (vb *VB) WriteAtCtx(ctx context.Context, offset uint64, data []byte) error {
@@ -1829,7 +1858,14 @@ func (vb *VB) WriteAtCtx(ctx context.Context, offset uint64, data []byte) error 
 	// actually rejected. Nearfull pressure rides on a SUCCESSFUL response and
 	// means "slow down", so it throttles via maxPendingBytes instead.
 	if vb.backendFull.Load() {
-		return ErrNoSpace
+		// A write landing here is exactly the moment a guest retries after an
+		// operator frees space and resumes -- probe with a real drain instead
+		// of waiting for the next background ChunkUploadInterval tick, so
+		// genuine capacity recovery does not need a second resume to be
+		// observed.
+		if !vb.probeBackendRecovery(ctx) {
+			return ErrNoSpace
+		}
 	}
 
 	// First check the block exists in our volume size

--- a/viperblock/viperblock.go
+++ b/viperblock/viperblock.go
@@ -54,6 +54,11 @@ const DefaultGCInterval time.Duration = 5 * time.Minute
 // blip rather than a hard outage: three attempts spend ~3s total before giving up.
 const DefaultCheckpointRetryBackoff time.Duration = time.Second
 
+// DefaultBackendRecoveryProbeTimeout bounds probeBackendRecovery's drain, since
+// the guest write path (WriteAt) has no deadline of its own. Long enough for a
+// healthy round trip; short of a guest's own block-layer command timeout.
+const DefaultBackendRecoveryProbeTimeout time.Duration = 3 * time.Second
+
 // DefaultMaxPendingBytes bounds the combined size of Writes.Blocks and
 // PendingBackendWrites.Blocks — the guest-write backpressure high-watermark.
 // WriteAtCtx blocks the caller once this is crossed, draining synchronously
@@ -375,6 +380,11 @@ type VB struct {
 	// set it, shrinking a retry storm from seconds of real sleeping to
 	// microseconds.
 	checkpointRetryBackoff time.Duration
+
+	// backendRecoveryProbeTimeout bounds probeBackendRecovery's drain (0 uses
+	// DefaultBackendRecoveryProbeTimeout). Only tests set it, so a hanging
+	// fake backend times out in microseconds instead of the production bound.
+	backendRecoveryProbeTimeout time.Duration
 
 	// GCEnabled turns on chunk garbage collection: deleting superseded chunk
 	// objects no live block references. Default false — opt-in, since a
@@ -1705,6 +1715,15 @@ func (vb *VB) checkpointBackoff() time.Duration {
 	return vb.checkpointRetryBackoff
 }
 
+// recoveryProbeTimeout returns the configured backendRecoveryProbeTimeout,
+// or the default if unset.
+func (vb *VB) recoveryProbeTimeout() time.Duration {
+	if vb.backendRecoveryProbeTimeout <= 0 {
+		return DefaultBackendRecoveryProbeTimeout
+	}
+	return vb.backendRecoveryProbeTimeout
+}
+
 // signalSizeTrigger asks the background chunk uploader to drain now, once
 // pendingBytes crosses FlushSize, instead of waiting for the next
 // ChunkUploadInterval tick. Non-blocking: a trigger already pending
@@ -1825,9 +1844,18 @@ func (vb *VB) probeBackendRecovery(ctx context.Context) bool {
 	}
 	defer vb.drainInFlight.Store(false)
 
+	// ctx may be context.Background() on the guest write path, so bound the
+	// drain explicitly -- otherwise a slow or unreachable backend would hang
+	// the write instead of failing fast, as it did before this probe existed.
+	probeCtx, cancel := context.WithTimeout(ctx, vb.recoveryProbeTimeout())
+	defer cancel()
+
 	// Gated on a real upload+checkpoint round trip, not a cached threshold,
-	// so the result can't flap: it reports exactly what the backend just did.
-	_ = vb.DrainToBackendCtx(ctx)
+	// so a clean result can't flap: it reports exactly what the backend just
+	// did. A timed-out or failed probe leaves the latch set.
+	if err := vb.DrainToBackendCtx(probeCtx); err != nil {
+		return false
+	}
 	return !vb.backendFull.Load()
 }
 

--- a/viperblock/viperblock.go
+++ b/viperblock/viperblock.go
@@ -197,21 +197,14 @@ type VB struct {
 	// exact linearizability with the slices is not required.
 	pendingBytes atomic.Int64
 
-	// drainInFlight ensures at most one goroutine actively drives
-	// DrainToBackendCtx from inside awaitBackpressure or probeBackendRecovery
-	// at a time; concurrent blocked writers poll pendingBytes (or, for the
-	// recovery probe, just fail fast) instead of each launching a redundant
-	// drain. Only an optimization for these write-path triggers — drainMu
-	// below is the actual cross-trigger exclusion guarantee.
+	// drainInFlight bounds awaitBackpressure and probeBackendRecovery to one
+	// active drain each at a time; other callers fail fast or poll instead of
+	// launching redundant drains. drainMu below is the real exclusion guarantee.
 	drainInFlight atomic.Bool
 
-	// backendFull latches an out-of-space error from the backend (predastore
-	// 507/503, or local ENOSPC). Writes are acked before their chunk is PUT,
-	// so the error surfaces on a later drain; WriteAtCtx checks this latch
-	// up front and fails fast with ErrNoSpace while set. Cleared on the next
-	// successful drain — including one driven synchronously by
-	// probeBackendRecovery, so a guest write retried after capacity is freed
-	// does not need a prior, otherwise-triggered successful drain first.
+	// backendFull latches when a drain reports the backend out of space, so
+	// WriteAtCtx can fail fast with ErrNoSpace up front. See
+	// DrainToBackendCtx's deferred handler for where it is set and cleared.
 	backendFull atomic.Bool
 
 	// pendingWALChunks holds WAL generations that were rotated out but whose
@@ -1822,27 +1815,18 @@ func (vb *VB) isBackendNearFull() bool {
 }
 
 // probeBackendRecovery drives a real DrainToBackendCtx while backendFull is
-// latched and reports whether the latch is clear afterward. This is the
-// same capacity check DrainToBackendCtx already performs on every trigger
-// (ticker, size threshold, explicit drain) -- calling it here just adds the
-// write path as a trigger, so a guest write retried after the operator
-// frees space observes recovery immediately instead of waiting for the next
-// background drain.
-//
-// drainInFlight ensures only one write drives the probe at a time; a
-// concurrent write just fails fast rather than piling onto a backend that
-// is still full or unreachable, since DrainToBackendCtx's own drainMu would
-// otherwise queue them into redundant, possibly slow calls. Because the
-// clear is gated on an actual successful upload+checkpoint round trip (not
-// a cheap threshold read), it cannot flap on its own: it reports exactly
-// what the backend just did, and repeated calls while backendFull is
-// already clear skip the probe entirely (see the caller's gate).
+// latched and reports whether the latch cleared, so a retried write can
+// observe recovery immediately instead of waiting for the next drain tick.
 func (vb *VB) probeBackendRecovery(ctx context.Context) bool {
+	// One write drives the probe at a time; concurrent writers fail fast
+	// rather than queuing on drainMu behind a possibly slow backend.
 	if !vb.drainInFlight.CompareAndSwap(false, true) {
 		return false
 	}
 	defer vb.drainInFlight.Store(false)
 
+	// Gated on a real upload+checkpoint round trip, not a cached threshold,
+	// so the result can't flap: it reports exactly what the backend just did.
 	_ = vb.DrainToBackendCtx(ctx)
 	return !vb.backendFull.Load()
 }
@@ -1858,11 +1842,8 @@ func (vb *VB) WriteAtCtx(ctx context.Context, offset uint64, data []byte) error 
 	// actually rejected. Nearfull pressure rides on a SUCCESSFUL response and
 	// means "slow down", so it throttles via maxPendingBytes instead.
 	if vb.backendFull.Load() {
-		// A write landing here is exactly the moment a guest retries after an
-		// operator frees space and resumes -- probe with a real drain instead
-		// of waiting for the next background ChunkUploadInterval tick, so
-		// genuine capacity recovery does not need a second resume to be
-		// observed.
+		// Probe for recovery instead of failing outright: this is exactly the
+		// moment a guest retries after an operator frees space and resumes.
 		if !vb.probeBackendRecovery(ctx) {
 			return ErrNoSpace
 		}


### PR DESCRIPTION
## Summary

Closes **mulga-mv3mt** — the `backendFull` latch was sticky across space recovery, so a guest needed two consecutive successful writes before I/O resumed after the backend regained capacity.

`WriteAtCtx` set `backendFull` on an out-of-space drain and only ever cleared it as a side effect of a later drain that happened to succeed for other reasons. A write arriving after capacity was restored still saw the latch and returned `ErrNoSpace`.

## Changes

- `WriteAtCtx` now runs `probeBackendRecovery` when the latch is set, so the first write after recovery clears it rather than the second.
- The probe is bounded by `DefaultBackendRecoveryProbeTimeout` (3s), configurable per-`VB` via `backendRecoveryProbeTimeout` for tests. Without a deadline the probe inherited an unbounded context: `WriteAt` (`viperblock.go:1670-1672`) delegates to `WriteAtCtx(context.Background(), ...)`, and the nbd guest write path (`nbd/viperblock.go:450` `PWrite`, `:473` `Zero`) only ever calls `WriteAt` — so a synchronous `DrainToBackendCtx` against an unresponsive backend would have hung the guest write indefinitely.
- On any probe error, including `DeadlineExceeded`, the write returns `ErrNoSpace` — identical to the pre-probe behaviour. `drainInFlight` is released via the existing `defer`, so a timed-out probe cannot wedge the CAS.

3s rather than reusing `shutdownDrainTimeout` (20s): that constant budgets a one-time teardown against systemd's `TimeoutStopSec`, whereas this runs inside a hot guest write. 3s covers a healthy chunk-upload plus checkpoint round trip while staying well under typical guest block-layer command timeouts (~30s), so a genuinely stuck backend surfaces as a bounded per-write failure rather than a hang.

## Testing

`TestWriteAtRecoveryProbeDoesNotHangAgainstUnresponsiveBackend` (`enospc_test.go`) adds a `blockUntilCancelled` mode to the `enospcBackend` double, where `WriteCtx` blocks on `<-ctx.Done()`. The probe timeout is set to 1ms so the assertion is gated on the probe's own deadline, not wall clock. It asserts `ErrNoSpace`, that `backendFull` stays set, and that `drainInFlight` is released — then makes the backend responsive again and confirms a later write still recovers the latch.

Pre-fix, with the probe unbounded:

```
=== RUN   TestWriteAtRecoveryProbeDoesNotHangAgainstUnresponsiveBackend
    enospc_test.go:572: WriteAt did not return within 5s -- awaitBackpressure is hanging instead of bounding consecutive drain failures
--- FAIL: TestWriteAtRecoveryProbeDoesNotHangAgainstUnresponsiveBackend (5.00s)
```

`make preflight` passes: 0 lint issues, no vulnerabilities, race detector clean.