### PR TITLE
fix: accept nbdkit S3 credentials from the environment as well as argv

### DIFF
--- a/nbd/viperblock.go
+++ b/nbd/viperblock.go
@@ -92,6 +92,25 @@ var disk []byte
 // disabled for this plugin instance.
 var loadedMasterKey *masterkey.Key
 
+// accessKeyEnv and secretKeyEnv name the environment variables that supply
+// S3 credentials when nbdkit's plugin argv did not set them. This keeps
+// credentials out of argv, which is world-readable via /proc/<pid>/cmdline
+// for the life of the process.
+const (
+	accessKeyEnv = "VB_ACCESS_KEY"
+	secretKeyEnv = "VB_SECRET_KEY"
+)
+
+// credentialFromArgOrEnv resolves a credential, preferring the nbdkit argv
+// value and falling back to the named environment variable when argv did
+// not set it. Mirrors LoadMasterKeyFromFlagOrEnv's flag-then-env precedence.
+func credentialFromArgOrEnv(argValue, envName string) string {
+	if argValue != "" {
+		return argValue
+	}
+	return os.Getenv(envName)
+}
+
 // NOTE: For profiling viperblock/nbdkit, use Linux perf instead of Go pprof.
 // Go's pprof does NOT work correctly when running as a CGO shared library.
 //
@@ -171,6 +190,11 @@ func (p *ViperBlockPlugin) Config(key string, value string) error {
 }
 
 func (p *ViperBlockPlugin) ConfigComplete() error {
+	// Fall back to the environment when nbdkit's argv did not supply
+	// credentials, so spinifex can stop passing them as literal argv.
+	access_key = credentialFromArgOrEnv(access_key, accessKeyEnv)
+	secret_key = credentialFromArgOrEnv(secret_key, secretKeyEnv)
+
 	if size == 0 {
 		return nbdkit.PluginError{Errmsg: "size parameter is required"}
 	} else if volume == "" {

--- a/nbd/viperblock_test.go
+++ b/nbd/viperblock_test.go
@@ -11,6 +11,113 @@ import (
 	"libguestfs.org/nbdkit"
 )
 
+// resetPluginConfigState clears package-level nbdkit config vars so each
+// test starts from ConfigComplete's zero state instead of leaking values
+// set by a previous test.
+func resetPluginConfigState() {
+	size = 0
+	volume = ""
+	bucket = ""
+	region = ""
+	access_key = ""
+	secret_key = ""
+	host = ""
+	base_dir = ""
+	encryption_key_file = ""
+	loadedMasterKey = nil
+}
+
+// TestCredentialFromArgOrEnv_ArgvTakesPriority pins that a non-empty argv
+// value wins over the environment, matching LoadMasterKeyFromFlagOrEnv's
+// flag-then-env precedence.
+func TestCredentialFromArgOrEnv_ArgvTakesPriority(t *testing.T) {
+	t.Setenv("VB_TEST_CRED", "from-env")
+
+	got := credentialFromArgOrEnv("from-argv", "VB_TEST_CRED")
+	assert.Equal(t, "from-argv", got)
+}
+
+// TestCredentialFromArgOrEnv_FallsBackToEnv pins that an empty argv value
+// falls back to the named environment variable.
+func TestCredentialFromArgOrEnv_FallsBackToEnv(t *testing.T) {
+	t.Setenv("VB_TEST_CRED", "from-env")
+
+	got := credentialFromArgOrEnv("", "VB_TEST_CRED")
+	assert.Equal(t, "from-env", got)
+}
+
+// TestCredentialFromArgOrEnv_EmptyWhenNeitherSet pins that an empty argv
+// value with no environment variable set resolves to empty.
+func TestCredentialFromArgOrEnv_EmptyWhenNeitherSet(t *testing.T) {
+	got := credentialFromArgOrEnv("", "VB_TEST_CRED_UNSET")
+	assert.Equal(t, "", got)
+}
+
+// TestConfigComplete_AcceptsEnvSuppliedCredentials pins that ConfigComplete
+// succeeds when credentials arrive via VB_ACCESS_KEY/VB_SECRET_KEY instead
+// of argv, and that the resolved package vars carry the env values.
+func TestConfigComplete_AcceptsEnvSuppliedCredentials(t *testing.T) {
+	resetPluginConfigState()
+	defer resetPluginConfigState()
+
+	t.Setenv("VB_ACCESS_KEY", "env-access-key")
+	t.Setenv("VB_SECRET_KEY", "env-secret-key")
+
+	size = 1
+	volume = "vol-1"
+	bucket = "bucket-1"
+	region = "region-1"
+	base_dir = "/data"
+	host = "localhost:9000"
+
+	p := &ViperBlockPlugin{}
+	err := p.ConfigComplete()
+	assert.NoError(t, err)
+	assert.Equal(t, "env-access-key", access_key)
+	assert.Equal(t, "env-secret-key", secret_key)
+}
+
+// TestConfigComplete_StillAcceptsArgvSuppliedCredentials pins the transition
+// path: an unpinned spinifex still passing credentials via argv (Config
+// callbacks) must keep working with no environment variables set.
+func TestConfigComplete_StillAcceptsArgvSuppliedCredentials(t *testing.T) {
+	resetPluginConfigState()
+	defer resetPluginConfigState()
+
+	size = 1
+	volume = "vol-1"
+	bucket = "bucket-1"
+	region = "region-1"
+	access_key = "argv-access-key"
+	secret_key = "argv-secret-key"
+	base_dir = "/data"
+	host = "localhost:9000"
+
+	p := &ViperBlockPlugin{}
+	err := p.ConfigComplete()
+	assert.NoError(t, err)
+	assert.Equal(t, "argv-access-key", access_key)
+	assert.Equal(t, "argv-secret-key", secret_key)
+}
+
+// TestConfigComplete_RejectsMissingCredentialsFromBothSources pins that
+// ConfigComplete still errors when credentials are absent from both argv
+// and the environment.
+func TestConfigComplete_RejectsMissingCredentialsFromBothSources(t *testing.T) {
+	resetPluginConfigState()
+	defer resetPluginConfigState()
+
+	size = 1
+	volume = "vol-1"
+	bucket = "bucket-1"
+	region = "region-1"
+
+	p := &ViperBlockPlugin{}
+	err := p.ConfigComplete()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "access_key parameter is required")
+}
+
 // TestBackendErrToPluginErrorMapsErrNoSpaceToENOSPC pins that a
 // viperblock.ErrNoSpace write error reaches nbdkit as ENOSPC, not a generic
 // I/O error.


### PR DESCRIPTION
Half one of two for **mulga-r3tim**. **Safe to merge on its own** — this only *adds* an environment fallback; argv still works exactly as before.

## Why

spinifex passes the S3 access key and secret to `nbdkit` as literal argv, so they are world-readable via `/proc/<pid>/cmdline` for the lifetime of every nbdkit process. Fixing that requires the plugin to accept the credentials from somewhere other than argv first.

## Changes

`nbd/viperblock.go` gains `accessKeyEnv`/`secretKeyEnv` constants (`VB_ACCESS_KEY`/`VB_SECRET_KEY`) and a `credentialFromArgOrEnv` helper, wired into `ConfigComplete` ahead of the required-field checks. An argv-supplied value wins if set; otherwise it falls back to the environment.

This mirrors `viperblock/masterkey_load.go`'s existing `LoadMasterKeyFromFlagOrEnv`, which already does exactly this for `ENCRYPTION_KEY_FILE` — a proven pattern in this codebase rather than a new mechanism.

## Ordering

Accepting *either* source is deliberate, and is what makes this mergeable independently: an unpinned spinifex that still sends credentials via argv keeps working. The spinifex half, which stops sending them in argv, must not be merged until `spinifex/go.mod` pins viperblock to this commit or later.

## Testing

6 new tests. `TestConfigComplete_StillAcceptsArgvSuppliedCredentials` proves the transition path — credentials via argv only, no env vars set. `TestConfigComplete_RejectsMissingCredentialsFromBothSources` proves the plugin still errors with `access_key parameter is required` when absent from both.

Pre-fix:
```
nbd/viperblock_test.go:36:9: undefined: credentialFromArgOrEnv
nbd/viperblock_test.go:45:9: undefined: credentialFromArgOrEnv
nbd/viperblock_test.go:52:9: undefined: credentialFromArgOrEnv
FAIL	command-line-arguments [build failed]
```

`make preflight` passes. Note for reviewers: `nbd/` is a separate Go module, explicitly excluded from the root golangci-lint config (cgo/gosec issues) and not reached by root preflight's `go test ./...`. It was validated separately via `go test nbd/viperblock.go nbd/viperblock_test.go` in file-arg mode, because `cd nbd && go test` trips Go's `internal/` import-visibility rule against the nested `module main`.