### PR TITLE
fix: prevent concurrent volume opens from corrupting WAL and state

### DIFF
--- a/nbd/viperblock.go
+++ b/nbd/viperblock.go
@@ -59,6 +59,13 @@ type ViperBlockConnection struct {
 // shutdown mode).
 var activeVB *viperblock.VB
 
+// volumeLock holds the flock'd file for the currently-open volume, admission
+// control for the race CanMultiConn's false return only advises about (it
+// does not gate connection admission — nbdkit's Go binding hard-codes
+// NBDKIT_THREAD_MODEL_PARALLEL). Acquired in Open before New() constructs a
+// VB, released in Close/Unload. See viperblock.AcquireVolumeLock.
+var volumeLock *os.File
+
 // snapshotListener is the unix socket that spinifex connects to before calling
 // CreateSnapshot. The handler calls DrainToBackend and acks "OK\n", ensuring S3
 // state is current without requiring every guest fsync to hit S3.
@@ -249,6 +256,34 @@ func (p *ViperBlockPlugin) GetReady() error {
 
 func (p *ViperBlockPlugin) Open(readonly bool) (nbdkit.ConnectionInterface, error) {
 
+	// Admission control: at most one Open() proceeds past this point per
+	// volume. Acquired before viperblock.New() so a second concurrent
+	// connection (nbdkit's parallel thread model) never races the first
+	// through LoadState/OpenWAL/persistStateLocal — the vector that tears
+	// config.json and corrupts WAL headers. Non-blocking: a losing opener
+	// fails fast with a clear error instead of queuing.
+	lock, err := viperblock.AcquireVolumeLock(base_dir, volume)
+	if err != nil {
+		return &ViperBlockConnection{}, nbdkit.PluginError{Errmsg: fmt.Sprintf("Could not open volume %q: %v", volume, err)}
+	}
+	volumeLock = lock
+
+	// Release the lock on every early return below — those are failed Open
+	// attempts, and the caller (nbdkit, retried by the client) must not be
+	// wedged behind a half-finished Open. success is only set true once the
+	// connection is fully constructed and handed back, at which point the
+	// lock's lifetime transfers to Close/Unload.
+	success := false
+	defer func() {
+		if success {
+			return
+		}
+		if relErr := viperblock.ReleaseVolumeLock(volumeLock); relErr != nil {
+			slog.Error("Open: failed to release volume lock after error", "err", relErr)
+		}
+		volumeLock = nil
+	}()
+
 	cfg := s3.S3Config{
 		VolumeName: volume,
 		VolumeSize: size,
@@ -364,6 +399,7 @@ func (p *ViperBlockPlugin) Open(readonly bool) (nbdkit.ConnectionInterface, erro
 
 	activeVB = vb
 	snapshotListenerDone = startSnapshotListener(vb, filepath.Join(base_dir, volume, "snapshot.sock"))
+	success = true
 	return &ViperBlockConnection{vb: vb}, nil
 }
 
@@ -557,6 +593,14 @@ func (c *ViperBlockConnection) Close() {
 		slog.Error("Close: could not write seal receipt", "err", err)
 	}
 	activeVB = nil
+
+	// Release the volume lock last, after the VB is fully drained and
+	// closed, so a racing opener that was refused admission cannot start
+	// until this connection has genuinely finished with the volume.
+	if err := viperblock.ReleaseVolumeLock(volumeLock); err != nil {
+		slog.Error("Close: failed to release volume lock", "err", err)
+	}
+	volumeLock = nil
 }
 
 // Unload is called by nbdkit immediately before the process exits. It flushes
@@ -575,6 +619,15 @@ func (p *ViperBlockPlugin) Unload() {
 	}()
 
 	if activeVB == nil {
+		// Close may have already run (lock already released), or Open may
+		// have failed after acquiring the lock but before its own defer ran
+		// (process exiting mid-Open). Release defensively either way so
+		// Unload never leaves a lock behind — ReleaseVolumeLock(nil) is a
+		// no-op if there is nothing to release.
+		if err := viperblock.ReleaseVolumeLock(volumeLock); err != nil {
+			slog.Error("Unload: failed to release volume lock", "err", err)
+		}
+		volumeLock = nil
 		return
 	}
 	slog.Info("Unload: Close was not called, flushing block state now")
@@ -594,6 +647,10 @@ func (p *ViperBlockPlugin) Unload() {
 		slog.Error("Unload: could not write seal receipt", "err", err)
 	}
 	activeVB = nil
+	if err := viperblock.ReleaseVolumeLock(volumeLock); err != nil {
+		slog.Error("Unload: failed to release volume lock", "err", err)
+	}
+	volumeLock = nil
 }
 
 //----------------------------------------------------------------------

--- a/viperblock/concurrent_nbd_open_test.go
+++ b/viperblock/concurrent_nbd_open_test.go
@@ -1,0 +1,227 @@
+// Repro + regression coverage for mulga-w1iu8: concurrent raw NBD connections
+// against the SAME nbdkit socket race independent viperblock.New()/
+// LoadState()/EnsureVolumeUUID() sequences.
+//
+// nbdkit's Go plugin wrapper defaults every plugin to
+// NBDKIT_THREAD_MODEL_PARALLEL (nbd/libguestfs.org/nbdkit/nbdkit.go:535) and
+// the viperblock plugin (nbd/viperblock.go) never overrides ThreadModel().
+// CanMultiConn() returning false only affects the cache-coherency flag nbdkit
+// reports to the NBD client -- it does NOT admission-control connections.
+// So N simultaneous client connections (e.g. concurrent qemu-io processes,
+// exactly the bead's repro steps) drove N concurrent calls to
+// ViperBlockPlugin.Open(), each constructing an independent *viperblock.VB
+// against the identical BaseDir + volume name, with no shared lock, lease, or
+// exclusivity between them.
+//
+// Three defects combined to produce the corruption:
+//  1. writeFileAtomic (viperblock.go) used a FIXED "path.tmp" scratch name,
+//     so racing persistStateLocal calls tore each other's config.json.
+//  2. openWALLocked appended a fresh WAL header on every open, even to a
+//     WAL another racer had already header-stamped, desyncing the record
+//     stream (see wal_double_open_test.go for the isolated regression).
+//  3. Nothing enforced single-writer admission: two independently
+//     constructed *VB values could run New -> LoadState -> ... -> OpenWAL
+//     concurrently with no shared lock between them.
+//
+// Fixing 1 and 2 alone is not sufficient: two live writers still race
+// last-writer-wins renames of VBState, so residual live AEAD failures
+// persisted (~15% of rounds, measured while validating this fix, down from
+// the original ~5.8%-and-climbing-with-conn-count baseline). Only adding the
+// admission-control lock (AcquireVolumeLock/ReleaseVolumeLock, the same
+// primitive nbd/viperblock.go's ViperBlockPlugin.Open/Close now wrap around
+// the New()..OpenWAL() sequence) eliminates the race outright, which is why
+// this test wraps every simulated "NBD connection" attempt with the same
+// lock nbdkit's Open() takes. See volumelock_test.go for the lock primitive
+// tested in isolation, and encryption_test.go's
+// TestWriteFileAtomic_ConcurrentWritersNeverTear for defect 1 in isolation.
+package viperblock
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/mulgadc/viperblock/types"
+	"github.com/mulgadc/viperblock/viperblock/backends/file"
+)
+
+// nbdOpenRound seeds one fresh volume (mirroring CreateVolume's New+Init+
+// SaveState) then fires numConns concurrent "NBD connection" Opens at it,
+// each gated by AcquireVolumeLock exactly as nbd/viperblock.go's Open() now
+// gates the real sequence. Returns how many connections were admitted, how
+// many were cleanly refused admission (ErrVolumeLocked), and how many
+// observed ErrIntegrity directly, plus whether the subsequent cold reopen
+// (the bead's "reopen shortly after" step) still authenticates.
+func nbdOpenRound(t *testing.T, volName string, numConns int) (admitted, refused, integrityErrs int, coldErr error) {
+	t.Helper()
+	dir := t.TempDir()
+	key := testKey(t, 0x42)
+	const volSize = 4 * 1024 * 1024
+
+	seedCfg := file.FileConfig{BaseDir: dir, VolumeName: volName}
+	seedVB, err := New(&VB{
+		VolumeName:        volName,
+		VolumeSize:        volSize,
+		BaseDir:           dir,
+		MasterKey:         key,
+		EncryptionEnabled: true,
+	}, "file", seedCfg)
+	if err != nil {
+		t.Fatalf("seed New: %v", err)
+	}
+	if err := seedVB.Backend.Init(); err != nil {
+		t.Fatalf("seed Backend.Init: %v", err)
+	}
+	if err := seedVB.SaveState(); err != nil {
+		t.Fatalf("seed SaveState: %v", err)
+	}
+	seedVB.StopChunkUploader()
+	seedVB.StopWALSyncer()
+
+	var wg sync.WaitGroup
+	errs := make([]error, numConns)
+	admittedFlags := make([]bool, numConns)
+
+	for i := range numConns {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+
+			// The admission-control gate every real NBD connection now goes
+			// through in ViperBlockPlugin.Open() before New() runs.
+			lock, lockErr := AcquireVolumeLock(dir, volName)
+			if lockErr != nil {
+				if errors.Is(lockErr, ErrVolumeLocked) {
+					return // cleanly refused admission -- expected outcome
+				}
+				errs[idx] = fmt.Errorf("AcquireVolumeLock: %w", lockErr)
+				return
+			}
+			admittedFlags[idx] = true
+			defer func() { _ = ReleaseVolumeLock(lock) }()
+
+			cfg := file.FileConfig{BaseDir: dir, VolumeName: volName}
+			vbcfg := VB{
+				VolumeName:        volName,
+				VolumeSize:        volSize,
+				BaseDir:           dir,
+				MasterKey:         key,
+				EncryptionEnabled: true,
+				Role:              "nbdkit",
+			}
+			vb, err := New(&vbcfg, "file", cfg)
+			if err != nil {
+				errs[idx] = fmt.Errorf("New: %w", err)
+				return
+			}
+			if err := vb.Backend.Init(); err != nil {
+				errs[idx] = fmt.Errorf("Backend.Init: %w", err)
+				return
+			}
+			if err := vb.LoadState(); err != nil {
+				errs[idx] = fmt.Errorf("LoadState: %w", err)
+				return
+			}
+			if err := vb.EnsureVolumeUUID(); err != nil {
+				errs[idx] = fmt.Errorf("EnsureVolumeUUID: %w", err)
+				return
+			}
+			if err := vb.LoadLiveCheckpoint(); err != nil {
+				errs[idx] = fmt.Errorf("LoadLiveCheckpoint: %w", err)
+				return
+			}
+			if err := vb.RecoverLocalWALs(); err != nil {
+				errs[idx] = fmt.Errorf("RecoverLocalWALs: %w", err)
+				return
+			}
+			walNum := vb.WAL.WallNum.Add(1)
+			if err := vb.OpenWAL(&vb.WAL, fmt.Sprintf("%s/%s", vb.WAL.BaseDir,
+				types.GetFilePath(types.FileTypeWALChunk, walNum, vb.GetVolume()))); err != nil {
+				errs[idx] = fmt.Errorf("OpenWAL: %w", err)
+				return
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		if admittedFlags[i] {
+			admitted++
+		} else if err == nil {
+			refused++
+		}
+		if err != nil && errors.Is(err, ErrIntegrity) {
+			integrityErrs++
+			t.Logf("round %s connection %d: %v", volName, i, err)
+		}
+	}
+
+	cfg := file.FileConfig{BaseDir: dir, VolumeName: volName}
+	cold, err := New(&VB{
+		VolumeName:        volName,
+		VolumeSize:        volSize,
+		BaseDir:           dir,
+		MasterKey:         key,
+		EncryptionEnabled: true,
+	}, "file", cfg)
+	if err != nil {
+		t.Fatalf("cold New: %v", err)
+	}
+	if err := cold.Backend.Init(); err != nil {
+		t.Fatalf("cold Backend.Init: %v", err)
+	}
+	coldErr = cold.LoadState()
+	return admitted, refused, integrityErrs, coldErr
+}
+
+// TestConcurrentNBDConnections_RaceOpenSaveState runs many independent rounds
+// (fresh volume each time) of numConns concurrent NBD-style opens and
+// asserts the fixed sequence -- New..OpenWAL gated by AcquireVolumeLock,
+// mirroring the real ViperBlockPlugin.Open()/Close() -- never produces an
+// observable AEAD/integrity failure, live or on a subsequent cold reopen
+// (the bead's literal repro: "Reopen the volume shortly after").
+func TestConcurrentNBDConnections_RaceOpenSaveState(t *testing.T) {
+	const rounds = 40
+	const numConns = 8
+
+	roundsWithLiveIntegrityErr := 0
+	roundsWithColdIntegrityErr := 0
+	totalIntegrityErrs := 0
+	totalAdmitted := 0
+	totalRefused := 0
+
+	for r := range rounds {
+		volName := fmt.Sprintf("vol-concurrent-nbd-%d", r)
+		admitted, refused, integrityErrs, coldErr := nbdOpenRound(t, volName, numConns)
+		totalAdmitted += admitted
+		totalRefused += refused
+		if admitted+refused != numConns {
+			t.Fatalf("round %s: %d admitted + %d refused != %d connections -- some connection neither succeeded nor was cleanly refused",
+				volName, admitted, refused, numConns)
+		}
+		if admitted == 0 {
+			t.Fatalf("round %s: no connection was ever admitted -- the lock wedged every opener", volName)
+		}
+		if integrityErrs > 0 {
+			roundsWithLiveIntegrityErr++
+			totalIntegrityErrs += integrityErrs
+		}
+		if coldErr != nil && errors.Is(coldErr, ErrIntegrity) {
+			roundsWithColdIntegrityErr++
+			t.Logf("round %s: cold reopen failed to authenticate: %v", volName, coldErr)
+		}
+	}
+
+	t.Logf("mulga-w1iu8: %d/%d rounds hit a LIVE AEAD/integrity failure "+
+		"during concurrent open (%d total), %d/%d rounds left a COLD-UNREADABLE "+
+		"config.json behind -- %d connections admitted, %d cleanly refused across %d rounds",
+		roundsWithLiveIntegrityErr, rounds, totalIntegrityErrs,
+		roundsWithColdIntegrityErr, rounds, totalAdmitted, totalRefused, rounds)
+
+	if roundsWithLiveIntegrityErr > 0 || roundsWithColdIntegrityErr > 0 {
+		t.Fatalf("mulga-w1iu8 REGRESSED: concurrent NBD-style opens against one volume "+
+			"produced an AEAD/integrity failure in %d/%d rounds (live) and %d/%d rounds "+
+			"(cold reopen)", roundsWithLiveIntegrityErr, rounds, roundsWithColdIntegrityErr, rounds)
+	}
+}

--- a/viperblock/encryption_test.go
+++ b/viperblock/encryption_test.go
@@ -6,10 +6,10 @@
 package viperblock
 
 import (
+	"bytes"
 	"context"
 	"os"
 	"path/filepath"
-	"strings"
 	"sync"
 	"testing"
 
@@ -122,8 +122,66 @@ func TestWriteFileAtomic_RoundTrip(t *testing.T) {
 	got, err = os.ReadFile(path)
 	require.NoError(t, err)
 	assert.Equal(t, updated, got)
-	_, err = os.Stat(path + ".tmp")
-	assert.ErrorIs(t, err, os.ErrNotExist, "tmp file should not remain after rename")
+
+	// The tmp name is randomized per call (os.CreateTemp), so glob for any
+	// leftover sibling rather than a fixed "path.tmp" suffix.
+	leftovers, err := filepath.Glob(path + ".tmp-*")
+	require.NoError(t, err)
+	assert.Empty(t, leftovers, "no tmp file should remain after rename")
+}
+
+// TestWriteFileAtomic_ConcurrentWritersNeverTear is the direct A/B test for
+// mulga-w1iu8 defect 1: many goroutines writing the SAME path concurrently
+// must never produce a torn file. The old fixed "path.tmp" name let one
+// writer's O_TRUNC clobber another's in-flight write and one writer's rename
+// delete another's tmp, publishing a mix of two payloads (or, for an
+// encrypted VBState, a blob that fails AEAD authentication). Each writer's
+// payload here has a distinct length so a torn merge is detectable as a
+// byte-for-byte mismatch against every single payload, not just a length
+// check.
+func TestWriteFileAtomic_ConcurrentWritersNeverTear(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+
+	const writers = 16
+	payloads := make([][]byte, writers)
+	for i := range payloads {
+		payloads[i] = bytes.Repeat([]byte{byte('A' + i)}, 4096+i*37)
+	}
+
+	var wg sync.WaitGroup
+	errs := make([]error, writers)
+	for i := range writers {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			errs[idx] = writeFileAtomic(path, payloads[idx], 0600)
+		}(i)
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		require.NoError(t, err, "writer %d", i)
+	}
+
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	matched := false
+	for _, p := range payloads {
+		if bytes.Equal(got, p) {
+			matched = true
+			break
+		}
+	}
+	assert.True(t, matched,
+		"final file (%d bytes) must exactly match exactly one writer's payload -- a mismatch means the rename published a torn mix of two writers", len(got))
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	for _, e := range entries {
+		assert.NotContains(t, e.Name(), ".tmp-", "no leftover tmp file should remain: %s", e.Name())
+	}
 }
 
 // A remount on a node that never held the volume locally has no per-volume
@@ -294,12 +352,16 @@ func TestReserveSeqNum_FailedSaveStateDoesNotPublishHighWater(t *testing.T) {
 
 	hwBefore := vb.seqNumHighWater.Load()
 
-	// Wedge writeFileAtomic by parking a directory at the tmp path: the next
-	// SaveState's OpenFile(O_CREATE|O_WRONLY) fails with EISDIR. Removing the
-	// per-volume dir no longer wedges since writeFileAtomic recreates it.
+	// Wedge writeFileAtomic by replacing the per-volume dir with a plain
+	// file: writeFileAtomic's os.MkdirAll(dir, ...) fails with ENOTDIR
+	// before it ever reaches os.CreateTemp (whose name is now randomized per
+	// call, so it can no longer be pre-occupied by path). This is a
+	// filesystem type mismatch, not a permission check, so it wedges
+	// regardless of the test's uid. Removing the per-volume dir no longer
+	// wedges since writeFileAtomic recreates it.
 	configDir := filepath.Join(vb.BaseDir, vb.GetVolume())
-	tmpPath := filepath.Join(configDir, "config.json.tmp")
-	require.NoError(t, os.MkdirAll(tmpPath, 0700))
+	require.NoError(t, os.RemoveAll(configDir))
+	require.NoError(t, os.WriteFile(configDir, []byte("blocking"), 0600))
 
 	vb.SeqNum.Store(hwBefore + 5)
 	_, err := vb.reserveSeqNum(context.Background(), 1)
@@ -310,7 +372,7 @@ func TestReserveSeqNum_FailedSaveStateDoesNotPublishHighWater(t *testing.T) {
 
 	// And after the failure is cleared, a successor reservation must persist
 	// and publish the same target hw — no skipped window, no double-count.
-	require.NoError(t, os.RemoveAll(tmpPath))
+	require.NoError(t, os.RemoveAll(configDir))
 	_, err = vb.reserveSeqNum(context.Background(), 1)
 	require.NoError(t, err)
 	assert.Greater(t, vb.seqNumHighWater.Load(), hwBefore,
@@ -333,7 +395,10 @@ func TestSaveState_AtomicRenameLeavesNoTmp(t *testing.T) {
 		if e.IsDir() {
 			continue
 		}
-		assert.False(t, strings.HasSuffix(e.Name(), ".tmp"), "no .tmp should remain: %s", e.Name())
+		// The tmp name is now "config.json.tmp-<random>", so a trailing
+		// HasSuffix(".tmp") check would silently stop catching leftovers —
+		// match on the ".tmp-" infix the randomized suffix always follows.
+		assert.NotContains(t, e.Name(), ".tmp-", "no .tmp-* should remain: %s", e.Name())
 		if e.Name() == "config.json" {
 			sawConfig = true
 		}

--- a/viperblock/viperblock.go
+++ b/viperblock/viperblock.go
@@ -912,6 +912,12 @@ var ErrPreEncryptionFormat = errors.New("viperblock: chunk has pre-encryption fo
 // (it validates the header once, at offset 0, then reads fixed-size records).
 var ErrWALAlreadyOpen = errors.New("viperblock: WAL file already has content, refusing to append a second header")
 
+// ErrWALHeaderShort is returned by readWALFileForRecovery when a WAL file is
+// smaller than the header, e.g. a crash between create and header flush. It
+// holds no recoverable records, so RecoverLocalWALs deletes it on sight
+// rather than keeping it for retry.
+var ErrWALHeaderShort = errors.New("viperblock: WAL file too short to contain a header")
+
 // classifyStateLoad maps the local and backend LoadStateRequest errors into a
 // sentinel suitable for callers. The local read is informational — its
 // absence is normal on multi-node deployments and post-restart recovery. The
@@ -1589,19 +1595,9 @@ func (vb *VB) openWALLocked(wal *WAL, filename string) (err error) {
 		return fmt.Errorf("failed to open WAL file: %w", err)
 	}
 
-	// The chunk WAL (vb.WAL) is the only WAL type that both rotates to a
-	// fresh walNum on every boot (RecoverLocalWALs drains/removes prior
-	// generations, then the caller increments WallNum before opening) and is
-	// actually replayed record-by-record by readWALFileForRecovery, which
-	// validates the header once at offset 0 and desyncs on anything appended
-	// after it. A non-empty file at a freshly rotated walNum means another
-	// writer already created and header-stamped it -- refuse rather than
-	// append a second header into the middle of its records.
-	//
-	// BlockToObjectWAL is intentionally excluded: its walNum is never
-	// rotated across reopens (every boot reopens walNum unchanged), so a
-	// prior header is expected, not a collision, and nothing replays this
-	// file's records (RecoverLocalWALs only scans the chunk-WAL directory).
+	// Chunk WAL: a non-empty file at a freshly rotated walNum means another
+	// writer already header-stamped it; refuse instead of corrupting it.
+	// BlockToObjectWAL never rotates, so a prior header there is expected.
 	if wal.WALMagic == vb.WAL.WALMagic {
 		info, statErr := file.Stat()
 		if statErr != nil {
@@ -4282,6 +4278,12 @@ func (vb *VB) readWALFileForRecovery(filename string) ([]Block, uint64, error) {
 	headerSize := vb.WALHeaderSize()
 	header := make([]byte, headerSize)
 	if _, err := io.ReadFull(f, header); err != nil {
+		// Confirm via Stat rather than trusting io.EOF/ErrUnexpectedEOF alone,
+		// so a transient read error on a full-length file still falls through
+		// to the generic (keep-for-retry) path below instead of being deleted.
+		if info, statErr := f.Stat(); statErr == nil && info.Size() < int64(headerSize) {
+			return nil, 0, fmt.Errorf("%w: %s: %w", ErrWALHeaderShort, filename, err)
+		}
 		return nil, 0, fmt.Errorf("failed to read WAL header: %w", err)
 	}
 
@@ -4448,6 +4450,16 @@ func (vb *VB) RecoverLocalWALs() (err error) {
 			// the volume up; the file stays on disk for forensics + retry.
 			if errors.Is(err, ErrIntegrity) {
 				return fmt.Errorf("WAL recovery: integrity failure in %s: %w", fname, err)
+			}
+			// A short-header stub (torn create) holds no recoverable
+			// records by definition. Deleting it here is what stops it
+			// wedging OpenWAL's refuse-a-nonempty-file guard forever.
+			if errors.Is(err, ErrWALHeaderShort) {
+				vb.logger().Warn("WAL recovery: removing short-header stub WAL file", "file", fname, "error", err)
+				if rmErr := os.Remove(fullPath); rmErr != nil {
+					vb.logger().Warn("WAL recovery: failed to remove short-header WAL file", "file", fname, "error", rmErr)
+				}
+				continue
 			}
 			vb.logger().Error("WAL recovery: failed to read WAL file, keeping for retry", "file", fname, "error", err)
 			continue

--- a/viperblock/viperblock.go
+++ b/viperblock/viperblock.go
@@ -903,6 +903,15 @@ var ErrIntegrity = errors.New("viperblock: integrity check failed")
 // (dd, filesystem-level copy). Callers must refuse to open the volume.
 var ErrPreEncryptionFormat = errors.New("viperblock: chunk has pre-encryption format (VBCH) but volume opened with EncryptionEnabled=true; create a new encrypted volume and copy data across via guest-side tooling")
 
+// ErrWALAlreadyOpen is returned by OpenWAL when the target WAL file already
+// has content. Every normal caller (boot, rotation) targets a walNum that
+// RecoverLocalWALs has just drained/removed or that was freshly incremented,
+// so a non-empty file here means another writer already opened it — most
+// likely a second concurrent VB instance racing the same volume. Appending a
+// second header would land mid-stream, which the WAL reader cannot parse
+// (it validates the header once, at offset 0, then reads fixed-size records).
+var ErrWALAlreadyOpen = errors.New("viperblock: WAL file already has content, refusing to append a second header")
+
 // classifyStateLoad maps the local and backend LoadStateRequest errors into a
 // sentinel suitable for callers. The local read is informational — its
 // absence is normal on multi-node deployments and post-restart recovery. The
@@ -1578,6 +1587,31 @@ func (vb *VB) openWALLocked(wal *WAL, filename string) (err error) {
 	file, err := os.OpenFile(filename, os.O_CREATE|os.O_APPEND|os.O_RDWR, 0600)
 	if err != nil {
 		return fmt.Errorf("failed to open WAL file: %w", err)
+	}
+
+	// The chunk WAL (vb.WAL) is the only WAL type that both rotates to a
+	// fresh walNum on every boot (RecoverLocalWALs drains/removes prior
+	// generations, then the caller increments WallNum before opening) and is
+	// actually replayed record-by-record by readWALFileForRecovery, which
+	// validates the header once at offset 0 and desyncs on anything appended
+	// after it. A non-empty file at a freshly rotated walNum means another
+	// writer already created and header-stamped it -- refuse rather than
+	// append a second header into the middle of its records.
+	//
+	// BlockToObjectWAL is intentionally excluded: its walNum is never
+	// rotated across reopens (every boot reopens walNum unchanged), so a
+	// prior header is expected, not a collision, and nothing replays this
+	// file's records (RecoverLocalWALs only scans the chunk-WAL directory).
+	if wal.WALMagic == vb.WAL.WALMagic {
+		info, statErr := file.Stat()
+		if statErr != nil {
+			_ = file.Close()
+			return fmt.Errorf("failed to stat WAL file: %w", statErr)
+		}
+		if info.Size() > 0 {
+			_ = file.Close()
+			return fmt.Errorf("%w: %s has %d existing bytes", ErrWALAlreadyOpen, filename, info.Size())
+		}
 	}
 
 	// Append the WAL header, format
@@ -4849,19 +4883,34 @@ func (vb *VB) pushStateToBackend(ctx context.Context, persisted []byte) error {
 // writeFileAtomic writes data to path atomically via tmp + fsync + rename +
 // fsync(parent). On return without error, the file exists at path with the
 // new contents fully durable on disk. A crash before return may leave a
-// stale path.tmp behind (caller-tolerable: next SaveState rewrites it).
+// stale *.tmp-* file behind (caller-tolerable: next SaveState rewrites path;
+// stale tmp siblings are otherwise inert).
 //
 // The parent dir is created if absent so a remount on a node that never held
 // the volume locally (LoadState pulls authoritative state from the backend,
 // then persists it locally) does not fail opening the tmp file with ENOENT.
+//
+// The tmp name is unique per call (os.CreateTemp, O_EXCL under the hood) so
+// two concurrent writers of the same path -- e.g. independently-constructed
+// *VB instances racing persistStateLocal for the same volume -- never share
+// an inode. A fixed "path.tmp" name let one writer's O_TRUNC clobber the
+// other's in-flight write, and one writer's rename delete the other's tmp,
+// producing a torn file that fails AEAD authentication on the next load.
 func writeFileAtomic(path string, data []byte, perm os.FileMode) error {
 	dir := filepath.Dir(path)
 	if err := os.MkdirAll(dir, 0750); err != nil {
 		return err
 	}
-	tmp := path + ".tmp"
-	f, err := os.OpenFile(tmp, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, perm)
+	base := filepath.Base(path)
+	f, err := os.CreateTemp(dir, base+".tmp-*")
 	if err != nil {
+		return err
+	}
+	tmp := f.Name()
+	// os.CreateTemp always creates with 0600; the caller's perm may differ.
+	if err := f.Chmod(perm); err != nil {
+		_ = f.Close()
+		_ = os.Remove(tmp)
 		return err
 	}
 	if _, err := f.Write(data); err != nil {

--- a/viperblock/volumelock.go
+++ b/viperblock/volumelock.go
@@ -18,26 +18,16 @@ var ErrVolumeLocked = errors.New("viperblock: volume is locked by another opener
 const volumeLockFileName = ".viperblock.lock"
 
 // AcquireVolumeLock takes an exclusive, non-blocking flock on a per-volume
-// lock file under baseDir/volume, so at most one caller at a time can
-// proceed through the New -> LoadState -> ... -> OpenWAL sequence for a
-// given volume. This is defence-in-depth at the storage layer: it does not
-// replace control-plane single-owner-per-volume enforcement, it stops a
-// second local opener from tearing WAL/state files underneath the first.
+// lock file, admitting only one caller through New..OpenWAL at a time. This
+// is storage-layer defence-in-depth, not control-plane ownership.
 //
-// flock is per-open-file-description, so two separate callers in the SAME
-// process (nbdkit's parallel thread model admitting concurrent connections)
-// contend for the lock exactly like two different processes would — this is
-// the proven repro vector for mulga-w1iu8. The kernel drops the lock
-// automatically when every file descriptor referencing this open file
-// description closes, including on process death, so a crashed holder can
-// never leave a stale lock that wedges the next attach. That property is why
-// flock is used here instead of a PID lockfile, which needs its own
-// (fallible) staleness-detection logic.
+// flock is per-open-file-description, so same-process callers (nbdkit's
+// parallel thread model) contend like separate processes would. The kernel
+// drops it on last-fd-close or process death, so crashes can't wedge the
+// lock -- unlike a PID lockfile, which needs its own staleness detection.
 //
-// Returns the open, locked *os.File; the caller must keep it open for the
-// lifetime of the volume and release it via ReleaseVolumeLock. Does not
-// block: a lock already held by another opener fails fast with
-// ErrVolumeLocked rather than queuing.
+// Returns the open, locked file; caller releases it via ReleaseVolumeLock.
+// Non-blocking: a lock already held fails fast with ErrVolumeLocked.
 func AcquireVolumeLock(baseDir, volume string) (*os.File, error) {
 	dir := filepath.Join(baseDir, volume)
 	if err := os.MkdirAll(dir, 0750); err != nil {

--- a/viperblock/volumelock.go
+++ b/viperblock/volumelock.go
@@ -1,0 +1,81 @@
+package viperblock
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+// ErrVolumeLocked is returned by AcquireVolumeLock when another opener
+// already holds the volume's exclusive lock.
+var ErrVolumeLocked = errors.New("viperblock: volume is locked by another opener")
+
+// volumeLockFileName is a fixed sibling of config.json under the volume's
+// local directory. Its only purpose is to be flock'd; contents are never
+// read or written.
+const volumeLockFileName = ".viperblock.lock"
+
+// AcquireVolumeLock takes an exclusive, non-blocking flock on a per-volume
+// lock file under baseDir/volume, so at most one caller at a time can
+// proceed through the New -> LoadState -> ... -> OpenWAL sequence for a
+// given volume. This is defence-in-depth at the storage layer: it does not
+// replace control-plane single-owner-per-volume enforcement, it stops a
+// second local opener from tearing WAL/state files underneath the first.
+//
+// flock is per-open-file-description, so two separate callers in the SAME
+// process (nbdkit's parallel thread model admitting concurrent connections)
+// contend for the lock exactly like two different processes would — this is
+// the proven repro vector for mulga-w1iu8. The kernel drops the lock
+// automatically when every file descriptor referencing this open file
+// description closes, including on process death, so a crashed holder can
+// never leave a stale lock that wedges the next attach. That property is why
+// flock is used here instead of a PID lockfile, which needs its own
+// (fallible) staleness-detection logic.
+//
+// Returns the open, locked *os.File; the caller must keep it open for the
+// lifetime of the volume and release it via ReleaseVolumeLock. Does not
+// block: a lock already held by another opener fails fast with
+// ErrVolumeLocked rather than queuing.
+func AcquireVolumeLock(baseDir, volume string) (*os.File, error) {
+	dir := filepath.Join(baseDir, volume)
+	if err := os.MkdirAll(dir, 0750); err != nil {
+		return nil, fmt.Errorf("AcquireVolumeLock: create volume dir %s: %w", dir, err)
+	}
+
+	path := filepath.Join(dir, volumeLockFileName)
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0600)
+	if err != nil {
+		return nil, fmt.Errorf("AcquireVolumeLock: open %s: %w", path, err)
+	}
+
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		_ = f.Close()
+		if errors.Is(err, syscall.EWOULDBLOCK) {
+			return nil, fmt.Errorf("%w: volume %q, lock file %s", ErrVolumeLocked, volume, path)
+		}
+		return nil, fmt.Errorf("AcquireVolumeLock: flock %s: %w", path, err)
+	}
+
+	return f, nil
+}
+
+// ReleaseVolumeLock unlocks and closes a lock file returned by
+// AcquireVolumeLock. Safe to call with nil, so callers can defer it
+// unconditionally on every return path, including ones where the lock was
+// never acquired.
+func ReleaseVolumeLock(f *os.File) error {
+	if f == nil {
+		return nil
+	}
+	unlockErr := syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+	closeErr := f.Close()
+	if unlockErr != nil {
+		return fmt.Errorf("ReleaseVolumeLock: unlock: %w", unlockErr)
+	}
+	if closeErr != nil {
+		return fmt.Errorf("ReleaseVolumeLock: close: %w", closeErr)
+	}
+	return nil
+}

--- a/viperblock/volumelock_test.go
+++ b/viperblock/volumelock_test.go
@@ -1,0 +1,125 @@
+package viperblock
+
+import (
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAcquireVolumeLock_SecondCallerFails is the core admission-control
+// contract for mulga-w1iu8: a second concurrent opener of the SAME volume
+// must fail fast with ErrVolumeLocked, not block or silently proceed.
+func TestAcquireVolumeLock_SecondCallerFails(t *testing.T) {
+	dir := t.TempDir()
+
+	first, err := AcquireVolumeLock(dir, "vol-1")
+	require.NoError(t, err)
+	defer func() { _ = ReleaseVolumeLock(first) }()
+
+	_, err = AcquireVolumeLock(dir, "vol-1")
+	require.Error(t, err, "a second opener must not be admitted while the first holds the lock")
+	assert.ErrorIs(t, err, ErrVolumeLocked, "error must wrap ErrVolumeLocked, got: %v", err)
+}
+
+// TestAcquireVolumeLock_ReleaseThenReacquire models a legitimate reattach:
+// stop, terminate, or a spinifex service restart that closes the volume and
+// reopens it. The lock must never wedge a clean reopen.
+func TestAcquireVolumeLock_ReleaseThenReacquire(t *testing.T) {
+	dir := t.TempDir()
+
+	first, err := AcquireVolumeLock(dir, "vol-1")
+	require.NoError(t, err)
+	require.NoError(t, ReleaseVolumeLock(first))
+
+	second, err := AcquireVolumeLock(dir, "vol-1")
+	require.NoError(t, err, "reopen after a clean release must succeed")
+	require.NoError(t, ReleaseVolumeLock(second))
+}
+
+// TestAcquireVolumeLock_CrashedHolderDoesNotWedge models the kernel dropping
+// the lock when a holder dies without an orderly Close/Unload — e.g. a
+// killed viperblockd. Closing the *os.File without an explicit unlock is
+// what a process death looks like from the OS's perspective: the open file
+// description goes away and flock releases it automatically. A PID-lockfile
+// scheme would need extra staleness-detection logic to reach the same
+// outcome; flock gets it for free, which is why the fix uses flock.
+func TestAcquireVolumeLock_CrashedHolderDoesNotWedge(t *testing.T) {
+	dir := t.TempDir()
+
+	first, err := AcquireVolumeLock(dir, "vol-1")
+	require.NoError(t, err)
+	// Simulate a crash: close the fd directly, skipping ReleaseVolumeLock's
+	// explicit LOCK_UN. The kernel must still drop the lock on close.
+	require.NoError(t, first.Close())
+
+	second, err := AcquireVolumeLock(dir, "vol-1")
+	require.NoError(t, err, "a lock held by a now-dead file descriptor must not wedge the next opener")
+	require.NoError(t, ReleaseVolumeLock(second))
+}
+
+// TestAcquireVolumeLock_DifferentVolumesIndependent pins that the lock is
+// scoped per-volume, not per-baseDir: two different volumes under the same
+// BaseDir must be independently lockable.
+func TestAcquireVolumeLock_DifferentVolumesIndependent(t *testing.T) {
+	dir := t.TempDir()
+
+	a, err := AcquireVolumeLock(dir, "vol-a")
+	require.NoError(t, err)
+	defer func() { _ = ReleaseVolumeLock(a) }()
+
+	b, err := AcquireVolumeLock(dir, "vol-b")
+	require.NoError(t, err, "a different volume under the same BaseDir must not be blocked")
+	require.NoError(t, ReleaseVolumeLock(b))
+}
+
+// TestAcquireVolumeLock_ConcurrentRace fires many concurrent acquire
+// attempts at one volume and asserts exactly one wins at a time — the direct
+// analogue of nbdkit's parallel thread model admitting concurrent Open()
+// calls for the same volume.
+func TestAcquireVolumeLock_ConcurrentRace(t *testing.T) {
+	dir := t.TempDir()
+	const attempts = 16
+
+	results := make(chan *os.File, attempts)
+	errs := make(chan error, attempts)
+	for range attempts {
+		go func() {
+			f, err := AcquireVolumeLock(dir, "vol-race")
+			results <- f
+			errs <- err
+		}()
+	}
+
+	var winners int
+	var busyErrs int
+	for range attempts {
+		f := <-results
+		err := <-errs
+		switch {
+		case err == nil:
+			winners++
+			require.NoError(t, ReleaseVolumeLock(f))
+		case errors.Is(err, ErrVolumeLocked):
+			busyErrs++
+		default:
+			t.Fatalf("unexpected error: %v", err)
+		}
+	}
+
+	// Attempts are not synchronized to fire simultaneously, so more than one
+	// may win sequentially as earlier winners release before later attempts
+	// run — the invariant is that every attempt either won cleanly or got
+	// ErrVolumeLocked, never anything else, and never silently double-opened.
+	assert.Equal(t, attempts, winners+busyErrs)
+	assert.Positive(t, winners, "at least one attempt must have won the lock")
+}
+
+// TestReleaseVolumeLock_NilIsNoOp lets every call site defer
+// ReleaseVolumeLock unconditionally, including paths where AcquireVolumeLock
+// itself failed and never produced a file.
+func TestReleaseVolumeLock_NilIsNoOp(t *testing.T) {
+	assert.NoError(t, ReleaseVolumeLock(nil))
+}

--- a/viperblock/wal_double_open_test.go
+++ b/viperblock/wal_double_open_test.go
@@ -1,0 +1,100 @@
+// Dedicated regression coverage for mulga-w1iu8 defect 2: openWALLocked used
+// to unconditionally append a fresh WAL header on every open, even to an
+// existing populated WAL. readWALFileForRecovery only validates the header
+// once, at offset 0, then reads fixed-size records for the rest of the
+// file -- a second header landing mid-stream desyncs every record after it.
+// This is the same concurrent-open vector as defect 1 (two independently
+// constructed *VB instances computing the same walNum and racing OpenWAL on
+// one file), isolated here from the flock fix so it is provable on its own.
+package viperblock
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mulgadc/viperblock/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestOpenWAL_RefusesReopenOfNonEmptyFile is the direct A/B test for defect
+// 2: a second OpenWAL against a file that already has header+content must
+// be refused with ErrWALAlreadyOpen and must not touch the file, rather than
+// silently appending a second header into the middle of the record stream.
+func TestOpenWAL_RefusesReopenOfNonEmptyFile(t *testing.T) {
+	key := testKey(t, 0x42)
+	vb := newFileBackedVB(t, "vol-wal-guard", key)
+	vb.BlockSize = DefaultBlockSize
+	require.NoError(t, vb.EnsureVolumeUUID())
+
+	walPath := filepath.Join(vb.BaseDir, types.GetFilePath(types.FileTypeWALChunk, 1, vb.GetVolume()))
+
+	require.NoError(t, vb.OpenWAL(&vb.WAL, walPath))
+	info, err := os.Stat(walPath)
+	require.NoError(t, err)
+	headerSize := info.Size()
+	assert.Equal(t, int64(vb.WALHeaderSize()), headerSize, "first open must write exactly one header")
+
+	// A second opener targeting the SAME file -- modelling the concurrent
+	// double-open race -- must be refused outright.
+	second := &WAL{WALMagic: vb.WAL.WALMagic, BaseDir: vb.WAL.BaseDir}
+	err = vb.OpenWAL(second, walPath)
+	require.Error(t, err, "a second open of an already header-stamped WAL must fail")
+	assert.ErrorIs(t, err, ErrWALAlreadyOpen)
+
+	// The refused second open must be a pure read: file untouched.
+	info2, statErr := os.Stat(walPath)
+	require.NoError(t, statErr)
+	assert.Equal(t, headerSize, info2.Size(),
+		"refused second open must not append or truncate the existing WAL")
+}
+
+// TestOpenWAL_ConcurrentDoubleOpenNeverCorrupts drives two goroutines at the
+// SAME wal filename concurrently (no serialization between them, unlike the
+// flock-gated integration test) and asserts the file is left in exactly one
+// of two safe states: either one opener won and the other was cleanly
+// refused, or (TOCTOU on the empty-file check) both raced through and wrote
+// -- in which case readWALFileForRecovery must still not silently misparse
+// the result into fabricated blocks. It must fail loudly (ErrIntegrity /
+// version-mismatch/etc.) rather than return corrupt-but-plausible data.
+func TestOpenWAL_ConcurrentDoubleOpenNeverCorrupts(t *testing.T) {
+	key := testKey(t, 0x42)
+	vb := newFileBackedVB(t, "vol-wal-race", key)
+	vb.BlockSize = DefaultBlockSize
+	require.NoError(t, vb.EnsureVolumeUUID())
+
+	walPath := filepath.Join(vb.BaseDir, types.GetFilePath(types.FileTypeWALChunk, 1, vb.GetVolume()))
+
+	results := make(chan error, 2)
+	for range 2 {
+		go func() {
+			w := &WAL{WALMagic: vb.WAL.WALMagic, BaseDir: vb.WAL.BaseDir}
+			results <- vb.OpenWAL(w, walPath)
+		}()
+	}
+
+	var oks, refused int
+	for range 2 {
+		if err := <-results; err == nil {
+			oks++
+		} else {
+			refused++
+		}
+	}
+
+	// At least one must have won (created the file); the other either lost
+	// cleanly or (rare TOCTOU) also "won" its own os.CreateTemp/Stat race.
+	// Either way, the file must never end up unparseable-but-silent.
+	assert.GreaterOrEqual(t, oks, 1)
+	t.Logf("concurrent double-open: %d succeeded, %d refused", oks, refused)
+
+	blocks, _, err := vb.readWALFileForRecovery(walPath)
+	if err != nil {
+		// A loud failure (header/version mismatch, integrity error) is the
+		// acceptable failure mode -- never silent corruption.
+		t.Logf("post-race readWALFileForRecovery reported (acceptable, fail-closed): %v", err)
+		return
+	}
+	assert.Empty(t, blocks, "a header-only WAL must recover zero blocks, not fabricated ones")
+}

--- a/viperblock/wal_double_open_test.go
+++ b/viperblock/wal_double_open_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/mulgadc/viperblock/types"
+	"github.com/mulgadc/viperblock/viperblock/backends/file"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -97,4 +98,55 @@ func TestOpenWAL_ConcurrentDoubleOpenNeverCorrupts(t *testing.T) {
 		return
 	}
 	assert.Empty(t, blocks, "a header-only WAL must recover zero blocks, not fabricated ones")
+}
+
+// TestRecoverLocalWALs_RemovesShortHeaderStub covers a different crash point
+// than the double-open tests above: a torn create, where a file shorter than
+// the WAL header exists at the exact walNum the next boot will target (e.g.
+// crash between os.OpenFile and the header write finishing). Such a stub
+// holds no recoverable records, so RecoverLocalWALs must delete it rather
+// than keep it for retry -- keeping it would make openWALLocked's refuse-a-
+// nonempty-file guard trip on every subsequent boot, wedging the volume
+// closed forever instead of merely losing the torn write.
+func TestRecoverLocalWALs_RemovesShortHeaderStub(t *testing.T) {
+	dir := t.TempDir()
+	key := testKey(t, 0x42)
+	const volName = "vol-short-header-stub"
+	const volSize = 4 * 1024 * 1024
+	cfg := file.FileConfig{BaseDir: dir, VolumeName: volName}
+
+	seed, err := New(&VB{
+		VolumeName: volName, VolumeSize: volSize, BaseDir: dir,
+		MasterKey: key, EncryptionEnabled: true,
+	}, "file", cfg)
+	require.NoError(t, err)
+	require.NoError(t, seed.Backend.Init())
+	require.NoError(t, seed.SaveState())
+	seed.StopChunkUploader()
+	seed.StopWALSyncer()
+
+	// A fresh volume's WallNum loads as 0, so the first open after recovery
+	// always targets walNum 1 -- stage the stub at exactly that number.
+	walPath := filepath.Join(dir, types.GetFilePath(types.FileTypeWALChunk, 1, volName))
+	require.NoError(t, os.MkdirAll(filepath.Dir(walPath), 0750))
+	require.NoError(t, os.WriteFile(walPath, []byte{0x01, 0x02, 0x03}, 0600))
+
+	vb, err := New(&VB{
+		VolumeName: volName, VolumeSize: volSize, BaseDir: dir,
+		MasterKey: key, EncryptionEnabled: true, Role: "nbdkit",
+	}, "file", cfg)
+	require.NoError(t, err)
+	require.NoError(t, vb.Backend.Init())
+	require.NoError(t, vb.LoadState())
+	require.NoError(t, vb.EnsureVolumeUUID())
+	require.NoError(t, vb.LoadLiveCheckpoint())
+	require.NoError(t, vb.RecoverLocalWALs())
+
+	_, statErr := os.Stat(walPath)
+	assert.True(t, os.IsNotExist(statErr), "short-header stub must be removed by RecoverLocalWALs")
+
+	walNum := vb.WAL.WallNum.Add(1)
+	require.Equal(t, uint64(1), walNum, "sanity: this open must target the exact walNum the stub was staged at")
+	err = vb.OpenWAL(&vb.WAL, filepath.Join(dir, types.GetFilePath(types.FileTypeWALChunk, walNum, volName)))
+	require.NoError(t, err, "the volume must open cleanly once the stub is cleaned up, not wedge forever")
 }


### PR DESCRIPTION
Closes mulga-w1iu8 (P1).

## Problem

Concurrent opens of one volume tear AEAD-sealed state and WAL headers. The vector is not the daemon-vs-viperblockd double open already characterised in `dualopen_test.go` — it is raw concurrent NBD connections. `ViperBlockPlugin.Open()` runs the full `New` → `LoadState` → `OpenWAL` → `RecoverLocalWALs` sequence on every connection, and nbdkit's Go binding hard-codes the PARALLEL thread model, so N clients build N independent `*VB` inside one process. `CanMultiConn() == false` only advises the client about cache coherency; it does not gate admission.

The existing `saveStateMu` and `WAL.mu` locks are per-instance and in-memory, so they are invisible across two `*VB` values.

## Three defects

1. `writeFileAtomic` shared one `path + ".tmp"` scratch name across all callers, so one writer's `O_TRUNC` clobbered another's in-flight write and one writer's rename deleted the other's tmp. The published file failed AEAD authentication on the next load.
2. `openWALLocked` wrote a fresh header on every open. The chunk WAL filename is state-derived, so two instances opened the same file and injected a header mid-stream, which the reader cannot parse.
3. Nothing enforced single-writer access at all — no flock, no `O_EXCL`, no lease anywhere in the module.

## Changes

- `writeFileAtomic` now uses `os.CreateTemp` for a unique per-call scratch file, with an explicit `Chmod` since `CreateTemp` always creates 0600.
- `openWALLocked` refuses to append a second header to a non-empty chunk WAL. Scoped to `WAL.WALMagic` only: `BlockToObjectWAL` never rotates its walNum, so a prior header there is expected, and nothing replays its records.
- New `AcquireVolumeLock` / `ReleaseVolumeLock` using `flock(LOCK_EX|LOCK_NB)` on a per-volume lock file, acquired in the nbdkit plugin's `Open()` and released in `Close()`/`Unload()`. flock is per open-file-description, so it catches two openers in the same process, and the kernel releases it on process death, so a crashed holder cannot leave a stale lock that wedges the next attach.
- The lock is deliberately not taken inside `viperblock.New()` — that has call sites in the CLI tools and in `dualopen_test.go`, which intentionally constructs two coexisting VBs.

## Follow-up commit, from review

The header guard introduced a way to wedge a volume permanently. `RecoverLocalWALs` only deletes WAL files it read successfully; a header read failure logged "keeping for retry" and left the file. A crash between creating a WAL and flushing its header leaves a stub shorter than the header, state never advances, the next boot targets the same walNum, and the guard then refuses to open it — forever.

`readWALFileForRecovery` now returns `ErrWALHeaderShort` when the file is genuinely shorter than the header, confirmed by `Stat` rather than trusting `io.EOF` alone, and `RecoverLocalWALs` deletes those instead of keeping them. A file long enough for a header but with a magic, version or blocksize mismatch is unaffected and still kept for retry, since that indicates a foreign file rather than a torn create.

## Evidence

Every test A/B proven against the unfixed tree:

| Defect | Without fix | With fix |
|---|---|---|
| `writeFileAtomic` tearing | 10/10 fail | 10/10 pass |
| WAL double header | 5/5 fail | 5/5 pass |
| flock admission | 3/3 fail | 3/3 pass |
| short-header stub wedge | fails with `refusing to append a second header: wal.00000001.bin has 3 existing bytes` | 5/5 pass |

`TestConcurrentNBDConnections_RaceOpenSaveState` passes 20/20 with `-count=1` and clean under `-race`. Before the fix it failed 10/10 invocations, with 23/400 rounds hitting `integrity check failed: VBState envelope: metadata envelope parse: unexpected end of JSON input`.

`make preflight` clean: lint 0 issues, govulncheck 0 reachable vulns, coverage 67.2%, diff coverage 70.5%, race clean.

## Live verification, env13

Plugin built with `GOFIPS140=v1.0.0` and deployed directly. Instance launch with EBS root and EFI, volume create and attach, stop then start, hot detach and reattach while running, and a `spinifex-viperblock` restart with a volume attached — all clean, with the lock released explicitly in `Close()` rather than relying on process exit.

## Scope

Storage-layer defence in depth. Control-plane single-owner-per-volume enforcement is separate work and is not touched here.

## Not verified

The flock crash-auto-release path was not exercised live by killing an nbdkit mid-write; it is covered by `TestAcquireVolumeLock_CrashedHolderDoesNotWedge` in the unit suite only. Permanent volume unopenability, as seen in the two field incidents, was not reproduced on a local file backend — it needs the torn writer's rename to land last, a window that widens considerably over S3 round-trip timing.