### PR TITLE
feat: add gp3 Throughput field to VolumeMetadata

### DIFF
--- a/viperblock/viperblock.go
+++ b/viperblock/viperblock.go
@@ -829,6 +829,7 @@ type VolumeMetadata struct {
 	DeviceName          string            `json:"DeviceName"`          // e.g. "/dev/nbd1"
 	VolumeType          string            `json:"VolumeType"`          // e.g. "gp3", "io1"
 	IOPS                int               `json:"IOPS"`                // For provisioned volumes
+	Throughput          int               `json:"Throughput"`          // gp3 MiB/s (125-1000); zero means unset/pre-field volume
 	Tags                map[string]string `json:"Tags"`                // User-defined metadata
 	SnapshotID          string            `json:"SnapshotID"`          // If created from a snapshot
 	DeleteOnTermination bool              `json:"DeleteOnTermination"` // Whether to delete volume when instance terminates


### PR DESCRIPTION
## Summary
- Adds a `Throughput int` field to `viperblock.VolumeMetadata` (gp3 MiB/s, 125-1000) so spinifex can persist and surface the value on CreateVolume/DescribeVolumes.
- Zero value means "unset" (volume created before this field existed) — no migration needed, matches the existing `IOPS` field's zero-value convention.

Part of mulga-siv-492 (EBS gap #2: persist + surface gp3 Throughput on CreateVolume/DescribeVolumes). Evidence: `TestGetVolumeByID_ThroughputOmitted_PreFieldVolume` (spinifex) confirms old volumes without the field round-trip cleanly.

## Test plan
- [x] `make preflight` green (lint, govulncheck, test-cover, test-race)