### PR TITLE
perf: ordered extent index, batched read resolution, working persisted-data cache

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/mulgadc/predastore v1.14.0
 	github.com/stretchr/testify v1.11.1
+	github.com/tidwall/btree v1.8.1
 	go.opentelemetry.io/contrib/bridges/otelslog v0.19.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.69.0
 	go.opentelemetry.io/otel v1.44.0

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	go.opentelemetry.io/otel/sdk/log v0.20.0
 	go.opentelemetry.io/otel/sdk/metric v1.44.0
 	go.opentelemetry.io/otel/trace v1.44.0
+	golang.org/x/sys v0.47.0
 	libguestfs.org/nbdkit v0.0.0-00010101000000-000000000000
 )
 
@@ -84,7 +85,6 @@ require (
 	golang.org/x/mod v0.37.0 // indirect
 	golang.org/x/net v0.56.0 // indirect
 	golang.org/x/sync v0.22.0 // indirect
-	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/telemetry v0.0.0-20260625142307-59b4966ccb57 // indirect
 	golang.org/x/text v0.40.0 // indirect
 	golang.org/x/time v0.15.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -225,6 +225,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/tidwall/btree v1.8.1 h1:27ehoXvm5AG/g+1VxLS1SD3vRhp/H7LuEfwNvddEdmA=
+github.com/tidwall/btree v1.8.1/go.mod h1:jBbTdUWhSZClZWoDg54VnvV7/54modSOzDN7VXftj1A=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 go.etcd.io/bbolt v1.4.3 h1:dEadXpI6G79deX5prL3QRNP6JB8UxVkqo4UPnHaNXJo=
 go.etcd.io/bbolt v1.4.3/go.mod h1:tKQlpPaYCVFctUIgFKFnAlvbmB3tpy1vkTnDWohtc0E=

--- a/nbd/viperblock.go
+++ b/nbd/viperblock.go
@@ -74,7 +74,7 @@ var access_key string
 var secret_key string
 var host string
 var base_dir string
-var cache_size int = 20
+var cache_size int = viperblock.DefaultCacheBlocks
 var max_pending_bytes uint64 = 0
 var upload_workers int = 16
 var use_shardwal bool = false

--- a/viperblock/blockmap_coalesce_test.go
+++ b/viperblock/blockmap_coalesce_test.go
@@ -70,7 +70,7 @@ func TestBlockMapCoalesce_SequentialWrite(t *testing.T) {
 	require.NoError(t, vb.WriteWALToChunk(true))
 
 	vb.BlocksToObject.mu.RLock()
-	require.Equal(t, vb.BlocksToObject.lookup.len(), 1, "one consecutive run must coalesce into one BlockLookup entry")
+	require.Equal(t, 1, vb.BlocksToObject.lookup.len(), "one consecutive run must coalesce into one BlockLookup entry")
 	entry := lookupMap(&vb.BlocksToObject)[0]
 	vb.BlocksToObject.mu.RUnlock()
 	require.Equal(t, uint16(numBlocks), entry.NumBlocks)
@@ -104,7 +104,7 @@ func TestBlockMapCoalesce_OverwriteFracturesExtent(t *testing.T) {
 	require.NoError(t, vb.WriteWALToChunk(true))
 
 	vb.BlocksToObject.mu.RLock()
-	require.Equal(t, vb.BlocksToObject.lookup.len(), 1)
+	require.Equal(t, 1, vb.BlocksToObject.lookup.len())
 	vb.BlocksToObject.mu.RUnlock()
 
 	// Overwrite [8, 12) -- strictly inside the [0, 20) extent, leaving
@@ -115,7 +115,7 @@ func TestBlockMapCoalesce_OverwriteFracturesExtent(t *testing.T) {
 	require.NoError(t, vb.WriteWALToChunk(true))
 
 	vb.BlocksToObject.mu.RLock()
-	require.Equal(t, vb.BlocksToObject.lookup.len(), 3, "overwrite must fracture the original extent into head/new/tail")
+	require.Equal(t, 3, vb.BlocksToObject.lookup.len(), "overwrite must fracture the original extent into head/new/tail")
 	head, headOK := lookupMap(&vb.BlocksToObject)[0]
 	mid, midOK := lookupMap(&vb.BlocksToObject)[8]
 	tail, tailOK := lookupMap(&vb.BlocksToObject)[12]
@@ -160,7 +160,7 @@ func TestBlockMapCoalesce_MultiChunkBoundary(t *testing.T) {
 	require.NoError(t, vb.WriteWALToChunk(true))
 
 	vb.BlocksToObject.mu.RLock()
-	require.Equal(t, vb.BlocksToObject.lookup.len(), 3, "20 blocks at 8 blocks/chunk must produce 3 extents")
+	require.Equal(t, 3, vb.BlocksToObject.lookup.len(), "20 blocks at 8 blocks/chunk must produce 3 extents")
 	e0, ok0 := lookupMap(&vb.BlocksToObject)[0]
 	e1, ok1 := lookupMap(&vb.BlocksToObject)[8]
 	e2, ok2 := lookupMap(&vb.BlocksToObject)[16]
@@ -203,7 +203,7 @@ func TestBlockMapCoalesce_EncryptedReadback(t *testing.T) {
 	require.NoError(t, vb.WriteWALToChunk(true))
 
 	vb.BlocksToObject.mu.RLock()
-	require.Equal(t, vb.BlocksToObject.lookup.len(), 3, "encrypted volumes coalesce the same way as plaintext ones")
+	require.Equal(t, 3, vb.BlocksToObject.lookup.len(), "encrypted volumes coalesce the same way as plaintext ones")
 	vb.BlocksToObject.mu.RUnlock()
 
 	got, err := vb.ReadAt(0, uint64(numBlocks)*uint64(vb.BlockSize))
@@ -321,7 +321,7 @@ func TestBlockMapCoalesce_LegacyCheckpointEncryptedReadback(t *testing.T) {
 
 	// Capture the real per-block AEAD SeqNums the chunk was actually sealed with.
 	vb.BlocksToObject.mu.RLock()
-	require.Equal(t, vb.BlocksToObject.lookup.len(), 1, "the write must have coalesced into one extent")
+	require.Equal(t, 1, vb.BlocksToObject.lookup.len(), "the write must have coalesced into one extent")
 	entry := lookupMap(&vb.BlocksToObject)[0]
 	realSeqNums := make([]uint64, numBlocks)
 	for i := range numBlocks {

--- a/viperblock/blockmap_coalesce_test.go
+++ b/viperblock/blockmap_coalesce_test.go
@@ -70,8 +70,8 @@ func TestBlockMapCoalesce_SequentialWrite(t *testing.T) {
 	require.NoError(t, vb.WriteWALToChunk(true))
 
 	vb.BlocksToObject.mu.RLock()
-	require.Len(t, vb.BlocksToObject.BlockLookup, 1, "one consecutive run must coalesce into one BlockLookup entry")
-	entry := vb.BlocksToObject.BlockLookup[0]
+	require.Equal(t, vb.BlocksToObject.lookup.len(), 1, "one consecutive run must coalesce into one BlockLookup entry")
+	entry := lookupMap(&vb.BlocksToObject)[0]
 	vb.BlocksToObject.mu.RUnlock()
 	require.Equal(t, uint16(numBlocks), entry.NumBlocks)
 
@@ -104,7 +104,7 @@ func TestBlockMapCoalesce_OverwriteFracturesExtent(t *testing.T) {
 	require.NoError(t, vb.WriteWALToChunk(true))
 
 	vb.BlocksToObject.mu.RLock()
-	require.Len(t, vb.BlocksToObject.BlockLookup, 1)
+	require.Equal(t, vb.BlocksToObject.lookup.len(), 1)
 	vb.BlocksToObject.mu.RUnlock()
 
 	// Overwrite [8, 12) -- strictly inside the [0, 20) extent, leaving
@@ -115,10 +115,10 @@ func TestBlockMapCoalesce_OverwriteFracturesExtent(t *testing.T) {
 	require.NoError(t, vb.WriteWALToChunk(true))
 
 	vb.BlocksToObject.mu.RLock()
-	require.Len(t, vb.BlocksToObject.BlockLookup, 3, "overwrite must fracture the original extent into head/new/tail")
-	head, headOK := vb.BlocksToObject.BlockLookup[0]
-	mid, midOK := vb.BlocksToObject.BlockLookup[8]
-	tail, tailOK := vb.BlocksToObject.BlockLookup[12]
+	require.Equal(t, vb.BlocksToObject.lookup.len(), 3, "overwrite must fracture the original extent into head/new/tail")
+	head, headOK := lookupMap(&vb.BlocksToObject)[0]
+	mid, midOK := lookupMap(&vb.BlocksToObject)[8]
+	tail, tailOK := lookupMap(&vb.BlocksToObject)[12]
 	vb.BlocksToObject.mu.RUnlock()
 
 	require.True(t, headOK && midOK && tailOK, "expected entries keyed at 0, 8, 12")
@@ -160,10 +160,10 @@ func TestBlockMapCoalesce_MultiChunkBoundary(t *testing.T) {
 	require.NoError(t, vb.WriteWALToChunk(true))
 
 	vb.BlocksToObject.mu.RLock()
-	require.Len(t, vb.BlocksToObject.BlockLookup, 3, "20 blocks at 8 blocks/chunk must produce 3 extents")
-	e0, ok0 := vb.BlocksToObject.BlockLookup[0]
-	e1, ok1 := vb.BlocksToObject.BlockLookup[8]
-	e2, ok2 := vb.BlocksToObject.BlockLookup[16]
+	require.Equal(t, vb.BlocksToObject.lookup.len(), 3, "20 blocks at 8 blocks/chunk must produce 3 extents")
+	e0, ok0 := lookupMap(&vb.BlocksToObject)[0]
+	e1, ok1 := lookupMap(&vb.BlocksToObject)[8]
+	e2, ok2 := lookupMap(&vb.BlocksToObject)[16]
 	vb.BlocksToObject.mu.RUnlock()
 
 	require.True(t, ok0 && ok1 && ok2, "expected extents keyed at 0, 8, 16")
@@ -203,7 +203,7 @@ func TestBlockMapCoalesce_EncryptedReadback(t *testing.T) {
 	require.NoError(t, vb.WriteWALToChunk(true))
 
 	vb.BlocksToObject.mu.RLock()
-	require.Len(t, vb.BlocksToObject.BlockLookup, 3, "encrypted volumes coalesce the same way as plaintext ones")
+	require.Equal(t, vb.BlocksToObject.lookup.len(), 3, "encrypted volumes coalesce the same way as plaintext ones")
 	vb.BlocksToObject.mu.RUnlock()
 
 	got, err := vb.ReadAt(0, uint64(numBlocks)*uint64(vb.BlockSize))
@@ -250,7 +250,7 @@ func TestBlockMapCoalesce_EntryCountIsExtentsNotBlocks(t *testing.T) {
 	require.NoError(t, vb.WriteWALToChunk(true))
 
 	vb.BlocksToObject.mu.RLock()
-	entryCount := len(vb.BlocksToObject.BlockLookup)
+	entryCount := vb.BlocksToObject.lookup.len()
 	vb.BlocksToObject.mu.RUnlock()
 
 	wantExtents := (numBlocks + blocksPerChunk - 1) / blocksPerChunk // ceil
@@ -321,8 +321,8 @@ func TestBlockMapCoalesce_LegacyCheckpointEncryptedReadback(t *testing.T) {
 
 	// Capture the real per-block AEAD SeqNums the chunk was actually sealed with.
 	vb.BlocksToObject.mu.RLock()
-	require.Len(t, vb.BlocksToObject.BlockLookup, 1, "the write must have coalesced into one extent")
-	entry := vb.BlocksToObject.BlockLookup[0]
+	require.Equal(t, vb.BlocksToObject.lookup.len(), 1, "the write must have coalesced into one extent")
+	entry := lookupMap(&vb.BlocksToObject)[0]
 	realSeqNums := make([]uint64, numBlocks)
 	for i := range numBlocks {
 		realSeqNums[i] = entry.seqNumAt(i)
@@ -355,7 +355,7 @@ func TestBlockMapCoalesce_LegacyCheckpointEncryptedReadback(t *testing.T) {
 	// Drop all in-memory state and reload purely from the forged legacy bytes.
 	vb.BlockStore = NewUnifiedBlockStore(vb.BlockSize)
 	vb.BlocksToObject.mu.Lock()
-	vb.BlocksToObject.BlockLookup = make(map[uint64]BlockLookup)
+	vb.BlocksToObject.lookup.clear()
 	err = vb.parseBlockCheckpoint(legacy)
 	vb.BlocksToObject.mu.Unlock()
 	require.NoError(t, err)

--- a/viperblock/blockstore.go
+++ b/viperblock/blockstore.go
@@ -364,6 +364,91 @@ func (ubs *UnifiedBlockStore) ReadEntry(blockNum uint64) (BlockEntry, bool) {
 	return snapshot, true
 }
 
+// ReadEntryRun resolves the count blocks starting at startBlock into out,
+// setting found[i] for each block that resolved. Both slices must have length
+// count. Semantics per block are identical to ReadEntry -- a shard-resident
+// entry is newer than anything in the persisted index and wins -- but the
+// persisted index is consulted once for the whole run instead of once per
+// block.
+//
+// That matters for more than the tree descent: readPersisted takes
+// persistedMu for reading on every call, so a 1 MiB guest read used to
+// acquire it 256 times. Go's RWMutex blocks new readers behind a waiting
+// writer, so each of those acquisitions was a chance to stall behind a chunk
+// upload. This takes it once.
+func (ubs *UnifiedBlockStore) ReadEntryRun(startBlock, count uint64, out []BlockEntry, found []bool) {
+	if count == 0 {
+		return
+	}
+	ubs.stats.Reads.Add(count)
+
+	// Pass 1: the sharded index, which holds the hot/pending/cached overlay.
+	gaps := false
+	for i := range count {
+		blockNum := startBlock + i
+		shard := ubs.getShard(blockNum)
+		shard.mu.RLock()
+		entry, exists := shard.entries[blockNum]
+		if exists {
+			out[i] = *entry
+		}
+		shard.mu.RUnlock()
+
+		found[i] = exists
+		if !exists {
+			gaps = true
+			continue
+		}
+		switch out[i].State {
+		case BlockStateHot:
+			ubs.stats.HotReads.Add(1)
+		case BlockStatePending:
+			ubs.stats.PendReads.Add(1)
+		case BlockStateCached:
+			ubs.stats.CacheHits.Add(1)
+		case BlockStatePersisted:
+			ubs.stats.BackendReads.Add(1)
+		default:
+			ubs.stats.CacheMiss.Add(1)
+		}
+	}
+	if !gaps {
+		return
+	}
+
+	// Pass 2: one locked walk of the persisted index for whatever pass 1 did
+	// not resolve. A block coalesced into an extent after upload has no shard
+	// entry of its own, so a pass-1 miss is not "never written".
+	end := startBlock + count
+	ubs.persistedMu.RLock()
+	ubs.persistedExtents.overlaps(startBlock, end, func(pe persistedExtent) bool {
+		lo, hi := max(pe.startBlock, startBlock), min(pe.end(), end)
+		for blockNum := lo; blockNum < hi; blockNum++ {
+			i := blockNum - startBlock
+			if found[i] {
+				continue // the overlay already answered for this block
+			}
+			idx := uint16(blockNum - pe.startBlock) //nolint:gosec // G115: blockNum < pe.end() bounds this by pe.numBlocks (uint16)
+			out[i] = BlockEntry{
+				SeqNum:       pe.seqNumAt(idx),
+				State:        BlockStatePersisted,
+				ObjectID:     pe.objectID,
+				ObjectOffset: pe.offsetAt(idx),
+			}
+			found[i] = true
+			ubs.stats.BackendReads.Add(1)
+		}
+		return true
+	})
+	ubs.persistedMu.RUnlock()
+
+	for i := range count {
+		if !found[i] {
+			ubs.stats.CacheMiss.Add(1)
+		}
+	}
+}
+
 // Write stores a block in the Hot state and returns the assigned sequence number
 // The index is updated immediately (not rebuilt on read).
 func (ubs *UnifiedBlockStore) Write(blockNum uint64, data []byte) uint64 {
@@ -423,9 +508,9 @@ func (ubs *UnifiedBlockStore) WriteWithSeqNum(blockNum uint64, data []byte, seqN
 	shard.mu.Unlock()
 }
 
-// MarkPending transitions a block from Hot to Pending state
-// Called by Flush() after WAL write succeeds.
-func (ubs *UnifiedBlockStore) MarkPending(blockNum uint64) bool {
+// MarkPending transitions a block from Hot to Pending state.
+// Called by Flush() after the WAL write succeeds.
+func (ubs *UnifiedBlockStore) MarkPending(blockNum, seqNum uint64) bool {
 	shard := ubs.getShard(blockNum)
 	shard.mu.Lock()
 	defer shard.mu.Unlock()
@@ -435,7 +520,10 @@ func (ubs *UnifiedBlockStore) MarkPending(blockNum uint64) bool {
 		return false
 	}
 
-	if entry.State == BlockStateHot {
+	// seqNum identifies the write that actually reached the WAL. A block
+	// rewritten since then is Hot with a higher SeqNum and that newer data is
+	// not durable yet, so it must stay Hot.
+	if entry.State == BlockStateHot && entry.SeqNum == seqNum {
 		entry.State = BlockStatePending
 		return true
 	}
@@ -617,50 +705,6 @@ func (ubs *UnifiedBlockStore) SetPersistedRange(blocks []uint64, objectID uint64
 		ubs.persistedExtents.set(run)
 		i = j
 	}
-}
-
-// Cache transitions a block from Persisted to Cached state after backend read.
-func (ubs *UnifiedBlockStore) Cache(blockNum uint64, data []byte) bool {
-	shard := ubs.getShard(blockNum)
-	shard.mu.Lock()
-	defer shard.mu.Unlock()
-
-	entry, ok := shard.entries[blockNum]
-	if !ok {
-		return false
-	}
-
-	// Only cache if currently Persisted (not Hot or Pending which have newer data)
-	if entry.State == BlockStatePersisted {
-		// Make copy of data
-		dataCopy := make([]byte, len(data))
-		copy(dataCopy, data)
-
-		entry.State = BlockStateCached
-		entry.Data = dataCopy
-		return true
-	}
-	return false
-}
-
-// EvictCache transitions a block from Cached back to Persisted state
-// Used for LRU eviction.
-func (ubs *UnifiedBlockStore) EvictCache(blockNum uint64) bool {
-	shard := ubs.getShard(blockNum)
-	shard.mu.Lock()
-	defer shard.mu.Unlock()
-
-	entry, ok := shard.entries[blockNum]
-	if !ok {
-		return false
-	}
-
-	if entry.State == BlockStateCached {
-		entry.State = BlockStatePersisted
-		entry.Data = nil
-		return true
-	}
-	return false
 }
 
 // GetBlocksByState returns all block numbers in a given state

--- a/viperblock/blockstore.go
+++ b/viperblock/blockstore.go
@@ -82,7 +82,11 @@ type UnifiedBlockStore struct {
 	// a run's blocks are spread across many shards (shard = blockNum &
 	// ShardMask), so no single shard lock could cover a whole extent.
 	persistedMu      sync.RWMutex
-	persistedExtents map[uint64]persistedExtent
+	persistedExtents extentIndex[persistedExtent]
+
+	// fractureScratch is reused by fractureOverlapsLocked to collect the
+	// overlapping extents before mutating the index. Guarded by persistedMu.
+	fractureScratch []persistedExtent
 
 	// Stats for monitoring
 	stats BlockStoreStats
@@ -103,6 +107,11 @@ type persistedExtent struct {
 	objectOffset uint32
 	stride       uint32
 	numBlocks    uint16
+}
+
+// start returns the first block of the extent.
+func (pe persistedExtent) start() uint64 {
+	return pe.startBlock
 }
 
 // end returns the exclusive end block of the extent.
@@ -140,8 +149,7 @@ var ErrBlockNotFound = errors.New("block not found")
 // NewUnifiedBlockStore creates a new unified block store with the given block size.
 func NewUnifiedBlockStore(blockSize uint32) *UnifiedBlockStore {
 	ubs := &UnifiedBlockStore{
-		blockSize:        blockSize,
-		persistedExtents: make(map[uint64]persistedExtent),
+		blockSize: blockSize,
 	}
 
 	// Initialize all shards
@@ -160,19 +168,9 @@ func (ubs *UnifiedBlockStore) getShard(blockNum uint64) *IndexShard {
 }
 
 // findPersistedExtentLocked returns the persistedExtent covering blockNum, if
-// any. Callers must hold persistedMu (read or write). Checks the fast path
-// first (blockNum is itself an extent's startBlock) before falling back to a
-// scan, which is cheap since the index is O(extents), not O(blocks).
+// any. Callers must hold persistedMu (read or write).
 func (ubs *UnifiedBlockStore) findPersistedExtentLocked(blockNum uint64) (persistedExtent, bool) {
-	if pe, ok := ubs.persistedExtents[blockNum]; ok {
-		return pe, true
-	}
-	for _, pe := range ubs.persistedExtents {
-		if blockNum > pe.startBlock && blockNum < pe.end() {
-			return pe, true
-		}
-	}
-	return persistedExtent{}, false
+	return ubs.persistedExtents.find(blockNum)
 }
 
 // readPersisted resolves blockNum against the persisted-extent index and
@@ -203,18 +201,14 @@ func (ubs *UnifiedBlockStore) readPersisted(blockNum uint64) (BlockEntry, bool) 
 func (ubs *UnifiedBlockStore) fractureOverlapsLocked(newStart uint64, newNum uint16) {
 	newEnd := newStart + uint64(newNum)
 
-	keys := make([]uint64, 0, len(ubs.persistedExtents))
-	for k := range ubs.persistedExtents {
-		keys = append(keys, k)
-	}
+	// Collect before mutating: the walk holds a cursor into the index, so
+	// deleting and re-inserting during it is not safe. The set is bounded by
+	// the extents actually overlapped, not by the index size.
+	ubs.fractureScratch = ubs.persistedExtents.collectOverlaps(ubs.fractureScratch[:0], newStart, newEnd)
 
-	for _, key := range keys {
-		existing := ubs.persistedExtents[key]
+	for _, existing := range ubs.fractureScratch {
 		exStart, exEnd := existing.startBlock, existing.end()
-		if exEnd <= newStart || exStart >= newEnd {
-			continue // no overlap
-		}
-		delete(ubs.persistedExtents, key)
+		ubs.persistedExtents.remove(exStart)
 
 		// Surviving head: [exStart, newStart)
 		if exStart < newStart {
@@ -222,9 +216,13 @@ func (ubs *UnifiedBlockStore) fractureOverlapsLocked(newStart uint64, newNum uin
 			head := existing
 			head.numBlocks = uint16(headNum) //nolint:gosec // G115: headNum = newStart-exStart < existing.numBlocks (uint16) since exStart < newStart < exEnd
 			if len(existing.seqNums) > 0 {
-				head.seqNums = append([]uint64(nil), existing.seqNums[:headNum]...)
+				// Sub-slice rather than copy: a stored extent's seqNums are
+				// never mutated in place, only replaced wholesale, so head and
+				// tail can share the original backing array. Capped so a later
+				// append cannot reach into the tail's elements.
+				head.seqNums = existing.seqNums[:headNum:headNum]
 			}
-			ubs.persistedExtents[head.startBlock] = head
+			ubs.persistedExtents.set(head)
 		}
 
 		// Surviving tail: [newEnd, exEnd)
@@ -236,9 +234,9 @@ func (ubs *UnifiedBlockStore) fractureOverlapsLocked(newStart uint64, newNum uin
 			tail.numBlocks = uint16(tailNum)                                //nolint:gosec // G115: tailNum = exEnd-newEnd < existing.numBlocks (uint16) since newStart < newEnd < exEnd
 			tail.objectOffset = existing.offsetAt(uint16(tailOffsetBlocks)) //nolint:gosec // G115: tailOffsetBlocks = newEnd-exStart < existing.numBlocks (uint16) since exStart < newEnd < exEnd
 			if len(existing.seqNums) > 0 {
-				tail.seqNums = append([]uint64(nil), existing.seqNums[tailOffsetBlocks:]...)
+				tail.seqNums = existing.seqNums[tailOffsetBlocks:]
 			}
-			ubs.persistedExtents[tail.startBlock] = tail
+			ubs.persistedExtents.set(tail)
 		}
 	}
 }
@@ -534,7 +532,7 @@ func (ubs *UnifiedBlockStore) MarkPersistedRange(blocks []uint64, objectID uint6
 			seqNums:      append([]uint64(nil), seqNums[i:j]...),
 		}
 		ubs.fractureOverlapsLocked(run.startBlock, run.numBlocks)
-		ubs.persistedExtents[run.startBlock] = run
+		ubs.persistedExtents.set(run)
 		i = j
 	}
 	ubs.persistedMu.Unlock()
@@ -616,7 +614,7 @@ func (ubs *UnifiedBlockStore) SetPersistedRange(blocks []uint64, objectID uint64
 			seqNums:      append([]uint64(nil), seqNums[i:j]...),
 		}
 		ubs.fractureOverlapsLocked(run.startBlock, run.numBlocks)
-		ubs.persistedExtents[run.startBlock] = run
+		ubs.persistedExtents.set(run)
 		i = j
 	}
 }
@@ -769,9 +767,10 @@ func (ubs *UnifiedBlockStore) Count() int {
 	}
 
 	ubs.persistedMu.RLock()
-	for _, pe := range ubs.persistedExtents {
+	ubs.persistedExtents.scan(func(pe persistedExtent) bool {
 		total += int(pe.numBlocks)
-	}
+		return true
+	})
 	ubs.persistedMu.RUnlock()
 
 	return total
@@ -783,7 +782,7 @@ func (ubs *UnifiedBlockStore) Count() int {
 func (ubs *UnifiedBlockStore) PersistedExtentCount() int {
 	ubs.persistedMu.RLock()
 	defer ubs.persistedMu.RUnlock()
-	return len(ubs.persistedExtents)
+	return ubs.persistedExtents.len()
 }
 
 // CountByState returns the count of blocks in each state, across the sharded
@@ -801,9 +800,10 @@ func (ubs *UnifiedBlockStore) CountByState() map[BlockState]int {
 	}
 
 	ubs.persistedMu.RLock()
-	for _, pe := range ubs.persistedExtents {
+	ubs.persistedExtents.scan(func(pe persistedExtent) bool {
 		counts[BlockStatePersisted] += int(pe.numBlocks)
-	}
+		return true
+	})
 	ubs.persistedMu.RUnlock()
 
 	return counts
@@ -819,7 +819,7 @@ func (ubs *UnifiedBlockStore) Clear() {
 	}
 
 	ubs.persistedMu.Lock()
-	ubs.persistedExtents = make(map[uint64]persistedExtent)
+	ubs.persistedExtents.clear()
 	ubs.persistedMu.Unlock()
 }
 

--- a/viperblock/blockstore_test.go
+++ b/viperblock/blockstore_test.go
@@ -76,7 +76,7 @@ func TestBlockStore_StateTransitions(t *testing.T) {
 	data[0] = 0xAB
 
 	// Write block -> Hot state
-	bs.Write(50, data)
+	seqNum := bs.Write(50, data)
 	entry, ok := bs.ReadBlock(50)
 	if !ok {
 		t.Fatal("block not found after write")
@@ -86,7 +86,7 @@ func TestBlockStore_StateTransitions(t *testing.T) {
 	}
 
 	// Hot -> Pending
-	if !bs.MarkPending(50) {
+	if !bs.MarkPending(50, seqNum) {
 		t.Error("MarkPending failed")
 	}
 	entry, _ = bs.ReadBlock(50)
@@ -110,29 +110,6 @@ func TestBlockStore_StateTransitions(t *testing.T) {
 	}
 	if entry.Data != nil {
 		t.Error("Data should be nil for Persisted state")
-	}
-
-	// Persisted -> Cached
-	cacheData := make([]byte, 4096)
-	cacheData[0] = 0xCD
-	if !bs.Cache(50, cacheData) {
-		t.Error("Cache failed")
-	}
-	entry, _ = bs.ReadBlock(50)
-	if entry.State != BlockStateCached {
-		t.Errorf("expected Cached, got %s", entry.State.String())
-	}
-	if !bytes.Equal(entry.Data, cacheData) {
-		t.Error("cached data mismatch")
-	}
-
-	// Cached -> Persisted (eviction)
-	if !bs.EvictCache(50) {
-		t.Error("EvictCache failed")
-	}
-	entry, _ = bs.ReadBlock(50)
-	if entry.State != BlockStatePersisted {
-		t.Errorf("expected Persisted after eviction, got %s", entry.State.String())
 	}
 }
 
@@ -230,13 +207,14 @@ func TestBlockStore_GetBlocksByState(t *testing.T) {
 	data := make([]byte, 4096)
 
 	// Create 10 Hot blocks
+	seqs := make([]uint64, 10)
 	for i := range uint64(10) {
-		bs.Write(i, data)
+		seqs[i] = bs.Write(i, data)
 	}
 
 	// Move 5 to Pending
 	for i := range uint64(5) {
-		bs.MarkPending(i)
+		bs.MarkPending(i, seqs[i])
 	}
 
 	hotBlocks := bs.GetBlocksByState(BlockStateHot)
@@ -254,15 +232,16 @@ func TestBlockStore_GetHotBlocks(t *testing.T) {
 	bs := NewUnifiedBlockStore(4096)
 
 	// Write some blocks
+	seqs := make([]uint64, 10)
 	for i := range uint64(10) {
 		data := make([]byte, 4096)
 		data[0] = byte(i)
-		bs.Write(i, data)
+		seqs[i] = bs.Write(i, data)
 	}
 
 	// Mark some as pending
 	for i := range uint64(5) {
-		bs.MarkPending(i)
+		bs.MarkPending(i, seqs[i])
 	}
 
 	hotBlocks := bs.GetHotBlocks()
@@ -356,16 +335,17 @@ func TestBlockStore_CountByState(t *testing.T) {
 	data := make([]byte, 4096)
 
 	// Create mixed states
+	seqs := make([]uint64, 30)
 	for i := range uint64(30) {
-		bs.Write(i, data)
+		seqs[i] = bs.Write(i, data)
 	}
 
 	// 10 stay Hot, 10 go Pending, 10 go Persisted
 	for i := uint64(10); i < 20; i++ {
-		bs.MarkPending(i)
+		bs.MarkPending(i, seqs[i])
 	}
 	for i := uint64(20); i < 30; i++ {
-		bs.MarkPending(i)
+		bs.MarkPending(i, seqs[i])
 		e, _ := bs.ReadBlock(i)
 		bs.MarkPersisted(i, 0, 0, e.SeqNum)
 	}
@@ -481,7 +461,7 @@ func pendingRun(bs *UnifiedBlockStore, startBlock uint64, numBlocks int) (blocks
 	for i := range numBlocks {
 		b := startBlock + uint64(i)
 		sn := bs.Write(b, data)
-		bs.MarkPending(b)
+		bs.MarkPending(b, sn)
 		blocks = append(blocks, b)
 		seqNums = append(seqNums, sn)
 	}
@@ -709,8 +689,8 @@ func TestBlockStore_MarkPersistedRange_ConcurrentRewrite(t *testing.T) {
 					default:
 					}
 					b := startBlock + uint64(rand.IntN(numBlocks))
-					bs.Write(b, data)
-					bs.MarkPending(b)
+					sn := bs.Write(b, data)
+					bs.MarkPending(b, sn)
 				}
 			})
 		}
@@ -870,10 +850,8 @@ func BenchmarkBlockStore_StateTransition(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		blockNum := uint64(i)
 		seqNum := bs.Write(blockNum, data)
-		bs.MarkPending(blockNum)
+		bs.MarkPending(blockNum, seqNum)
 		bs.MarkPersisted(blockNum, uint64(i), uint32(i*4096), seqNum)
-		bs.Cache(blockNum, data)
-		bs.EvictCache(blockNum)
 	}
 }
 

--- a/viperblock/chunk_gc_test.go
+++ b/viperblock/chunk_gc_test.go
@@ -181,15 +181,15 @@ func assertClosure(t *testing.T, vb *VB) {
 	t.Helper()
 
 	vb.BlocksToObject.mu.RLock()
-	ownLookup := make(map[uint64]BlockLookup, len(vb.BlocksToObject.BlockLookup))
-	maps.Copy(ownLookup, vb.BlocksToObject.BlockLookup)
+	ownLookup := make(map[uint64]BlockLookup, vb.BlocksToObject.lookup.len())
+	maps.Copy(ownLookup, lookupMap(&vb.BlocksToObject))
 	vb.BlocksToObject.mu.RUnlock()
 	assertMapClosure(t, vb.Backend, vb.VolumeName, ownLookup)
 
 	if vb.BaseBlockMap != nil {
 		vb.BaseBlockMap.mu.RLock()
-		baseLookup := make(map[uint64]BlockLookup, len(vb.BaseBlockMap.BlockLookup))
-		maps.Copy(baseLookup, vb.BaseBlockMap.BlockLookup)
+		baseLookup := make(map[uint64]BlockLookup, vb.BaseBlockMap.lookup.len())
+		maps.Copy(baseLookup, lookupMap(vb.BaseBlockMap))
 		vb.BaseBlockMap.mu.RUnlock()
 		assertMapClosure(t, vb.Backend, vb.SourceVolumeName, baseLookup)
 	}
@@ -199,8 +199,8 @@ func assertClosure(t *testing.T, vb *VB) {
 			continue
 		}
 		anc.blocks.mu.RLock()
-		ancLookup := make(map[uint64]BlockLookup, len(anc.blocks.BlockLookup))
-		maps.Copy(ancLookup, anc.blocks.BlockLookup)
+		ancLookup := make(map[uint64]BlockLookup, anc.blocks.lookup.len())
+		maps.Copy(ancLookup, lookupMap(anc.blocks))
 		anc.blocks.mu.RUnlock()
 		assertMapClosure(t, vb.Backend, anc.sourceVolumeName, ancLookup)
 	}
@@ -836,7 +836,7 @@ func TestChunkGC_StaleDrainNeverClobbersNewerChunk(t *testing.T) {
 	// The block must still point at the NEWER chunk, and refcounts must be
 	// exactly: live chunk 1, orphaned stale chunk tracked at 0.
 	vb.BlocksToObject.mu.RLock()
-	lookup, mapOK := vb.BlocksToObject.BlockLookup[0]
+	lookup, mapOK := lookupMap(&vb.BlocksToObject)[0]
 	newerRefs := vb.gcRefcount[newerChunkID]
 	staleRefs, staleTracked := vb.gcRefcount[staleChunkID]
 	vb.BlocksToObject.mu.RUnlock()

--- a/viperblock/encryption_meta_test.go
+++ b/viperblock/encryption_meta_test.go
@@ -277,6 +277,10 @@ func TestBlockStoreReadEncrypted(t *testing.T) {
 
 	// Now tamper a byte on the chunk and verify the BlockStore path
 	// also fails closed.
+	// Drop the plaintext cache alongside the block store: a cached copy is
+	// returned without re-decrypting, so it would mask the tamper this test
+	// exists to catch.
+	env.vb.Cache.purge()
 	env.vb.BlockStore = NewUnifiedBlockStore(env.vb.BlockSize)
 	env.vb.BlocksToObject.mu.Lock()
 	env.vb.BlocksToObject.lookup.set(BlockLookup{

--- a/viperblock/encryption_meta_test.go
+++ b/viperblock/encryption_meta_test.go
@@ -279,13 +279,13 @@ func TestBlockStoreReadEncrypted(t *testing.T) {
 	// also fails closed.
 	env.vb.BlockStore = NewUnifiedBlockStore(env.vb.BlockSize)
 	env.vb.BlocksToObject.mu.Lock()
-	env.vb.BlocksToObject.BlockLookup[0] = BlockLookup{
+	env.vb.BlocksToObject.lookup.set(BlockLookup{
 		StartBlock:   0,
 		NumBlocks:    1,
 		ObjectID:     0,
 		ObjectOffset: uint32(env.blockOffset(0)),
 		SeqNum:       1,
-	}
+	})
 	env.vb.BlocksToObject.mu.Unlock()
 	env.vb.BlockStore.SetPersisted(0, 0, uint32(env.blockOffset(0)), 1)
 

--- a/viperblock/encryption_snapshot_test.go
+++ b/viperblock/encryption_snapshot_test.go
@@ -429,8 +429,8 @@ func TestEncryptedChunk_LiveCheckpointSeqNumConsistency(t *testing.T) {
 	// SeqNum that was used to seal the corresponding chunk ciphertext.
 	writer.BlocksToObject.mu.RLock()
 	defer writer.BlocksToObject.mu.RUnlock()
-	for blockNum, want := range writer.BlocksToObject.BlockLookup {
-		got, ok := remounted.BlocksToObject.BlockLookup[blockNum]
+	for blockNum, want := range lookupMap(&writer.BlocksToObject) {
+		got, ok := lookupMap(&remounted.BlocksToObject)[blockNum]
 		require.True(t, ok, "block %d missing from live checkpoint after createChunkFile", blockNum)
 		assert.Equal(t, want.SeqNum, got.SeqNum,
 			"block %d: live checkpoint SeqNum must match seal-time SeqNum (AEAD nonce component)", blockNum)

--- a/viperblock/encryption_tamper_test.go
+++ b/viperblock/encryption_tamper_test.go
@@ -153,6 +153,10 @@ func TestEncryptedChunk_TamperByteFailsRead(t *testing.T) {
 	require.True(t, bytes.Equal(plaintext, got), "baseline decrypt failed; tamper test would be meaningless")
 
 	// Clear caches so the next read must hit the backend.
+	// Drop the plaintext cache alongside the block store: a cached copy is
+	// returned without re-decrypting, so it would mask the tamper this test
+	// exists to catch.
+	env.vb.Cache.purge()
 	env.vb.BlockStore = NewUnifiedBlockStore(env.vb.BlockSize)
 	env.vb.BlocksToObject.mu.Lock()
 	env.vb.BlocksToObject.lookup.set(BlockLookup{
@@ -189,6 +193,10 @@ func TestEncryptedChunk_TagTamperFailsRead(t *testing.T) {
 	require.NoError(t, err)
 	env.writeAndChunk(t, 0, plaintext)
 
+	// Drop the plaintext cache alongside the block store: a cached copy is
+	// returned without re-decrypting, so it would mask the tamper this test
+	// exists to catch.
+	env.vb.Cache.purge()
 	env.vb.BlockStore = NewUnifiedBlockStore(env.vb.BlockSize)
 	env.vb.UseBlockStore = false
 	env.vb.BlocksToObject.mu.Lock()
@@ -250,6 +258,7 @@ func TestEncryptedChunk_CrossVolumeSpliceFailsRead(t *testing.T) {
 	require.NoError(t, os.WriteFile(envB.chunkPath(envB.vb.VolumeName, 0), bBytes, 0600))
 
 	// Force B's read to hit the backend rather than its in-memory cache.
+	envB.vb.Cache.purge()
 	envB.vb.BlockStore = NewUnifiedBlockStore(envB.vb.BlockSize)
 	envB.vb.UseBlockStore = false
 	envB.vb.BlocksToObject.mu.Lock()
@@ -312,6 +321,10 @@ func TestEncryptedChunk_InPlaceReplayFailsRead(t *testing.T) {
 	require.NoError(t, os.WriteFile(env.chunkPath(env.vb.VolumeName, 1), chunk1, 0600))
 
 	// Force a backend re-read for block 5.
+	// Drop the plaintext cache alongside the block store: a cached copy is
+	// returned without re-decrypting, so it would mask the tamper this test
+	// exists to catch.
+	env.vb.Cache.purge()
 	env.vb.BlockStore = NewUnifiedBlockStore(env.vb.BlockSize)
 	env.vb.UseBlockStore = false
 
@@ -414,6 +427,10 @@ func TestEncryptedChunk_PreEncryptionMagicRejected(t *testing.T) {
 
 	// Bypass caches so the next Read hits the backend (and therefore
 	// the magic preflight).
+	// Drop the plaintext cache alongside the block store: a cached copy is
+	// returned without re-decrypting, so it would mask the tamper this test
+	// exists to catch.
+	env.vb.Cache.purge()
 	env.vb.BlockStore = NewUnifiedBlockStore(env.vb.BlockSize)
 	env.vb.UseBlockStore = false
 	env.vb.BlocksToObject.mu.Lock()

--- a/viperblock/encryption_tamper_test.go
+++ b/viperblock/encryption_tamper_test.go
@@ -155,13 +155,13 @@ func TestEncryptedChunk_TamperByteFailsRead(t *testing.T) {
 	// Clear caches so the next read must hit the backend.
 	env.vb.BlockStore = NewUnifiedBlockStore(env.vb.BlockSize)
 	env.vb.BlocksToObject.mu.Lock()
-	env.vb.BlocksToObject.BlockLookup[0] = BlockLookup{
+	env.vb.BlocksToObject.lookup.set(BlockLookup{
 		StartBlock:   0,
 		NumBlocks:    1,
 		ObjectID:     0,
 		ObjectOffset: uint32(env.blockOffset(0)),
 		SeqNum:       1, // first write under a fresh VB allocates SeqNum 1
-	}
+	})
 	env.vb.BlocksToObject.mu.Unlock()
 	env.vb.UseBlockStore = false
 
@@ -192,13 +192,13 @@ func TestEncryptedChunk_TagTamperFailsRead(t *testing.T) {
 	env.vb.BlockStore = NewUnifiedBlockStore(env.vb.BlockSize)
 	env.vb.UseBlockStore = false
 	env.vb.BlocksToObject.mu.Lock()
-	env.vb.BlocksToObject.BlockLookup[0] = BlockLookup{
+	env.vb.BlocksToObject.lookup.set(BlockLookup{
 		StartBlock:   0,
 		NumBlocks:    1,
 		ObjectID:     0,
 		ObjectOffset: uint32(env.blockOffset(0)),
 		SeqNum:       1,
-	}
+	})
 	env.vb.BlocksToObject.mu.Unlock()
 
 	chunkFile := env.chunkPath(env.vb.VolumeName, 0)
@@ -253,13 +253,13 @@ func TestEncryptedChunk_CrossVolumeSpliceFailsRead(t *testing.T) {
 	envB.vb.BlockStore = NewUnifiedBlockStore(envB.vb.BlockSize)
 	envB.vb.UseBlockStore = false
 	envB.vb.BlocksToObject.mu.Lock()
-	envB.vb.BlocksToObject.BlockLookup[0] = BlockLookup{
+	envB.vb.BlocksToObject.lookup.set(BlockLookup{
 		StartBlock:   0,
 		NumBlocks:    1,
 		ObjectID:     0,
 		ObjectOffset: uint32(envB.blockOffset(0)),
 		SeqNum:       1,
-	}
+	})
 	envB.vb.BlocksToObject.mu.Unlock()
 
 	_, err = envB.vb.ReadAt(0, uint64(envB.blockSize))
@@ -292,7 +292,7 @@ func TestEncryptedChunk_InPlaceReplayFailsRead(t *testing.T) {
 	env.writeAndChunk(t, 5, newer)
 
 	env.vb.BlocksToObject.mu.RLock()
-	cur := env.vb.BlocksToObject.BlockLookup[5]
+	cur := lookupMap(&env.vb.BlocksToObject)[5]
 	env.vb.BlocksToObject.mu.RUnlock()
 	require.Equal(t, uint64(1), cur.ObjectID, "second write must land in chunk 1")
 
@@ -417,13 +417,13 @@ func TestEncryptedChunk_PreEncryptionMagicRejected(t *testing.T) {
 	env.vb.BlockStore = NewUnifiedBlockStore(env.vb.BlockSize)
 	env.vb.UseBlockStore = false
 	env.vb.BlocksToObject.mu.Lock()
-	env.vb.BlocksToObject.BlockLookup[0] = BlockLookup{
+	env.vb.BlocksToObject.lookup.set(BlockLookup{
 		StartBlock:   0,
 		NumBlocks:    1,
 		ObjectID:     0,
 		ObjectOffset: uint32(env.blockOffset(0)),
 		SeqNum:       1,
-	}
+	})
 	env.vb.BlocksToObject.mu.Unlock()
 
 	// Rewrite the chunk file's first 4 bytes to the legacy VBCH magic

--- a/viperblock/extent_index.go
+++ b/viperblock/extent_index.go
@@ -1,0 +1,110 @@
+package viperblock
+
+import "github.com/tidwall/btree"
+
+// extent is what the ordered index needs from a stored value: the half-open
+// block range [start, end) it covers. Both block indexes key on the start
+// block, and the index relies on stored ranges being disjoint.
+type extent interface {
+	start() uint64
+	end() uint64
+}
+
+// extentIndex is an ordered index over disjoint block extents, keyed by start
+// block. It answers the only two queries the storage layer asks -- "which
+// extent covers block X" and "which extents overlap [s, e)" -- by seeking to a
+// position rather than examining every entry, so cost tracks the number of
+// extents actually touched rather than the number stored.
+//
+// A hash map cannot answer either query without a full scan, because a block
+// in the interior of a coalesced run has no key of its own. That is what made
+// both queries O(N) and, at a million extents, made a single 4 KiB lookup take
+// tens of milliseconds.
+//
+// Not safe for concurrent use: callers hold the lock guarding their index.
+type extentIndex[V extent] struct {
+	t btree.Map[uint64, V]
+}
+
+// find returns the extent covering block, if one does. The only candidate is
+// the extent with the greatest start key <= block, so a single descent
+// answers it.
+func (ix *extentIndex[V]) find(block uint64) (V, bool) {
+	var (
+		found V
+		ok    bool
+	)
+	ix.t.Descend(block, func(_ uint64, v V) bool {
+		if block < v.end() {
+			found, ok = v, true
+		}
+		return false
+	})
+	return found, ok
+}
+
+// overlaps calls fn for each extent intersecting [start, end), in ascending
+// order, stopping early if fn returns false.
+//
+// fn must not mutate the index: the walk holds a cursor into the tree. Callers
+// that fracture collect first, then mutate.
+func (ix *extentIndex[V]) overlaps(start, end uint64, fn func(V) bool) {
+	if start >= end {
+		return
+	}
+
+	// The extent immediately below start may still reach into the range, so
+	// begin the ascent from there rather than from start itself.
+	from := start
+	ix.t.Descend(start, func(k uint64, _ V) bool {
+		from = k
+		return false
+	})
+
+	ix.t.Ascend(from, func(k uint64, v V) bool {
+		if k >= end {
+			return false
+		}
+		if v.end() <= start {
+			return true // the predecessor stops short of the range
+		}
+		return fn(v)
+	})
+}
+
+// collectOverlaps returns the extents intersecting [start, end), appended to
+// dst. Separate from overlaps because fracturing mutates the index, which
+// cannot be done during a walk; dst lets the caller reuse a scratch buffer.
+func (ix *extentIndex[V]) collectOverlaps(dst []V, start, end uint64) []V {
+	ix.overlaps(start, end, func(v V) bool {
+		dst = append(dst, v)
+		return true
+	})
+	return dst
+}
+
+// set inserts or replaces the extent starting at v.start().
+func (ix *extentIndex[V]) set(v V) {
+	ix.t.Set(v.start(), v)
+}
+
+// remove deletes the extent starting exactly at block.
+func (ix *extentIndex[V]) remove(block uint64) {
+	ix.t.Delete(block)
+}
+
+// len returns the number of extents held.
+func (ix *extentIndex[V]) len() int {
+	return ix.t.Len()
+}
+
+// scan visits every extent in ascending start order, stopping early if fn
+// returns false.
+func (ix *extentIndex[V]) scan(fn func(V) bool) {
+	ix.t.Scan(func(_ uint64, v V) bool { return fn(v) })
+}
+
+// clear drops every extent.
+func (ix *extentIndex[V]) clear() {
+	ix.t.Clear()
+}

--- a/viperblock/extent_index_bench_test.go
+++ b/viperblock/extent_index_bench_test.go
@@ -1,0 +1,240 @@
+package viperblock
+
+import (
+	"fmt"
+	"math/rand/v2"
+	"testing"
+)
+
+// Asymptotic benchmarks for the two extent indexes. Both answer range queries
+// ("which extent contains block X", "which extents overlap [s,e)"), so their
+// cost must grow no worse than logarithmically in the number of extents. A
+// linear scan shows up here as ns/op rising in proportion to extentCount.
+//
+// Setup builds the containers directly rather than through SetPersistedRange /
+// insertCoalescedLocked: those are themselves O(N) per insert, so a 1M-extent
+// fixture would take O(N^2) to construct and the benchmark could not run at all.
+
+// extentCounts is the sweep. Point lookups run the full range; mutation
+// benchmarks stop earlier because a linear implementation takes minutes per
+// operation at the top end.
+var extentCounts = []int{1_000, 10_000, 100_000, 1_000_000}
+
+const benchRunLen = 16 // blocks per extent, typical of a coalesced random-write volume
+
+// buildPersistedFixture returns a store holding n disjoint extents of runLen
+// blocks each, laid down back to back from block 0.
+func buildPersistedFixture(n int, runLen uint16) *UnifiedBlockStore {
+	ubs := NewUnifiedBlockStore(4096)
+	for i := range n {
+		start := uint64(i) * uint64(runLen)
+		ubs.persistedExtents.set(persistedExtent{
+			startBlock:   start,
+			numBlocks:    runLen,
+			objectID:     uint64(i / 64),
+			objectOffset: uint32(i%64) * 4096,
+			stride:       4096,
+			seqNums:      make([]uint64, runLen),
+		})
+	}
+	return ubs
+}
+
+// buildBlockLookupFixture is buildPersistedFixture's counterpart for the
+// BlocksToObject index.
+func buildBlockLookupFixture(n int, runLen uint16) *BlocksToObject {
+	b := &BlocksToObject{}
+	for i := range n {
+		start := uint64(i) * uint64(runLen)
+		b.lookup.set(BlockLookup{
+			StartBlock:   start,
+			NumBlocks:    runLen,
+			ObjectID:     uint64(i / 64),
+			ObjectOffset: uint32(i%64) * 4096,
+			SeqNums:      make([]uint64, runLen),
+		})
+	}
+	return b
+}
+
+// blockSpan is the highest block number covered by a fixture of n extents.
+func blockSpan(n int, runLen uint16) uint64 {
+	return uint64(n) * uint64(runLen)
+}
+
+// BenchmarkPersistedPointLookup measures the read path: resolving one block to
+// its persisted location. This is the hottest single operation in the system —
+// readBlockStore calls it once per 4 KiB block of every guest read.
+func BenchmarkPersistedPointLookup(b *testing.B) {
+	for _, n := range extentCounts {
+		b.Run(fmt.Sprintf("extents=%d", n), func(b *testing.B) {
+			ubs := buildPersistedFixture(n, benchRunLen)
+			span := blockSpan(n, benchRunLen)
+			rng := rand.New(rand.NewPCG(1, 1))
+
+			// Draw the probe sequence up front so the RNG is not part of the
+			// measurement, and reuse it across iterations.
+			probes := make([]uint64, 1024)
+			for i := range probes {
+				probes[i] = rng.Uint64() % span
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; b.Loop(); i++ {
+				if _, ok := ubs.readPersisted(probes[i%len(probes)]); !ok {
+					b.Fatal("probe missed a block that must be present")
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkPersistedRandomOverwrite measures the write path: fracturing the
+// index for a one-block overwrite. The overwrite covers an existing extent
+// exactly, so the entry count stays constant across iterations and later
+// iterations measure the same index size as the first.
+func BenchmarkPersistedRandomOverwrite(b *testing.B) {
+	for _, n := range extentCounts {
+		b.Run(fmt.Sprintf("extents=%d", n), func(b *testing.B) {
+			ubs := buildPersistedFixture(n, benchRunLen)
+			rng := rand.New(rand.NewPCG(2, 2))
+
+			starts := make([]uint64, 1024)
+			for i := range starts {
+				starts[i] = uint64(rng.IntN(n)) * uint64(benchRunLen)
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; b.Loop(); i++ {
+				start := starts[i%len(starts)]
+				ubs.persistedMu.Lock()
+				ubs.fractureOverlapsLocked(start, benchRunLen)
+				ubs.persistedExtents.set(persistedExtent{
+					startBlock: start, numBlocks: benchRunLen,
+					stride: 4096, seqNums: make([]uint64, benchRunLen),
+				})
+				ubs.persistedMu.Unlock()
+			}
+		})
+	}
+}
+
+// BenchmarkPersistedRangeOverwrite fractures a multi-extent range, the shape a
+// large sequential write produces. It replaces the extents it spans with one
+// covering entry, so the index shrinks; the fixture is rebuilt periodically to
+// keep the measured size honest.
+func BenchmarkPersistedRangeOverwrite(b *testing.B) {
+	const spanExtents = 8
+	const resetEvery = 512
+
+	for _, n := range extentCounts {
+		b.Run(fmt.Sprintf("extents=%d", n), func(b *testing.B) {
+			ubs := buildPersistedFixture(n, benchRunLen)
+			rng := rand.New(rand.NewPCG(3, 3))
+			width := uint16(benchRunLen * spanExtents)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; b.Loop(); i++ {
+				if i > 0 && i%resetEvery == 0 {
+					b.StopTimer()
+					ubs = buildPersistedFixture(n, benchRunLen)
+					b.StartTimer()
+				}
+				start := uint64(rng.IntN(n-spanExtents)) * uint64(benchRunLen)
+				ubs.persistedMu.Lock()
+				ubs.fractureOverlapsLocked(start, width)
+				ubs.persistedExtents.set(persistedExtent{
+					startBlock: start, numBlocks: width,
+					stride: 4096, seqNums: make([]uint64, width),
+				})
+				ubs.persistedMu.Unlock()
+			}
+		})
+	}
+}
+
+// BenchmarkPersistedBulkLoad measures recovery: replaying a checkpoint through
+// SetPersistedRange. Capped well below the other sweeps because a linear
+// implementation makes this O(N^2) overall and 100k would not complete.
+func BenchmarkPersistedBulkLoad(b *testing.B) {
+	for _, n := range []int{1_000, 10_000} {
+		b.Run(fmt.Sprintf("extents=%d", n), func(b *testing.B) {
+			blocks := make([]uint64, benchRunLen)
+			seqNums := make([]uint64, benchRunLen)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				b.StopTimer()
+				ubs := NewUnifiedBlockStore(4096)
+				b.StartTimer()
+				for i := range n {
+					base := uint64(i) * uint64(benchRunLen)
+					for k := range blocks {
+						blocks[k] = base + uint64(k)
+					}
+					ubs.SetPersistedRange(blocks, uint64(i/64), 0, 4096, seqNums)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkBlockLookupResolve is BenchmarkPersistedPointLookup's counterpart on
+// the BlocksToObject index.
+func BenchmarkBlockLookupResolve(b *testing.B) {
+	for _, n := range extentCounts {
+		b.Run(fmt.Sprintf("extents=%d", n), func(b *testing.B) {
+			bt := buildBlockLookupFixture(n, benchRunLen)
+			span := blockSpan(n, benchRunLen)
+			rng := rand.New(rand.NewPCG(4, 4))
+
+			probes := make([]uint64, 1024)
+			for i := range probes {
+				probes[i] = rng.Uint64() % span
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; b.Loop(); i++ {
+				if _, _, ok := bt.resolveBlockLookup(probes[i%len(probes)]); !ok {
+					b.Fatal("probe missed a block that must be present")
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkBlockLookupInsertCoalesced measures insertCoalescedLocked, which
+// runs once per consecutive run per chunk upload under a global write lock —
+// so its cost is also the time every other writer and reader spends blocked.
+func BenchmarkBlockLookupInsertCoalesced(b *testing.B) {
+	for _, n := range extentCounts {
+		b.Run(fmt.Sprintf("extents=%d", n), func(b *testing.B) {
+			bt := buildBlockLookupFixture(n, benchRunLen)
+			rng := rand.New(rand.NewPCG(5, 5))
+
+			starts := make([]uint64, 1024)
+			for i := range starts {
+				starts[i] = uint64(rng.IntN(n)) * uint64(benchRunLen)
+			}
+			gcRefcount := make(map[uint64]uint64)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; b.Loop(); i++ {
+				start := starts[i%len(starts)]
+				bt.mu.Lock()
+				bt.insertCoalescedLocked(BlockLookup{
+					StartBlock: start,
+					NumBlocks:  benchRunLen,
+					SeqNums:    make([]uint64, benchRunLen),
+				}, 4096, gcRefcount)
+				bt.mu.Unlock()
+			}
+		})
+	}
+}

--- a/viperblock/extent_index_helpers_test.go
+++ b/viperblock/extent_index_helpers_test.go
@@ -1,0 +1,12 @@
+package viperblock
+
+// lookupMap materialises the block index as the flat map tests used to read
+// directly. Only for assertions -- production code walks the index in order.
+func lookupMap(b *BlocksToObject) map[uint64]BlockLookup {
+	out := make(map[uint64]BlockLookup, b.lookup.len())
+	b.lookup.scan(func(bl BlockLookup) bool {
+		out[bl.StartBlock] = bl
+		return true
+	})
+	return out
+}

--- a/viperblock/parse_checkpoint_test.go
+++ b/viperblock/parse_checkpoint_test.go
@@ -148,7 +148,7 @@ func TestParseBlockCheckpointBytesMatchesVBLoad(t *testing.T) {
 		// flat, so compare by physical block coverage rather than map shape.
 		stride := vb.blockStride()
 		wantTotal := 0
-		for _, entry := range vb.BlocksToObject.BlockLookup {
+		for _, entry := range lookupMap(&vb.BlocksToObject) {
 			wantTotal += int(entry.NumBlocks)
 			for i := range int(entry.NumBlocks) {
 				blockNum := entry.StartBlock + uint64(i)

--- a/viperblock/persisted_cache_test.go
+++ b/viperblock/persisted_cache_test.go
@@ -1,0 +1,172 @@
+package viperblock
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+
+	"github.com/mulgadc/viperblock/types"
+	"github.com/mulgadc/viperblock/viperblock/backends/file"
+	"github.com/stretchr/testify/require"
+)
+
+// readCountingBackend wraps a real backend and counts ranged chunk reads, so a
+// test can assert that a read was answered from the plaintext cache rather than from
+// storage. Only chunk reads are counted; state and checkpoint traffic is not
+// part of the guest read path.
+type readCountingBackend struct {
+	types.Backend
+
+	chunkReads atomic.Int64
+}
+
+func (b *readCountingBackend) ReadCtx(ctx context.Context, fileType types.FileType, objectID uint64, offset, length uint32) ([]byte, error) {
+	if fileType == types.FileTypeChunk {
+		b.chunkReads.Add(1)
+	}
+	return b.Backend.ReadCtx(ctx, fileType, objectID, offset, length)
+}
+
+func (b *readCountingBackend) Read(fileType types.FileType, objectID uint64, offset, length uint32) ([]byte, error) {
+	return b.ReadCtx(context.Background(), fileType, objectID, offset, length)
+}
+
+// newCachedVolume builds a file-backed volume with a real plaintext cache,
+// writes nBlocks of recognisable data and drains them to the backend, so every
+// block is Persisted with no in-memory copy left behind.
+func newCachedVolume(t *testing.T, volume string, cacheBlocks, nBlocks int) (*VB, *readCountingBackend, []byte) {
+	t.Helper()
+
+	root := t.TempDir()
+	const volSize = 8 * 1024 * 1024
+
+	vb, err := New(&VB{
+		VolumeName:          volume,
+		VolumeSize:          volSize,
+		BaseDir:             fmt.Sprintf("%s/viperblock", root),
+		WALSyncInterval:     -1,
+		ChunkUploadInterval: -1,
+		Cache:               Cache{Config: CacheConfig{Size: cacheBlocks}},
+	}, FileBackend, file.FileConfig{VolumeName: volume, VolumeSize: volSize, BaseDir: root})
+	require.NoError(t, err)
+	require.NoError(t, vb.Backend.Init())
+	require.NoError(t, vb.OpenWAL(&vb.WAL, fmt.Sprintf("%s/%s", vb.WAL.BaseDir,
+		types.GetFilePath(types.FileTypeWALChunk, vb.WAL.WallNum.Load(), vb.GetVolume()))))
+	require.NoError(t, vb.OpenWAL(&vb.BlockToObjectWAL, fmt.Sprintf("%s/%s", vb.BlockToObjectWAL.BaseDir,
+		types.GetFilePath(types.FileTypeWALBlock, vb.BlockToObjectWAL.WallNum.Load(), vb.GetVolume()))))
+
+	bs := int(vb.BlockSize)
+	payload := make([]byte, nBlocks*bs)
+	for i := range payload {
+		payload[i] = byte(i % 251)
+	}
+	require.NoError(t, vb.WriteAt(0, append([]byte(nil), payload...)))
+	require.NoError(t, vb.DrainToBackend())
+	dropInMemoryCopies(t, vb)
+
+	// Count only reads issued after the data is already durable.
+	counting := &readCountingBackend{Backend: vb.Backend}
+	vb.Backend = counting
+
+	return vb, counting, payload
+}
+
+// dropInMemoryCopies leaves the volume in the state a freshly reopened one
+// would be in -- blocks resolvable as Persisted from the checkpoint, with
+// nothing left in the write buffers or the block-store overlay to answer a read
+// from. It deliberately does not touch vb.Cache, which is what the tests below
+// are measuring.
+func dropInMemoryCopies(t *testing.T, vb *VB) {
+	t.Helper()
+	vb.BlockStore.Clear()
+	vb.Writes.mu.Lock()
+	vb.Writes.Blocks = nil
+	vb.Writes.mu.Unlock()
+	vb.PendingBackendWrites.mu.Lock()
+	vb.PendingBackendWrites.Blocks = nil
+	vb.PendingBackendWrites.mu.Unlock()
+	require.NoError(t, vb.LoadLiveCheckpoint())
+}
+
+// TestPersistedCache_SecondReadIssuesNoBackendRequest is the exit criterion for
+// the cache repair: before it, MarkPersistedRange deleted the per-block shard
+// entry that BlockStore.Cache() needed, so persisted data was never cached and
+// every read of it was a backend round trip.
+func TestPersistedCache_SecondReadIssuesNoBackendRequest(t *testing.T) {
+	const nBlocks = 8
+	vb, counting, payload := newCachedVolume(t, "vol-persisted-cache", 1024, nBlocks)
+	length := uint64(len(payload))
+
+	// Start from a cold cache. The chunk-upload path warms it (see
+	// TestPersistedCache_UploadWarmsCache), which would mask a read-path miss.
+	vb.Cache.purge()
+
+	first, err := vb.ReadAt(0, length)
+	require.NoError(t, err)
+	require.True(t, bytes.Equal(payload, first), "first read returned wrong data")
+
+	afterFirst := counting.chunkReads.Load()
+	require.Positive(t, afterFirst, "first read should have gone to the backend")
+
+	second, err := vb.ReadAt(0, length)
+	require.NoError(t, err)
+	require.True(t, bytes.Equal(payload, second), "second read returned wrong data")
+
+	require.Equal(t, afterFirst, counting.chunkReads.Load(),
+		"second read of persisted data must be served from cache without a backend request")
+}
+
+// TestPersistedCache_UploadWarmsCache pins the other half of the win: a block
+// is cached as it is uploaded, so data that was just written stays readable
+// without a backend round trip even after every in-memory write buffer is
+// dropped.
+func TestPersistedCache_UploadWarmsCache(t *testing.T) {
+	const nBlocks = 8
+	vb, counting, payload := newCachedVolume(t, "vol-persisted-cache-warm", 1024, nBlocks)
+
+	got, err := vb.ReadAt(0, uint64(len(payload)))
+	require.NoError(t, err)
+	require.True(t, bytes.Equal(payload, got), "read after upload returned wrong data")
+	require.Zero(t, counting.chunkReads.Load(),
+		"a block cached during upload must not be refetched")
+}
+
+// TestPersistedCache_StaleEntryIsNotServed pins the property that makes the
+// cache safe without write-path invalidation. Entries are tagged with the
+// sequence number they were cached under, so a copy that a re-persist has
+// superseded fails the tag check and is refetched rather than served. The stale
+// entry is planted directly because the upload path keeps the cache coherent on
+// its own -- the tag is the defence for the cases that do not go through it,
+// such as a volume reopened over data another instance has since rewritten.
+func TestPersistedCache_StaleEntryIsNotServed(t *testing.T) {
+	const nBlocks = 8
+	vb, counting, payload := newCachedVolume(t, "vol-persisted-cache-stale", 1024, nBlocks)
+	bs := uint64(vb.BlockSize)
+	length := uint64(len(payload))
+
+	entry, ok := vb.BlockStore.ReadEntry(3)
+	require.True(t, ok, "block 3 should be resolvable")
+
+	// Plant a copy of block 3 under a sequence number the index has moved past.
+	stale := make([]byte, bs)
+	for i := range stale {
+		stale[i] = 0xAB
+	}
+	vb.Cache.put(3, entry.SeqNum-1, stale)
+
+	before := counting.chunkReads.Load()
+
+	got, err := vb.ReadAt(0, length)
+	require.NoError(t, err)
+	require.True(t, bytes.Equal(payload[3*bs:4*bs], got[3*bs:4*bs]),
+		"a superseded cache entry was served instead of the current block")
+	require.Positive(t, counting.chunkReads.Load()-before,
+		"the superseded block should have been refetched from the backend")
+
+	for i := range uint64(nBlocks) {
+		require.True(t, bytes.Equal(payload[i*bs:(i+1)*bs], got[i*bs:(i+1)*bs]),
+			"block %d returned wrong data", i)
+	}
+}

--- a/viperblock/short_read_test.go
+++ b/viperblock/short_read_test.go
@@ -96,6 +96,7 @@ func TestShortBackendRead_IsRefusedNotZeroFilled(t *testing.T) {
 	// has to come from the backend.
 	trunc := &truncatingBackend{Backend: vb.Backend, trimChunk: objectID, trimBytes: 1024}
 	vb.Backend = trunc
+	vb.Cache.purge()
 	vb.BlockStore.Clear()
 	vb.Writes.mu.Lock()
 	vb.Writes.Blocks = nil

--- a/viperblock/snapshot.go
+++ b/viperblock/snapshot.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/mulgadc/viperblock/types"
+	"github.com/mulgadc/viperblock/utils"
 )
 
 // SnapshotState holds metadata for a frozen snapshot stored on the backend.
@@ -76,16 +77,7 @@ func (vb *VB) drainForSnapshot() error {
 	vb.drainMu.Lock()
 	defer vb.drainMu.Unlock()
 
-	// Writes.mu is taken inside drainMu, matching DrainToBackendCtx's order.
-	vb.Writes.mu.Lock()
-	var flushErr error
-	if vb.UseShardedWAL {
-		flushErr = vb.flushLockedSharded()
-	} else {
-		flushErr = vb.flushLocked()
-	}
-	vb.Writes.mu.Unlock()
-	if flushErr != nil {
+	if flushErr := vb.flushWrites(); flushErr != nil {
 		return fmt.Errorf("snapshot flush failed: %w", flushErr)
 	}
 
@@ -374,7 +366,7 @@ func (vb *VB) LoadSnapshotBlockMap(snapshotID string) (*BlocksToObject, Snapshot
 	}
 
 	// 6. Validate block count against metadata
-	if snap.BlockCount > 0 && uint64(baseMap.lookup.len()) != snap.BlockCount {
+	if snap.BlockCount > 0 && utils.SafeIntToUint64(baseMap.lookup.len()) != snap.BlockCount {
 		return nil, ident, fmt.Errorf("snapshot block count mismatch: metadata says %d, checkpoint has %d", snap.BlockCount, baseMap.lookup.len())
 	}
 

--- a/viperblock/snapshot.go
+++ b/viperblock/snapshot.go
@@ -154,12 +154,13 @@ func (vb *VB) CreateSnapshot(snapshotID string) (*SnapshotState, error) {
 	var blockCount uint64
 	checkpoint := vb.BlockToObjectWALHeader()
 	stride := vb.blockStride()
-	for _, block := range vb.BlocksToObject.BlockLookup {
+	vb.BlocksToObject.lookup.scan(func(block BlockLookup) bool {
 		blockCount += uint64(block.NumBlocks)
 		for _, single := range expandBlockLookup(block, stride) {
 			checkpoint = append(checkpoint, vb.writeBlockWalChunk(&single)...)
 		}
-	}
+		return true
+	})
 	vb.BlocksToObject.mu.RUnlock()
 
 	hasFlatSection := vb.BaseBlockMap != nil
@@ -359,9 +360,7 @@ func (vb *VB) LoadSnapshotBlockMap(snapshotID string) (*BlocksToObject, Snapshot
 	}
 
 	// 5. Deserialize own block lookup entries
-	baseMap := &BlocksToObject{
-		BlockLookup: make(map[uint64]BlockLookup),
-	}
+	baseMap := &BlocksToObject{}
 
 	offset := headerSize
 	end := headerSize + ownBlocksSize
@@ -370,13 +369,13 @@ func (vb *VB) LoadSnapshotBlockMap(snapshotID string) (*BlocksToObject, Snapshot
 		if err != nil {
 			return nil, ident, fmt.Errorf("failed to read snapshot block entry at offset %d: %w", offset, err)
 		}
-		baseMap.BlockLookup[block.StartBlock] = block
+		baseMap.lookup.set(block)
 		offset += blockWalChunkSize
 	}
 
 	// 6. Validate block count against metadata
-	if snap.BlockCount > 0 && uint64(len(baseMap.BlockLookup)) != snap.BlockCount {
-		return nil, ident, fmt.Errorf("snapshot block count mismatch: metadata says %d, checkpoint has %d", snap.BlockCount, len(baseMap.BlockLookup))
+	if snap.BlockCount > 0 && uint64(baseMap.lookup.len()) != snap.BlockCount {
+		return nil, ident, fmt.Errorf("snapshot block count mismatch: metadata says %d, checkpoint has %d", snap.BlockCount, baseMap.lookup.len())
 	}
 
 	// 7. Parse the flat inherited-blocks section if present
@@ -391,7 +390,7 @@ func (vb *VB) LoadSnapshotBlockMap(snapshotID string) (*BlocksToObject, Snapshot
 	vb.logger().Debug("LoadSnapshotBlockMap: loaded",
 		"snapshotID", snapshotID,
 		"sourceVolume", snap.SourceVolumeName,
-		"blocks", len(baseMap.BlockLookup),
+		"blocks", baseMap.lookup.len(),
 		"inheritedLayers", len(ident.InheritedLayers))
 
 	return baseMap, ident, nil
@@ -438,7 +437,7 @@ func (vb *VB) OpenFromSnapshot(snapshotID string) error {
 		"volume", vb.VolumeName,
 		"snapshotID", snapshotID,
 		"sourceVolume", ident.SourceVolumeName,
-		"baseBlocks", len(baseMap.BlockLookup),
+		"baseBlocks", baseMap.lookup.len(),
 		"ancestorLayers", len(vb.ancestors))
 
 	return nil
@@ -454,13 +453,13 @@ func (vb *VB) LookupBaseBlockToObject(block uint64) (uint64, uint32, uint64, err
 	}
 
 	vb.BaseBlockMap.mu.RLock()
-	lookup, ok := vb.BaseBlockMap.BlockLookup[block]
+	lookup, pos, ok := vb.BaseBlockMap.resolveBlockLookup(block)
 	vb.BaseBlockMap.mu.RUnlock()
 
 	if !ok {
 		return 0, 0, 0, ErrZeroBlock
 	}
-	return lookup.ObjectID, lookup.ObjectOffset, lookup.SeqNum, nil
+	return lookup.ObjectID, lookup.offsetAt(pos, vb.blockStride()), lookup.seqNumAt(pos), nil
 }
 
 // buildFlatSection serialises all inherited ancestor blocks into a binary
@@ -484,13 +483,14 @@ func (vb *VB) buildFlatSection() ([]byte, error) {
 	// not already covered by the volume's own delta. Own entries may be
 	// coalesced runs (NumBlocks > 1), so expand each entry's full range into
 	// the seen-set rather than just its map key (StartBlock).
-	seen := make(map[uint64]struct{}, len(vb.BlocksToObject.BlockLookup))
+	seen := make(map[uint64]struct{}, vb.BlocksToObject.lookup.len())
 	vb.BlocksToObject.mu.RLock()
-	for _, bl := range vb.BlocksToObject.BlockLookup {
+	vb.BlocksToObject.lookup.scan(func(bl BlockLookup) bool {
 		for i := uint16(0); i < bl.NumBlocks; i++ {
 			seen[bl.StartBlock+uint64(i)] = struct{}{}
 		}
-	}
+		return true
+	})
 	vb.BlocksToObject.mu.RUnlock()
 
 	// Collect layers in priority order: base map first, then deeper ancestors.
@@ -498,24 +498,26 @@ func (vb *VB) buildFlatSection() ([]byte, error) {
 
 	baseGroup := sourceGroup{name: vb.SourceVolumeName, uuid: vb.SourceVolumeUUID, nameHash: vb.sourceVolumeNameHash}
 	vb.BaseBlockMap.mu.RLock()
-	for k, v := range vb.BaseBlockMap.BlockLookup {
-		if _, exists := seen[k]; !exists {
+	vb.BaseBlockMap.lookup.scan(func(v BlockLookup) bool {
+		if _, exists := seen[v.StartBlock]; !exists {
 			baseGroup.blocks = append(baseGroup.blocks, v)
-			seen[k] = struct{}{}
+			seen[v.StartBlock] = struct{}{}
 		}
-	}
+		return true
+	})
 	vb.BaseBlockMap.mu.RUnlock()
 	sources = append(sources, baseGroup)
 
 	for _, anc := range vb.ancestors {
 		g := sourceGroup{name: anc.sourceVolumeName, uuid: anc.sourceVolumeUUID, nameHash: anc.sourceVolumeNameHash}
 		anc.blocks.mu.RLock()
-		for k, v := range anc.blocks.BlockLookup {
-			if _, exists := seen[k]; !exists {
+		anc.blocks.lookup.scan(func(v BlockLookup) bool {
+			if _, exists := seen[v.StartBlock]; !exists {
 				g.blocks = append(g.blocks, v)
-				seen[k] = struct{}{}
+				seen[v.StartBlock] = struct{}{}
 			}
-		}
+			return true
+		})
 		anc.blocks.mu.RUnlock()
 		sources = append(sources, g)
 	}
@@ -588,7 +590,7 @@ func parseFlatSection(data []byte) ([]InheritedLayer, error) {
 		numBlocks := int(binary.BigEndian.Uint32(data[offset : offset+4]))
 		offset += 4
 
-		bm := &BlocksToObject{BlockLookup: make(map[uint64]BlockLookup, numBlocks)}
+		bm := &BlocksToObject{}
 		// Reuse a zero-value VB just to call readBlockWalChunk (pure function on data).
 		var tmp VB
 		for j := range numBlocks {
@@ -599,7 +601,7 @@ func parseFlatSection(data []byte) ([]InheritedLayer, error) {
 			if err != nil {
 				return nil, fmt.Errorf("flat section: source %d: block %d: %w", i, j, err)
 			}
-			bm.BlockLookup[block.StartBlock] = block
+			bm.lookup.set(block)
 			offset += blockWalChunkSize
 		}
 		layers = append(layers, InheritedLayer{

--- a/viperblock/snapshot_characterisation_test.go
+++ b/viperblock/snapshot_characterisation_test.go
@@ -92,9 +92,7 @@ func TestCreateSnapshot_NonOwningPath_MissesWritesDurableAfterLoad(t *testing.T)
 		BlockToObjectWAL: WAL{
 			WALMagic: owner.BlockToObjectWAL.WALMagic,
 		},
-		BlocksToObject: BlocksToObject{
-			BlockLookup: make(map[uint64]BlockLookup),
-		},
+		BlocksToObject: BlocksToObject{},
 	}
 	require.NoError(t, reader.LoadLiveCheckpoint())
 	require.False(t, reader.ownsWAL(), "reader must not own the WAL -- this is the path under test")
@@ -155,10 +153,10 @@ func TestCreateSnapshot_OwningPath_ObjectNumAtLeastReferencedChunks(t *testing.T
 
 		baseMap, _, err := vb.LoadSnapshotBlockMap(snapshotID)
 		require.NoError(t, err)
-		require.NotEmpty(t, baseMap.BlockLookup)
+		require.NotEmpty(t, lookupMap(baseMap))
 
 		var maxReferenced uint64
-		for _, bl := range baseMap.BlockLookup {
+		for _, bl := range lookupMap(baseMap) {
 			if bl.ObjectID > maxReferenced {
 				maxReferenced = bl.ObjectID
 			}

--- a/viperblock/snapshot_test.go
+++ b/viperblock/snapshot_test.go
@@ -3,7 +3,6 @@ package viperblock
 import (
 	"crypto/rand"
 	"fmt"
-	"maps"
 	"os"
 	"path/filepath"
 	"sort"
@@ -52,17 +51,17 @@ func TestCreateSnapshot(t *testing.T) {
 		// map stays flat, so compare by physical block coverage.
 		stride := vb.blockStride()
 		wantBlocks := 0
-		for _, lookup := range vb.BlocksToObject.BlockLookup {
+		for _, lookup := range lookupMap(&vb.BlocksToObject) {
 			wantBlocks += int(lookup.NumBlocks)
 			for i := range int(lookup.NumBlocks) {
 				block := lookup.StartBlock + uint64(i)
-				baseLookup, ok := baseMap.BlockLookup[block]
+				baseLookup, ok := lookupMap(baseMap)[block]
 				assert.True(t, ok, "block %d missing from snapshot", block)
 				assert.Equal(t, lookup.ObjectID, baseLookup.ObjectID)
 				assert.Equal(t, lookup.offsetAt(i, stride), baseLookup.ObjectOffset)
 			}
 		}
-		assert.Len(t, baseMap.BlockLookup, wantBlocks)
+		assert.Equal(t, baseMap.lookup.len(), wantBlocks)
 	})
 }
 
@@ -271,25 +270,26 @@ func TestSnapshotWithUnopenedShardedWAL(t *testing.T) {
 		// Create a second VB that loads state but does NOT open WAL files
 		// (simulates viperblockd's snapshot VB)
 		snapshotVB := &VB{
-			VolumeName:    vb.VolumeName,
-			VolumeSize:    vb.VolumeSize,
-			BlockSize:     vb.BlockSize,
-			ObjBlockSize:  vb.ObjBlockSize,
-			Version:       vb.Version,
-			BaseDir:       vb.BaseDir,
-			UseShardedWAL: true,
-			ShardedWAL:    NewShardedWAL(vb.BaseDir, vb.WAL.WALMagic),
-			Backend:       vb.Backend,
-			ChunkMagic:    vb.ChunkMagic,
-			BlocksToObject: BlocksToObject{
-				BlockLookup: make(map[uint64]BlockLookup),
-			},
-			BlockStore:    NewUnifiedBlockStore(vb.BlockSize),
-			UseBlockStore: true,
+			VolumeName:     vb.VolumeName,
+			VolumeSize:     vb.VolumeSize,
+			BlockSize:      vb.BlockSize,
+			ObjBlockSize:   vb.ObjBlockSize,
+			Version:        vb.Version,
+			BaseDir:        vb.BaseDir,
+			UseShardedWAL:  true,
+			ShardedWAL:     NewShardedWAL(vb.BaseDir, vb.WAL.WALMagic),
+			Backend:        vb.Backend,
+			ChunkMagic:     vb.ChunkMagic,
+			BlocksToObject: BlocksToObject{},
+			BlockStore:     NewUnifiedBlockStore(vb.BlockSize),
+			UseBlockStore:  true,
 		}
 		// Copy block-to-object map (simulates LoadState + LoadBlockState)
 		vb.BlocksToObject.mu.RLock()
-		maps.Copy(snapshotVB.BlocksToObject.BlockLookup, vb.BlocksToObject.BlockLookup)
+		vb.BlocksToObject.lookup.scan(func(bl BlockLookup) bool {
+			snapshotVB.BlocksToObject.lookup.set(bl)
+			return true
+		})
 		vb.BlocksToObject.mu.RUnlock()
 		snapshotVB.SeqNum.Store(vb.SeqNum.Load())
 		snapshotVB.ObjectNum.Store(vb.ObjectNum.Load())
@@ -507,11 +507,11 @@ func TestFlatSectionBinaryRoundtrip(t *testing.T) {
 		// section stays flat, so compare by physical block coverage.
 		stride := vb.blockStride()
 		wantBlocks := 0
-		for _, want := range vb.BlocksToObject.BlockLookup {
+		for _, want := range lookupMap(&vb.BlocksToObject) {
 			wantBlocks += int(want.NumBlocks)
 			for i := range int(want.NumBlocks) {
 				blockNum := want.StartBlock + uint64(i)
-				got, ok := layers[0].Blocks.BlockLookup[blockNum]
+				got, ok := lookupMap(layers[0].Blocks)[blockNum]
 				assert.True(t, ok, "block %d missing from decoded flat section", blockNum)
 				if ok {
 					assert.Equal(t, want.ObjectID, got.ObjectID, "block %d ObjectID", blockNum)
@@ -520,7 +520,7 @@ func TestFlatSectionBinaryRoundtrip(t *testing.T) {
 				}
 			}
 		}
-		assert.Len(t, layers[0].Blocks.BlockLookup, wantBlocks, "decoded block count must match parent")
+		assert.Equal(t, layers[0].Blocks.lookup.len(), wantBlocks, "decoded block count must match parent")
 	})
 }
 
@@ -554,9 +554,7 @@ func TestLiveCheckpointFallback(t *testing.T) {
 			BlockToObjectWAL: WAL{
 				WALMagic: vb.BlockToObjectWAL.WALMagic,
 			},
-			BlocksToObject: BlocksToObject{
-				BlockLookup: make(map[uint64]BlockLookup),
-			},
+			BlocksToObject: BlocksToObject{},
 		}
 
 		// No live checkpoint exists: must fall back to LoadBlockState.
@@ -565,11 +563,11 @@ func TestLiveCheckpointFallback(t *testing.T) {
 		vb.BlocksToObject.mu.RLock()
 		defer vb.BlocksToObject.mu.RUnlock()
 
-		assert.Len(t, reader.BlocksToObject.BlockLookup, len(vb.BlocksToObject.BlockLookup),
+		assert.Equal(t, reader.BlocksToObject.lookup.len(), vb.BlocksToObject.lookup.len(),
 			"fallback must restore the full block map")
 
-		for blockNum, want := range vb.BlocksToObject.BlockLookup {
-			got, ok := reader.BlocksToObject.BlockLookup[blockNum]
+		for blockNum, want := range lookupMap(&vb.BlocksToObject) {
+			got, ok := lookupMap(&reader.BlocksToObject)[blockNum]
 			assert.True(t, ok, "block %d missing after fallback", blockNum)
 			if ok {
 				assert.Equal(t, want.ObjectID, got.ObjectID, "block %d ObjectID", blockNum)
@@ -615,9 +613,7 @@ func TestLiveCheckpointRoundtrip(t *testing.T) {
 			BlockToObjectWAL: WAL{
 				WALMagic: vb.BlockToObjectWAL.WALMagic,
 			},
-			BlocksToObject: BlocksToObject{
-				BlockLookup: make(map[uint64]BlockLookup),
-			},
+			BlocksToObject: BlocksToObject{},
 		}
 
 		require.NoError(t, reader.LoadLiveCheckpoint())
@@ -625,11 +621,11 @@ func TestLiveCheckpointRoundtrip(t *testing.T) {
 		vb.BlocksToObject.mu.RLock()
 		defer vb.BlocksToObject.mu.RUnlock()
 
-		assert.Len(t, reader.BlocksToObject.BlockLookup, len(vb.BlocksToObject.BlockLookup),
+		assert.Equal(t, reader.BlocksToObject.lookup.len(), vb.BlocksToObject.lookup.len(),
 			"live checkpoint must contain all written blocks")
 
-		for blockNum, want := range vb.BlocksToObject.BlockLookup {
-			got, ok := reader.BlocksToObject.BlockLookup[blockNum]
+		for blockNum, want := range lookupMap(&vb.BlocksToObject) {
+			got, ok := lookupMap(&reader.BlocksToObject)[blockNum]
 			assert.True(t, ok, "block %d missing from live checkpoint", blockNum)
 			if ok {
 				assert.Equal(t, want.ObjectID, got.ObjectID, "block %d: ObjectID mismatch", blockNum)
@@ -665,7 +661,7 @@ func TestObjectNumReconcileOnLoad(t *testing.T) {
 
 		var maxObjectID uint64
 		vb.BlocksToObject.mu.RLock()
-		for _, bl := range vb.BlocksToObject.BlockLookup {
+		for _, bl := range lookupMap(&vb.BlocksToObject) {
 			if bl.ObjectID > maxObjectID {
 				maxObjectID = bl.ObjectID
 			}
@@ -685,9 +681,7 @@ func TestObjectNumReconcileOnLoad(t *testing.T) {
 				BlockToObjectWAL: WAL{
 					WALMagic: vb.BlockToObjectWAL.WALMagic,
 				},
-				BlocksToObject: BlocksToObject{
-					BlockLookup: make(map[uint64]BlockLookup),
-				},
+				BlocksToObject: BlocksToObject{},
 			}
 		}
 
@@ -738,7 +732,7 @@ func TestRecoverLocalWALsNoChunkReuse(t *testing.T) {
 
 	var maxObjectID uint64
 	vb.BlocksToObject.mu.RLock()
-	for _, bl := range vb.BlocksToObject.BlockLookup {
+	for _, bl := range lookupMap(&vb.BlocksToObject) {
 		if bl.ObjectID > maxObjectID {
 			maxObjectID = bl.ObjectID
 		}

--- a/viperblock/snapshot_test.go
+++ b/viperblock/snapshot_test.go
@@ -61,7 +61,7 @@ func TestCreateSnapshot(t *testing.T) {
 				assert.Equal(t, lookup.offsetAt(i, stride), baseLookup.ObjectOffset)
 			}
 		}
-		assert.Equal(t, baseMap.lookup.len(), wantBlocks)
+		assert.Equal(t, wantBlocks, baseMap.lookup.len())
 	})
 }
 
@@ -520,7 +520,7 @@ func TestFlatSectionBinaryRoundtrip(t *testing.T) {
 				}
 			}
 		}
-		assert.Equal(t, layers[0].Blocks.lookup.len(), wantBlocks, "decoded block count must match parent")
+		assert.Equal(t, wantBlocks, layers[0].Blocks.lookup.len(), "decoded block count must match parent")
 	})
 }
 

--- a/viperblock/viperblock.go
+++ b/viperblock/viperblock.go
@@ -49,6 +49,11 @@ const DefaultChunkUploadInterval time.Duration = 30 * time.Second
 // bucket-wide scan (see ensureGCSnapshotSafe), and reclaiming is not urgent.
 const DefaultGCInterval time.Duration = 5 * time.Minute
 
+// DefaultCacheBlocks is the plaintext block cache size, in blocks, that a
+// caller gets if it asks for a cache without sizing one. 32768 x 4 KiB =
+// 128 MiB per volume, so a host packed with volumes should size it down.
+const DefaultCacheBlocks = 32768
+
 // DefaultCheckpointRetryBackoff is the first sleep between SaveLiveCheckpointCtx's
 // write attempts, doubling on each subsequent retry. Sized for a transient backend
 // blip rather than a hard outage: three attempts spend ~3s total before giving up.
@@ -70,6 +75,24 @@ const DefaultMaxPendingBytes uint64 = 256 * 1024 * 1024
 // backend reports nearfull pressure. 8 takes the default 256MB window to 32MB,
 // still well above the 4MB chunk size so drains stay chunk-sized.
 const nearFullPendingDivisor uint64 = 8
+
+// The backpressure budget is a bound on unflushed bytes, so it is meaningless
+// above what the WAL device can actually hold. The budget is clamped to
+// walFreeFraction of the free space, sampled at most once per
+// walFreeSampleInterval so a statfs never lands on a per-write path, and never
+// clamped below walMinPendingBytes -- at that point the drain is the only thing
+// that can help and starving it of headroom does not.
+const (
+	walFreeFraction       uint64 = 2
+	walMinPendingBytes    uint64 = 16 * 1024 * 1024
+	walFreeSampleInterval        = 5 * time.Second
+)
+
+// backpressureLowFraction sets the release point as a fraction of the
+// high-watermark. Releasing at half meant a writer that tripped backpressure
+// waited for 128 MiB to drain before it could proceed; the gap only has to be
+// wide enough to stop the writer re-tripping on its next write.
+const backpressureLowFraction uint64 = 4 // release at 3/4 of high
 
 // DefaultUploadWorkers bounds the parallel chunk-upload worker pool used by
 // WriteWALToChunkCtx / WriteShardedWALToChunkCtx. 1 means fully serial.
@@ -207,6 +230,11 @@ type VB struct {
 	// launching redundant drains. drainMu below is the real exclusion guarantee.
 	drainInFlight atomic.Bool
 
+	// Last sampled free space on the WAL device, and when it was taken, so
+	// maxPendingBytes can clamp without a statfs per call.
+	walFreeBytes     atomic.Uint64
+	walFreeSampledAt atomic.Int64
+
 	// backendFull latches when a drain reports the backend out of space, so
 	// WriteAtCtx can fail fast with ErrNoSpace up front. See
 	// DrainToBackendCtx's deferred handler for where it is set and cleared.
@@ -224,6 +252,11 @@ type VB struct {
 	// newer chunk's live pointer and let GC delete a still-referenced chunk.
 	// createChunkFile's SeqNum guard is a secondary defense, not a substitute.
 	drainMu sync.Mutex
+
+	// flushMu serialises flushWrites. Writes.mu used to do this implicitly by
+	// being held across the whole WAL write, which also blocked every guest
+	// write for its duration; this keeps flushes ordered without that.
+	flushMu sync.Mutex
 
 	// rmwLocks serialize each block's read-modify-write cycle in WriteAtCtx,
 	// sharded by block number. See writeOneBlockLocked.
@@ -460,10 +493,68 @@ type CacheConfig struct {
 	SystemMemoryPercent int
 }
 
+// cachedBlock is a plaintext copy of a block, tagged with the sequence number
+// it was read under. The tag is what lets the cache be safe without write-path
+// invalidation: an overwritten block is re-persisted under a higher sequence
+// number, so a stale entry fails the check at lookup and is treated as a miss
+// rather than served.
+type cachedBlock struct {
+	seqNum uint64
+	data   []byte
+}
+
+// Cache is a bounded plaintext block cache sitting beside the authoritative
+// block index, not inside it. Eviction drops cached data only; the persisted
+// location of a block always remains resolvable from the extent index.
 type Cache struct {
 	mu     sync.RWMutex
-	lru    *lru.Cache[uint64, []byte]
+	lru    *lru.Cache[uint64, cachedBlock]
 	Config CacheConfig
+}
+
+// get returns the cached plaintext for a block only if it was cached under the
+// sequence number the caller resolved, so a superseded copy is never served.
+func (c *Cache) get(block, seqNum uint64) ([]byte, bool) {
+	if c.Config.Size == 0 {
+		return nil, false
+	}
+	cb, ok := c.lru.Get(block)
+	if !ok || cb.seqNum != seqNum {
+		return nil, false
+	}
+	return cb.data, true
+}
+
+// purge drops every cached block. The authoritative index is untouched: every
+// block stays resolvable from its persisted location.
+func (c *Cache) purge() {
+	if c.lru != nil {
+		c.lru.Purge()
+	}
+}
+
+// cacheFetched stores the plaintext of every block that was just fetched from a
+// backend. It takes the per-block request records rather than caching from
+// inside the fetch helpers, because those coalesce blocks into runs carrying a
+// single SeqNum -- the wrong granularity to tag a cache entry with.
+func (vb *VB) cacheFetched(data []byte, runs ...ConsecutiveBlocks) {
+	if vb.Cache.Config.Size == 0 {
+		return
+	}
+	for _, cbs := range runs {
+		for _, cb := range cbs {
+			vb.Cache.put(cb.StartBlock, cb.SeqNum, data[cb.OffsetStart:cb.OffsetEnd])
+		}
+	}
+}
+
+// put stores a copy of data. The caller's buffer is cloned because it is
+// usually a window into a larger read buffer that it will keep writing to.
+func (c *Cache) put(block, seqNum uint64, data []byte) {
+	if c.Config.Size == 0 {
+		return
+	}
+	c.lru.Add(block, cachedBlock{seqNum: seqNum, data: bytes.Clone(data)})
 }
 
 type ObjectMap struct {
@@ -955,7 +1046,7 @@ func (vb *VB) SetCacheSize(size int, percentage int) error {
 	defer vb.Cache.mu.Unlock()
 
 	// Create new LRU cache with specified size
-	newCache, err := lru.New[uint64, []byte](size)
+	newCache, err := lru.New[uint64, cachedBlock](size)
 	if err != nil {
 		return fmt.Errorf("failed to create new LRU cache: %w", err)
 	}
@@ -1081,17 +1172,16 @@ func New(config *VB, btype string, backendConfig any) (vb *VB, err error) {
 		config.GCInterval = DefaultGCInterval
 	}
 
-	var lruCache *lru.Cache[uint64, []byte]
+	var lruCache *lru.Cache[uint64, cachedBlock]
 
 	if config.Cache.Config.Size == 0 {
-		//config.Cache.Config.Size = calculateCacheSize(config.BlockSize, 30)
-		//config.Cache.Config.UseSystemMemory = true
-		//config.Cache.Config.SystemMemoryPercent = 30
+		// Size 0 is the established "no cache" request; callers that want one
+		// set it explicitly (spinifex passes DefaultCacheBlocks).
 		config.Cache.Config.UseSystemMemory = false
 		config.Cache.Config.SystemMemoryPercent = 0
 	} else {
 		// Create LRU cache with calculated size
-		lruCache, err = lru.New[uint64, []byte](config.Cache.Config.Size)
+		lruCache, err = lru.New[uint64, cachedBlock](config.Cache.Config.Size)
 		if err != nil {
 			panic(fmt.Sprintf("failed to create LRU cache: %v", err))
 		}
@@ -1695,7 +1785,28 @@ func (vb *VB) maxPendingBytes() uint64 {
 	if vb.isBackendNearFull() {
 		high /= nearFullPendingDivisor
 	}
+	if free := vb.walFreeBytesSampled(); free > 0 {
+		high = min(high, max(free/walFreeFraction, walMinPendingBytes))
+	}
 	return high
+}
+
+// walFreeBytesSampled returns the cached free space on the WAL device,
+// refreshing it at most once per walFreeSampleInterval. A refresh that races
+// with another caller yields to it and returns the previous sample rather than
+// issuing a second statfs.
+func (vb *VB) walFreeBytesSampled() uint64 {
+	now := time.Now().UnixNano()
+	last := vb.walFreeSampledAt.Load()
+	if now-last < int64(walFreeSampleInterval) {
+		return vb.walFreeBytes.Load()
+	}
+	if !vb.walFreeSampledAt.CompareAndSwap(last, now) {
+		return vb.walFreeBytes.Load()
+	}
+	free := walDeviceFreeBytes(vb.WAL.BaseDir)
+	vb.walFreeBytes.Store(free)
+	return free
 }
 
 // checkpointBackoff returns the configured first retry sleep, or the default if
@@ -1735,9 +1846,9 @@ func (vb *VB) signalSizeTrigger() {
 	}
 }
 
-// awaitBackpressure blocks the caller once pendingBytes has crossed
-// MaxPendingBytes, driving DrainToBackendCtx synchronously until pendingBytes
-// falls back under the low-watermark (MaxPendingBytes/2). This is the core
+// awaitBackpressure blocks the caller once pendingBytes has crossed the
+// high-watermark, driving DrainToBackendCtx synchronously until pendingBytes
+// falls back under the low-watermark (3/4 of it). This is the core
 // backpressure mechanism: a guest write that outruns the backend's ingest
 // rate self-throttles here instead of growing Writes.Blocks /
 // PendingBackendWrites.Blocks without bound.
@@ -1758,9 +1869,11 @@ func (vb *VB) awaitBackpressure(ctx context.Context) error {
 		return nil
 	}
 
-	low := high / 2
+	low := high - high/backpressureLowFraction
 	backoff := 10 * time.Millisecond
-	const maxBackoff = 500 * time.Millisecond
+	// The loop re-checks pendingBytes on every wake, so a long backoff only
+	// adds latency after the drain that unblocked the writer has finished.
+	const maxBackoff = 50 * time.Millisecond
 
 	// Bound consecutive non-ErrNoSpace drain failures so a persistently
 	// failing drain doesn't spin here forever; a single success resets the
@@ -2144,15 +2257,55 @@ func (vb *VB) Flush() (err error) {
 	return vb.syncWAL()
 }
 
-// flushWrites moves buffered blocks into the WAL file under Writes.mu, with
-// no fsync of its own.
+// flushWrites moves buffered blocks into the WAL file, with no fsync of its
+// own. Writes.mu is held only to snapshot the buffer and, later, to retire the
+// blocks that landed -- not across the WAL write itself, which would block
+// every guest write for the duration of a disk write.
 func (vb *VB) flushWrites() error {
+	vb.flushMu.Lock()
+	defer vb.flushMu.Unlock()
+
 	vb.Writes.mu.Lock()
-	defer vb.Writes.mu.Unlock()
-	if vb.UseShardedWAL {
-		return vb.flushLockedSharded()
+	flushBlocks := make([]Block, len(vb.Writes.Blocks))
+	copy(flushBlocks, vb.Writes.Blocks)
+	vb.Writes.mu.Unlock()
+
+	if len(flushBlocks) == 0 {
+		return nil
 	}
-	return vb.flushLocked()
+	if vb.UseShardedWAL {
+		return vb.flushSnapshotSharded(flushBlocks)
+	}
+	return vb.flushSnapshot(flushBlocks)
+}
+
+// retireFlushed removes from the write buffer every block the WAL now holds,
+// and hands them to PendingBackendWrites. A block is kept if it was rewritten
+// while the WAL write was in progress -- flushed records the SeqNum that
+// landed, so a strictly newer one in the buffer has not been written yet and
+// must survive to the next flush.
+func (vb *VB) retireFlushed(flushBlocks []Block, flushed map[uint64]uint64) {
+	if len(flushed) == 0 {
+		return
+	}
+
+	vb.Writes.mu.Lock()
+	remaining := make([]Block, 0, len(vb.Writes.Blocks))
+	for _, b := range vb.Writes.Blocks {
+		if seq, ok := flushed[b.Block]; !ok || b.SeqNum > seq {
+			remaining = append(remaining, b)
+		}
+	}
+	vb.Writes.Blocks = remaining
+	vb.Writes.mu.Unlock()
+
+	vb.PendingBackendWrites.mu.Lock()
+	for _, b := range flushBlocks {
+		if _, ok := flushed[b.Block]; ok {
+			vb.PendingBackendWrites.Blocks = append(vb.PendingBackendWrites.Blocks, b)
+		}
+	}
+	vb.PendingBackendWrites.mu.Unlock()
 }
 
 // DrainToBackend flushes all in-memory writes to the WAL, uploads accumulated
@@ -2208,11 +2361,9 @@ func (vb *VB) DrainToBackendCtx(ctx context.Context) (err error) {
 	return nil
 }
 
-// flushLocked flushes hot writes to WAL. Caller must hold vb.Writes.mu.Lock().
-func (vb *VB) flushLocked() error {
-	flushBlocks := make([]Block, len(vb.Writes.Blocks))
-	copy(flushBlocks, vb.Writes.Blocks)
-
+// flushSnapshot flushes a snapshot of the hot writes to the WAL. It does not
+// hold Writes.mu; the caller serialises flushes via flushMu.
+func (vb *VB) flushSnapshot(flushBlocks []Block) error {
 	// flushed maps block number -> latest SeqNum that landed in the WAL,
 	// used to filter vb.Writes.Blocks and feed PendingBackendWrites. It
 	// dedupes by block number, so its cardinality CANNOT be used to detect
@@ -2231,32 +2382,15 @@ func (vb *VB) flushLocked() error {
 		successCount++
 		flushed[block.Block] = block.SeqNum
 
-		// Mark block as Pending in BlockStore (Hot -> Pending transition)
+		// Mark block as Pending in BlockStore (Hot -> Pending transition).
+		// Keyed on SeqNum: without Writes.mu held, the block may have been
+		// rewritten since the snapshot, and that newer data is not in the WAL.
 		if vb.UseBlockStore && vb.BlockStore != nil {
-			vb.BlockStore.MarkPending(block.Block)
+			vb.BlockStore.MarkPending(block.Block, block.SeqNum)
 		}
 	}
 
-	// Filter vb.Writes.Blocks to keep only blocks NOT successfully flushed
-	if len(flushed) > 0 {
-		remaining := make([]Block, 0)
-		for _, b := range vb.Writes.Blocks {
-			if _, ok := flushed[b.Block]; !ok {
-				remaining = append(remaining, b)
-			}
-		}
-
-		vb.Writes.Blocks = remaining
-	}
-
-	// Append only successfully flushed blocks to PendingBackendWrites
-	vb.PendingBackendWrites.mu.Lock()
-	for _, b := range flushBlocks {
-		if _, ok := flushed[b.Block]; ok {
-			vb.PendingBackendWrites.Blocks = append(vb.PendingBackendWrites.Blocks, b)
-		}
-	}
-	vb.PendingBackendWrites.mu.Unlock()
+	vb.retireFlushed(flushBlocks, flushed)
 
 	if successCount < len(flushBlocks) {
 		return fmt.Errorf("partial flush: %d of %d records flushed", successCount, len(flushBlocks))
@@ -2265,17 +2399,10 @@ func (vb *VB) flushLocked() error {
 	return nil
 }
 
-// flushLockedSharded flushes hot writes to the sharded WAL in parallel.
-// Blocks are grouped by shard and written concurrently — one goroutine per shard.
-// Caller must hold vb.Writes.mu.Lock().
-func (vb *VB) flushLockedSharded() error {
-	flushBlocks := make([]Block, len(vb.Writes.Blocks))
-	copy(flushBlocks, vb.Writes.Blocks)
-
-	if len(flushBlocks) == 0 {
-		return nil
-	}
-
+// flushSnapshotSharded flushes a snapshot of the hot writes to the sharded WAL
+// in parallel, one goroutine per shard. It does not hold Writes.mu; the caller
+// serialises flushes via flushMu.
+func (vb *VB) flushSnapshotSharded(flushBlocks []Block) error {
 	// Group blocks by shard
 	var shardGroups [NumShards][]Block
 	for _, block := range flushBlocks {
@@ -2314,7 +2441,7 @@ func (vb *VB) flushLockedSharded() error {
 				flushed[block.Block] = block.SeqNum
 
 				if vb.UseBlockStore && vb.BlockStore != nil {
-					vb.BlockStore.MarkPending(block.Block)
+					vb.BlockStore.MarkPending(block.Block, block.SeqNum)
 				}
 			}
 			results[shardID].flushed = flushed
@@ -2337,25 +2464,7 @@ func (vb *VB) flushLockedSharded() error {
 		}
 	}
 
-	// Filter vb.Writes.Blocks to keep only blocks NOT successfully flushed
-	if len(allFlushed) > 0 {
-		remaining := make([]Block, 0)
-		for _, b := range vb.Writes.Blocks {
-			if _, ok := allFlushed[b.Block]; !ok {
-				remaining = append(remaining, b)
-			}
-		}
-		vb.Writes.Blocks = remaining
-	}
-
-	// Append successfully flushed blocks to PendingBackendWrites
-	vb.PendingBackendWrites.mu.Lock()
-	for _, b := range flushBlocks {
-		if _, ok := allFlushed[b.Block]; ok {
-			vb.PendingBackendWrites.Blocks = append(vb.PendingBackendWrites.Blocks, b)
-		}
-	}
-	vb.PendingBackendWrites.mu.Unlock()
+	vb.retireFlushed(flushBlocks, allFlushed)
 
 	if firstErr != nil {
 		return fmt.Errorf("partial sharded flush: %d of %d records flushed: %w", totalSuccess, len(flushBlocks), firstErr)
@@ -3380,9 +3489,7 @@ func (vb *VB) createChunkFile(ctx context.Context, currentWALNum uint64, chunkBu
 			n++
 		} else {
 			// Block was successfully written to backend, update cache
-			if vb.Cache.Config.Size > 0 {
-				vb.Cache.lru.Add(block.Block, block.Data)
-			}
+			vb.Cache.put(block.Block, block.SeqNum, block.Data)
 			freedBytes += int64(len(block.Data))
 		}
 	}
@@ -5277,17 +5384,11 @@ func (vb *VB) read(ctx context.Context, block uint64, blockLen uint64) (data []b
 			continue
 		}
 
-		// Next query the LRU cache if the data does not exist in the HOT write path, or pending write buffer.
-		if vb.Cache.Config.Size > 0 {
-			if cachedData, ok := vb.Cache.lru.Get(currentBlock); ok {
-				//vb.logger().Info("[READ] LRU CACHE BLOCK:", "block", currentBlock)
-
-				copy(data[start:end], cachedData)
-				continue
-			}
-		}
-
-		// Next, fetch which object and offset the block is within
+		// Next, fetch which object and offset the block is within. This is
+		// resolved before consulting the cache, not after, because the cache
+		// is validated against the block's current sequence number -- without
+		// it a block that was overwritten and re-persisted would be served
+		// from its stale cached copy.
 		objectID, objectOffset, seqNum, err := vb.LookupBlockToObject(currentBlock)
 		if err != nil {
 			if !errors.Is(err, ErrZeroBlock) {
@@ -5343,6 +5444,11 @@ func (vb *VB) read(ctx context.Context, block uint64, blockLen uint64) (data []b
 
 		vb.logger().Debug("[READ] OBJECT ID:", "objectID", objectID, "objectOffset", objectOffset)
 
+		if cachedData, ok := vb.Cache.get(currentBlock, seqNum); ok {
+			copy(data[start:end], cachedData)
+			continue
+		}
+
 		consecutiveBlocks = append(consecutiveBlocks, ConsecutiveBlock{
 			BlockPosition: i,
 			StartBlock:    currentBlock,
@@ -5358,29 +5464,19 @@ func (vb *VB) read(ctx context.Context, block uint64, blockLen uint64) (data []b
 	// Loop through all consecutive blocks that are required to fetch from the backend
 	var consecutiveBlocksToRead ConsecutiveBlocks
 
-	// Store which consecutive blocks we have already read - pre-allocate
-	consecutiveBlocksRead := make(map[uint64]bool, len(consecutiveBlocks))
-
-	for i := 0; i < len(consecutiveBlocks); i++ {
+	for i := 0; i < len(consecutiveBlocks); {
 		vb.logger().Debug("[READ] CONSECUTIVE BLOCK:", "startBlock", consecutiveBlocks[i].StartBlock, "numBlocks", consecutiveBlocks[i].NumBlocks, "offsetStart", consecutiveBlocks[i].OffsetStart, "offsetEnd", consecutiveBlocks[i].OffsetEnd, "objectID", consecutiveBlocks[i].ObjectID, "objectOffset", consecutiveBlocks[i].ObjectOffset)
 
-		// Skip if this blocks belongs to a previous consecutive block
-		if _, ok := consecutiveBlocksRead[consecutiveBlocks[i].StartBlock]; ok {
-			vb.logger().Debug("[READ] SKIPPING CONSECUTIVE BLOCK READ:", "startBlock", consecutiveBlocks[i].StartBlock)
-			continue
+		// Extend the run while blocks stay contiguous within one chunk, then
+		// resume from its end. Advancing the index is what stops an absorbed
+		// block starting a run of its own, so no seen-set is needed.
+		j := i + 1
+		for j < len(consecutiveBlocks) &&
+			consecutiveBlocks[j].StartBlock == consecutiveBlocks[j-1].StartBlock+1 &&
+			consecutiveBlocks[j].ObjectID == consecutiveBlocks[j-1].ObjectID {
+			j++
 		}
-
-		// Find out how many consecutive blocks there are
-		numBlocks := 1
-		for j := i + 1; j < len(consecutiveBlocks); j++ {
-			// If our StartBlock is consecutive, and the ObjectID is the same, then we have a consecutive block to read from our backend
-			if (consecutiveBlocks[j].StartBlock == consecutiveBlocks[j-1].StartBlock+1) && (consecutiveBlocks)[j].ObjectID == (consecutiveBlocks)[j-1].ObjectID {
-				numBlocks++
-				consecutiveBlocksRead[consecutiveBlocks[j].StartBlock] = true
-			} else {
-				break
-			}
-		}
+		numBlocks := j - i
 
 		// Carry per-block SeqNums for the run so the encrypted decrypt loop
 		// below can reconstruct each block's nonce + AAD. Unused on
@@ -5388,7 +5484,7 @@ func (vb *VB) read(ctx context.Context, block uint64, blockLen uint64) (data []b
 		var seqNums []uint64
 		if vb.EncryptionEnabled {
 			seqNums = make([]uint64, numBlocks)
-			for k := 0; k < numBlocks; k++ {
+			for k := range numBlocks {
 				seqNums[k] = consecutiveBlocks[i+k].SeqNum
 			}
 		}
@@ -5403,6 +5499,7 @@ func (vb *VB) read(ctx context.Context, block uint64, blockLen uint64) (data []b
 			ObjectOffset:  consecutiveBlocks[i].ObjectOffset,
 			SeqNums:       seqNums,
 		})
+		i = j
 	}
 
 	// Per-block on-disk stride: encrypted chunks add a 16-byte GCM tag after
@@ -5450,14 +5547,6 @@ func (vb *VB) read(ctx context.Context, block uint64, blockLen uint64) (data []b
 			}
 			copy(data[start:end], blockData)
 		}
-
-		// Update the cache with the read data
-		if vb.Cache.Config.Size > 0 {
-			for i := uint64(0); i < uint64(cb.NumBlocks); i++ {
-				currentBlock := cb.StartBlock + i
-				vb.Cache.lru.Add(currentBlock, bytes.Clone(data[start+i*uint64(vb.BlockSize):start+(i+1)*uint64(vb.BlockSize)]))
-			}
-		}
 	}
 
 	// Fetch blocks from the source volume's backend (snapshot fallback)
@@ -5477,6 +5566,9 @@ func (vb *VB) read(ctx context.Context, block uint64, blockLen uint64) (data []b
 			return nil, err
 		}
 	}
+
+	vb.cacheFetched(data, consecutiveBlocks, baseConsecutiveBlocks)
+	vb.cacheFetched(data, ancestorConsBlocks...)
 
 	return data, zeroBlockErr
 }
@@ -5680,9 +5772,7 @@ func (vb *VB) Reset() error {
 
 	vb.pendingBytes.Store(0)
 
-	if vb.Cache.lru != nil {
-		vb.Cache.lru.Purge()
-	}
+	vb.Cache.purge()
 
 	// Reset BlockStore if enabled
 	if vb.BlockStore != nil {
@@ -5819,20 +5909,29 @@ func (vb *VB) readBlockStore(ctx context.Context, block uint64, blockLen uint64)
 	var baseConsecutiveBlocks ConsecutiveBlocks
 	ancestorConsBlocks := make([]ConsecutiveBlocks, len(vb.ancestors))
 
+	// Resolve the whole request against the block store in one call. A single
+	// atomically-captured snapshot per block (state + data + persisted
+	// location together) -- NOT ReadSingle followed by a separate ReadBlock
+	// call, which would leave a window for a concurrent rewrite to change the
+	// entry between the two reads and hand back a torn (stale-state,
+	// fresh-location) pair. See ReadEntryRun's doc comment.
+	entries := make([]BlockEntry, blockRequests)
+	resolved := make([]bool, blockRequests)
+	vb.BlockStore.ReadEntryRun(block, blockRequests, entries, resolved)
+
+	// Ancestor layers are probed under one lock each rather than one lock per
+	// block per ancestor, which on a 1 MiB read with two ancestors was 512
+	// acquisitions.
+	ancestorLocked := false
+
 	for i := range blockRequests {
 		currentBlock := block + i
 		start := i * uint64(vb.BlockSize)
 		end := start + uint64(vb.BlockSize)
 
-		// O(1) lookup using BlockStore. A single atomically-captured snapshot
-		// (state + data + persisted location together) — NOT ReadSingle
-		// followed by a separate ReadBlock call, which would leave a window
-		// for a concurrent rewrite to change the entry between the two reads
-		// and hand back a torn (stale-state, fresh-location) pair. See
-		// ReadEntry's doc comment.
-		entry, exists := vb.BlockStore.ReadEntry(currentBlock)
+		entry := entries[i]
 		state := entry.State
-		if !exists {
+		if !resolved[i] {
 			state = BlockStateEmpty
 		}
 
@@ -5843,6 +5942,14 @@ func (vb *VB) readBlockStore(ctx context.Context, block uint64, blockLen uint64)
 			copy(data[start:end], entry.Data)
 
 		case BlockStatePersisted:
+			// The index resolved a location; the plaintext may still be in the
+			// bounded cache, in which case no backend round trip is needed.
+			if cachedData, ok := vb.Cache.get(currentBlock, entry.SeqNum); ok {
+				telemetry.RecordCacheLookup(ctx, true)
+				copy(data[start:end], cachedData)
+				continue
+			}
+
 			// Need to fetch from backend: a cache miss.
 			telemetry.RecordCacheLookup(ctx, false)
 
@@ -5875,12 +5982,16 @@ func (vb *VB) readBlockStore(ctx context.Context, block uint64, blockLen uint64)
 					continue
 				}
 			}
-			// Base map miss — check ancestor layers
+			// Base map miss -- check ancestor layers
+			if !ancestorLocked && len(vb.ancestors) > 0 {
+				for ai := range vb.ancestors {
+					vb.ancestors[ai].blocks.mu.RLock()
+				}
+				ancestorLocked = true
+			}
 			ancFound := false
 			for ai := range vb.ancestors {
-				vb.ancestors[ai].blocks.mu.RLock()
 				lookup, pos, ok := vb.ancestors[ai].blocks.resolveBlockLookup(currentBlock)
-				vb.ancestors[ai].blocks.mu.RUnlock()
 				if ok {
 					ancestorConsBlocks[ai] = append(ancestorConsBlocks[ai], ConsecutiveBlock{
 						BlockPosition: i,
@@ -5899,9 +6010,15 @@ func (vb *VB) readBlockStore(ctx context.Context, block uint64, blockLen uint64)
 			if ancFound {
 				continue
 			}
-			// ReadEntry's !exists / default-state paths both correspond to
-			// "no own-volume, base-map, or ancestor data for this block".
+			// ReadEntryRun's unresolved blocks correspond to "no own-volume,
+			// base-map, or ancestor data for this block".
 			zeroBlockErr = ErrZeroBlock
+		}
+	}
+
+	if ancestorLocked {
+		for ai := range vb.ancestors {
+			vb.ancestors[ai].blocks.mu.RUnlock()
 		}
 	}
 
@@ -5931,6 +6048,9 @@ func (vb *VB) readBlockStore(ctx context.Context, block uint64, blockLen uint64)
 		}
 	}
 
+	vb.cacheFetched(data, consecutiveBlocks, baseConsecutiveBlocks)
+	vb.cacheFetched(data, ancestorConsBlocks...)
+
 	return data, zeroBlockErr
 }
 
@@ -5938,28 +6058,22 @@ func (vb *VB) readBlockStore(ctx context.Context, block uint64, blockLen uint64)
 // Used by both legacy and BlockStore read paths.
 func (vb *VB) fetchConsecutiveBlocksFromBackend(ctx context.Context, consecutiveBlocks ConsecutiveBlocks, data []byte) error {
 	var consecutiveBlocksToRead ConsecutiveBlocks
-	consecutiveBlocksRead := make(map[uint64]bool, len(consecutiveBlocks))
-
-	for i := range consecutiveBlocks {
-		if _, ok := consecutiveBlocksRead[consecutiveBlocks[i].StartBlock]; ok {
-			continue
+	for i := 0; i < len(consecutiveBlocks); {
+		// Extend the run while blocks stay contiguous within one chunk, then
+		// resume from its end. Advancing the index is what stops an absorbed
+		// block starting a run of its own, so no seen-set is needed.
+		j := i + 1
+		for j < len(consecutiveBlocks) &&
+			consecutiveBlocks[j].StartBlock == consecutiveBlocks[j-1].StartBlock+1 &&
+			consecutiveBlocks[j].ObjectID == consecutiveBlocks[j-1].ObjectID {
+			j++
 		}
-
-		numBlocks := 1
-		for j := i + 1; j < len(consecutiveBlocks); j++ {
-			if (consecutiveBlocks[j].StartBlock == consecutiveBlocks[j-1].StartBlock+1) &&
-				consecutiveBlocks[j].ObjectID == consecutiveBlocks[j-1].ObjectID {
-				numBlocks++
-				consecutiveBlocksRead[consecutiveBlocks[j].StartBlock] = true
-			} else {
-				break
-			}
-		}
+		numBlocks := j - i
 
 		var seqNums []uint64
 		if vb.EncryptionEnabled {
 			seqNums = make([]uint64, numBlocks)
-			for k := 0; k < numBlocks; k++ {
+			for k := range numBlocks {
 				seqNums[k] = consecutiveBlocks[i+k].SeqNum
 			}
 		}
@@ -5974,6 +6088,7 @@ func (vb *VB) fetchConsecutiveBlocksFromBackend(ctx context.Context, consecutive
 			ObjectOffset:  consecutiveBlocks[i].ObjectOffset,
 			SeqNums:       seqNums,
 		})
+		i = j
 	}
 
 	stride := vb.BlockSize
@@ -6013,26 +6128,6 @@ func (vb *VB) fetchConsecutiveBlocksFromBackend(ctx context.Context, consecutive
 			}
 			copy(data[start:end], blockData)
 		}
-
-		// Cache blocks in BlockStore (post-decrypt plaintext)
-		if vb.UseBlockStore {
-			for i := uint64(0); i < uint64(cb.NumBlocks); i++ {
-				currentBlock := cb.StartBlock + i
-				blockStart := start + i*uint64(vb.BlockSize)
-				blockEnd := blockStart + uint64(vb.BlockSize)
-				vb.BlockStore.Cache(currentBlock, data[blockStart:blockEnd])
-			}
-		}
-
-		// Also update legacy LRU cache if enabled (post-decrypt plaintext)
-		if vb.Cache.Config.Size > 0 {
-			for i := uint64(0); i < uint64(cb.NumBlocks); i++ {
-				currentBlock := cb.StartBlock + i
-				blockStart := start + i*uint64(vb.BlockSize)
-				blockEnd := blockStart + uint64(vb.BlockSize)
-				vb.Cache.lru.Add(currentBlock, bytes.Clone(data[blockStart:blockEnd]))
-			}
-		}
 	}
 
 	return nil
@@ -6047,28 +6142,22 @@ func (vb *VB) fetchBaseBlocksFromBackend(ctx context.Context, sourceVolume strin
 		return fmt.Errorf("fetchBaseBlocksFromBackend: sourceVolume is empty")
 	}
 	var consecutiveBlocksToRead ConsecutiveBlocks
-	consecutiveBlocksRead := make(map[uint64]bool, len(consecutiveBlocks))
-
-	for i := range consecutiveBlocks {
-		if _, ok := consecutiveBlocksRead[consecutiveBlocks[i].StartBlock]; ok {
-			continue
+	for i := 0; i < len(consecutiveBlocks); {
+		// Extend the run while blocks stay contiguous within one chunk, then
+		// resume from its end. Advancing the index is what stops an absorbed
+		// block starting a run of its own, so no seen-set is needed.
+		j := i + 1
+		for j < len(consecutiveBlocks) &&
+			consecutiveBlocks[j].StartBlock == consecutiveBlocks[j-1].StartBlock+1 &&
+			consecutiveBlocks[j].ObjectID == consecutiveBlocks[j-1].ObjectID {
+			j++
 		}
-
-		numBlocks := 1
-		for j := i + 1; j < len(consecutiveBlocks); j++ {
-			if (consecutiveBlocks[j].StartBlock == consecutiveBlocks[j-1].StartBlock+1) &&
-				consecutiveBlocks[j].ObjectID == consecutiveBlocks[j-1].ObjectID {
-				numBlocks++
-				consecutiveBlocksRead[consecutiveBlocks[j].StartBlock] = true
-			} else {
-				break
-			}
-		}
+		numBlocks := j - i
 
 		var seqNums []uint64
 		if vb.EncryptionEnabled {
 			seqNums = make([]uint64, numBlocks)
-			for k := 0; k < numBlocks; k++ {
+			for k := range numBlocks {
 				seqNums[k] = consecutiveBlocks[i+k].SeqNum
 			}
 		}
@@ -6083,6 +6172,7 @@ func (vb *VB) fetchBaseBlocksFromBackend(ctx context.Context, sourceVolume strin
 			ObjectOffset:  consecutiveBlocks[i].ObjectOffset,
 			SeqNums:       seqNums,
 		})
+		i = j
 	}
 
 	stride := vb.BlockSize
@@ -6126,25 +6216,6 @@ func (vb *VB) fetchBaseBlocksFromBackend(ctx context.Context, sourceVolume strin
 					types.ErrShortRead, sourceVolume, cb.ObjectID, cb.ObjectOffset, cb.NumBlocks, len(blockData), consecutiveBlockOffset)
 			}
 			copy(data[start:end], blockData)
-		}
-
-		// Cache blocks in BlockStore (post-decrypt plaintext)
-		if vb.UseBlockStore {
-			for i := uint64(0); i < uint64(cb.NumBlocks); i++ {
-				currentBlock := cb.StartBlock + i
-				blockStart := start + i*uint64(vb.BlockSize)
-				blockEnd := blockStart + uint64(vb.BlockSize)
-				vb.BlockStore.Cache(currentBlock, data[blockStart:blockEnd])
-			}
-		}
-
-		if vb.Cache.Config.Size > 0 {
-			for i := uint64(0); i < uint64(cb.NumBlocks); i++ {
-				currentBlock := cb.StartBlock + i
-				blockStart := start + i*uint64(vb.BlockSize)
-				blockEnd := blockStart + uint64(vb.BlockSize)
-				vb.Cache.lru.Add(currentBlock, bytes.Clone(data[blockStart:blockEnd]))
-			}
 		}
 	}
 
@@ -6224,7 +6295,7 @@ func (vb *VB) FlushBlockStore() error {
 		successCount++
 		flushed[block.Block] = block.SeqNum
 		// Transition to Pending in BlockStore
-		vb.BlockStore.MarkPending(block.Block)
+		vb.BlockStore.MarkPending(block.Block, block.SeqNum)
 	}
 
 	// Also update legacy Writes buffer for compatibility
@@ -6266,7 +6337,7 @@ func (vb *VB) SyncBlockStoreFromLegacy() {
 	vb.PendingBackendWrites.mu.RLock()
 	for _, block := range vb.PendingBackendWrites.Blocks {
 		vb.BlockStore.WriteWithSeqNum(block.Block, block.Data, block.SeqNum)
-		vb.BlockStore.MarkPending(block.Block)
+		vb.BlockStore.MarkPending(block.Block, block.SeqNum)
 	}
 	vb.PendingBackendWrites.mu.RUnlock()
 

--- a/viperblock/viperblock.go
+++ b/viperblock/viperblock.go
@@ -496,7 +496,11 @@ type BlocksToObject struct {
 	mu    sync.RWMutex
 	dirty atomic.Bool
 
-	BlockLookup map[uint64]BlockLookup
+	lookup extentIndex[BlockLookup]
+
+	// fractureScratch is reused across insertCoalescedLocked calls to hold the
+	// overlapping entries, which must be collected before the index is mutated.
+	fractureScratch []BlockLookup
 }
 
 type BlockLookup struct {
@@ -520,6 +524,12 @@ type BlockLookup struct {
 
 	ObjectOffset uint32
 	NumBlocks    uint16
+}
+
+// start returns the inclusive lower bound of the block range this entry
+// covers.
+func (bl BlockLookup) start() uint64 {
+	return bl.StartBlock
 }
 
 // end returns the exclusive upper bound of the block range this entry
@@ -604,19 +614,11 @@ type ConsecutiveBlocks []ConsecutiveBlock
 // entry's run (0 for a direct StartBlock hit). Callers must hold
 // BlocksToObject.mu for at least reading.
 func (b *BlocksToObject) resolveBlockLookup(block uint64) (BlockLookup, int, bool) {
-	if bl, ok := b.BlockLookup[block]; ok {
-		return bl, 0, true
+	bl, ok := b.lookup.find(block)
+	if !ok {
+		return BlockLookup{}, 0, false
 	}
-	// Fall back to an O(n) containment scan: coalescing keys the map by
-	// StartBlock only, so a block inside a multi-block run has no entry of
-	// its own. n is bounded by the number of extents, not the number of
-	// blocks, so this stays cheap post-coalescing.
-	for _, bl := range b.BlockLookup {
-		if block > bl.StartBlock && block < bl.end() {
-			return bl, utils.SafeUint64ToInt(block - bl.StartBlock), true
-		}
-	}
-	return BlockLookup{}, 0, false
+	return bl, utils.SafeUint64ToInt(block - bl.StartBlock), true
 }
 
 // insertCoalescedLocked inserts newEntry into BlockLookup, fracturing any
@@ -630,25 +632,15 @@ func (b *BlocksToObject) insertCoalescedLocked(newEntry BlockLookup, stride uint
 	newStart := newEntry.StartBlock
 	newEnd := newEntry.end()
 
-	// Snapshot keys first: Go forbids inserting new keys into a map while
-	// ranging over it, and fracturing does delete+reinsert below.
-	keys := make([]uint64, 0, len(b.BlockLookup))
-	for k := range b.BlockLookup {
-		keys = append(keys, k)
-	}
+	// Collect the overlapping entries before touching the index: fracturing
+	// deletes and reinserts, which cannot be done during an ordered walk.
+	b.fractureScratch = b.lookup.collectOverlaps(b.fractureScratch[:0], newStart, newEnd)
 
-	for _, k := range keys {
-		existing, ok := b.BlockLookup[k]
-		if !ok {
-			continue // already replaced by an earlier iteration
-		}
+	for _, existing := range b.fractureScratch {
 		exStart := existing.StartBlock
 		exEnd := existing.end()
-		if exEnd <= newStart || exStart >= newEnd {
-			continue // no overlap
-		}
 
-		delete(b.BlockLookup, k)
+		b.lookup.remove(exStart)
 		if gcRefcount != nil {
 			if n := gcRefcount[existing.ObjectID]; n > 0 {
 				gcRefcount[existing.ObjectID] = n - 1
@@ -666,7 +658,7 @@ func (b *BlocksToObject) insertCoalescedLocked(newEntry BlockLookup, stride uint
 				SeqNum:       existing.seqNumAt(0),
 				SeqNums:      existing.sliceSeqNums(0, headLen),
 			}
-			b.BlockLookup[head.StartBlock] = head
+			b.lookup.set(head)
 			if gcRefcount != nil {
 				gcRefcount[head.ObjectID]++
 			}
@@ -685,14 +677,14 @@ func (b *BlocksToObject) insertCoalescedLocked(newEntry BlockLookup, stride uint
 				SeqNum:       existing.seqNumAt(tailOffset),
 				SeqNums:      existing.sliceSeqNums(tailOffset, tailOffset+tailLen),
 			}
-			b.BlockLookup[tail.StartBlock] = tail
+			b.lookup.set(tail)
 			if gcRefcount != nil {
 				gcRefcount[tail.ObjectID]++
 			}
 		}
 	}
 
-	b.BlockLookup[newEntry.StartBlock] = newEntry
+	b.lookup.set(newEntry)
 	if gcRefcount != nil {
 		gcRefcount[newEntry.ObjectID]++
 	}
@@ -1174,7 +1166,7 @@ func New(config *VB, btype string, backendConfig any) (vb *VB, err error) {
 		vb.volumeNameHash = computeVolumeNameHash(config.VolumeName)
 	}
 
-	vb.BlocksToObject.BlockLookup = make(map[uint64]BlockLookup)
+	vb.BlocksToObject.lookup.clear()
 	if vb.GCEnabled {
 		vb.gcRefcount = make(map[uint64]uint64)
 	}
@@ -3555,11 +3547,12 @@ func (vb *VB) SaveBlockStateCtx(ctx context.Context) (err error) {
 	// block: the on-disk wire format stays unchanged even though the
 	// in-memory map is coalesced into extents.
 	stride := vb.blockStride()
-	for _, block := range vb.BlocksToObject.BlockLookup {
+	vb.BlocksToObject.lookup.scan(func(block BlockLookup) bool {
 		for _, single := range expandBlockLookup(block, stride) {
 			checkpoint = append(checkpoint, vb.writeBlockWalChunk(&single)...)
 		}
-	}
+		return true
+	})
 
 	filepath := fmt.Sprintf("%s/%s", vb.BaseDir, types.GetFilePath(types.FileTypeBlockCheckpoint, vb.BlockToObjectWAL.WallNum.Load(), vb.GetVolume()))
 	file, err := os.Create(filepath)
@@ -3651,7 +3644,7 @@ func ParseBlockCheckpointBytes(raw []byte, version uint16) (map[uint64]BlockLook
 	return blocks, nil
 }
 
-// parseBlockCheckpoint deserialises a checkpoint binary into BlocksToObject.BlockLookup.
+// parseBlockCheckpoint deserialises a checkpoint binary into the block index.
 // Caller must hold BlocksToObject.mu (write).
 func (vb *VB) parseBlockCheckpoint(checkpoint []byte) error {
 	// Rebuild refcounts from scratch alongside the map: zero-refcount GC
@@ -3687,20 +3680,24 @@ func (vb *VB) parseBlockCheckpoint(checkpoint []byte) error {
 		return err
 	}
 
-	vb.BlocksToObject.BlockLookup = coalesceBlockLookup(flat, vb.blockStride())
+	vb.BlocksToObject.lookup.clear()
+	for _, entry := range coalesceBlockLookup(flat, vb.blockStride()) {
+		vb.BlocksToObject.lookup.set(entry)
+	}
 
 	// gcRefcount counts entries in the coalesced BlockLookup, not physical
 	// blocks, so it must be tallied post-coalesce -- tallying the flat,
 	// one-record-per-block decode above would overcount every multi-block
 	// run by its block count instead of by 1.
 	if vb.GCEnabled {
-		for _, entry := range vb.BlocksToObject.BlockLookup {
+		vb.BlocksToObject.lookup.scan(func(entry BlockLookup) bool {
 			vb.gcRefcount[entry.ObjectID]++
-		}
+			return true
+		})
 	}
 
 	if vb.UseBlockStore && vb.BlockStore != nil {
-		for _, entry := range vb.BlocksToObject.BlockLookup {
+		vb.BlocksToObject.lookup.scan(func(entry BlockLookup) bool {
 			blocks := make([]uint64, entry.NumBlocks)
 			seqNums := make([]uint64, entry.NumBlocks)
 			for i := range blocks {
@@ -3708,7 +3705,8 @@ func (vb *VB) parseBlockCheckpoint(checkpoint []byte) error {
 				seqNums[i] = entry.seqNumAt(i)
 			}
 			vb.BlockStore.SetPersistedRange(blocks, entry.ObjectID, entry.ObjectOffset, vb.blockStride(), seqNums)
-		}
+			return true
+		})
 	}
 
 	// Runtime drains persist chunks but not config.json ObjectNum, so a re-Open can
@@ -4183,11 +4181,12 @@ func (vb *VB) SaveLiveCheckpointCtx(ctx context.Context) error {
 	vb.BlocksToObject.mu.RLock()
 	checkpoint := vb.BlockToObjectWALHeader()
 	stride := vb.blockStride()
-	for _, block := range vb.BlocksToObject.BlockLookup {
+	vb.BlocksToObject.lookup.scan(func(block BlockLookup) bool {
 		for _, single := range expandBlockLookup(block, stride) {
 			checkpoint = append(checkpoint, vb.writeBlockWalChunk(&single)...)
 		}
-	}
+		return true
+	})
 	vb.BlocksToObject.mu.RUnlock()
 
 	headers := []byte{}
@@ -4461,12 +4460,13 @@ func (vb *VB) RecoverLocalWALs() (err error) {
 	vb.BlocksToObject.mu.RLock()
 	var maxObjectID uint64
 	haveObject := false
-	for _, lookup := range vb.BlocksToObject.BlockLookup {
+	vb.BlocksToObject.lookup.scan(func(lookup BlockLookup) bool {
 		if !haveObject || lookup.ObjectID > maxObjectID {
 			maxObjectID = lookup.ObjectID
 			haveObject = true
 		}
-	}
+		return true
+	})
 	vb.BlocksToObject.mu.RUnlock()
 	if haveObject {
 		next := maxObjectID + 1
@@ -4514,7 +4514,7 @@ func (vb *VB) RecoverLocalWALs() (err error) {
 	if vb.UseBlockStore && vb.BlockStore != nil {
 		vb.BlocksToObject.mu.RLock()
 		stride := vb.blockStride()
-		for _, lookup := range vb.BlocksToObject.BlockLookup {
+		vb.BlocksToObject.lookup.scan(func(lookup BlockLookup) bool {
 			blocks := make([]uint64, lookup.NumBlocks)
 			seqNums := make([]uint64, lookup.NumBlocks)
 			for i := range blocks {
@@ -4522,7 +4522,8 @@ func (vb *VB) RecoverLocalWALs() (err error) {
 				seqNums[i] = lookup.seqNumAt(i)
 			}
 			vb.BlockStore.SetPersistedRange(blocks, lookup.ObjectID, lookup.ObjectOffset, stride, seqNums)
-		}
+			return true
+		})
 		vb.BlocksToObject.mu.RUnlock()
 	}
 
@@ -5313,7 +5314,7 @@ func (vb *VB) read(ctx context.Context, block uint64, blockLen uint64) (data []b
 			ancFound := false
 			for ai := range vb.ancestors {
 				vb.ancestors[ai].blocks.mu.RLock()
-				lookup, ok := vb.ancestors[ai].blocks.BlockLookup[currentBlock]
+				lookup, pos, ok := vb.ancestors[ai].blocks.resolveBlockLookup(currentBlock)
 				vb.ancestors[ai].blocks.mu.RUnlock()
 				if ok {
 					ancestorConsBlocks[ai] = append(ancestorConsBlocks[ai], ConsecutiveBlock{
@@ -5323,8 +5324,8 @@ func (vb *VB) read(ctx context.Context, block uint64, blockLen uint64) (data []b
 						OffsetStart:   start,
 						OffsetEnd:     end,
 						ObjectID:      lookup.ObjectID,
-						ObjectOffset:  lookup.ObjectOffset,
-						SeqNum:        lookup.SeqNum,
+						ObjectOffset:  lookup.offsetAt(pos, vb.blockStride()),
+						SeqNum:        lookup.seqNumAt(pos),
 					})
 					ancFound = true
 					break
@@ -5666,7 +5667,7 @@ func (vb *VB) Reset() error {
 	}
 
 	vb.BlocksToObject.mu.Lock()
-	vb.BlocksToObject.BlockLookup = make(map[uint64]BlockLookup, 0)
+	vb.BlocksToObject.lookup.clear()
 	vb.BlocksToObject.mu.Unlock()
 
 	vb.Writes.mu.Lock()
@@ -5878,7 +5879,7 @@ func (vb *VB) readBlockStore(ctx context.Context, block uint64, blockLen uint64)
 			ancFound := false
 			for ai := range vb.ancestors {
 				vb.ancestors[ai].blocks.mu.RLock()
-				lookup, ok := vb.ancestors[ai].blocks.BlockLookup[currentBlock]
+				lookup, pos, ok := vb.ancestors[ai].blocks.resolveBlockLookup(currentBlock)
 				vb.ancestors[ai].blocks.mu.RUnlock()
 				if ok {
 					ancestorConsBlocks[ai] = append(ancestorConsBlocks[ai], ConsecutiveBlock{
@@ -5888,8 +5889,8 @@ func (vb *VB) readBlockStore(ctx context.Context, block uint64, blockLen uint64)
 						OffsetStart:   start,
 						OffsetEnd:     end,
 						ObjectID:      lookup.ObjectID,
-						ObjectOffset:  lookup.ObjectOffset,
-						SeqNum:        lookup.SeqNum,
+						ObjectOffset:  lookup.offsetAt(pos, vb.blockStride()),
+						SeqNum:        lookup.seqNumAt(pos),
 					})
 					ancFound = true
 					break
@@ -6276,14 +6277,15 @@ func (vb *VB) SyncBlockStoreFromLegacy() {
 	// path, kept as-is here.
 	vb.BlocksToObject.mu.RLock()
 	stride := vb.blockStride()
-	for _, lookup := range vb.BlocksToObject.BlockLookup {
+	vb.BlocksToObject.lookup.scan(func(lookup BlockLookup) bool {
 		blocks := make([]uint64, lookup.NumBlocks)
 		seqNums := make([]uint64, lookup.NumBlocks)
 		for i := range blocks {
 			blocks[i] = lookup.StartBlock + uint64(i)
 		}
 		vb.BlockStore.SetPersistedRange(blocks, lookup.ObjectID, lookup.ObjectOffset, stride, seqNums)
-	}
+		return true
+	})
 	vb.BlocksToObject.mu.RUnlock()
 
 	// Sync sequence number

--- a/viperblock/viperblock_test.go
+++ b/viperblock/viperblock_test.go
@@ -765,9 +765,7 @@ func TestWriteAndRead(t *testing.T) {
 						//t.Log("Checking cache for block", tc.blockID+i)
 
 						if cachedData, ok := vb.Cache.lru.Get(tc.blockID + i); ok {
-							//slog.Info("CACHE HIT:", "block", tc.blockID+i)
-
-							assert.Equal(t, tc.data[blockCount:blockCount+uint64(vb.BlockSize)], cachedData)
+							assert.Equal(t, tc.data[blockCount:blockCount+uint64(vb.BlockSize)], cachedData.data)
 						}
 
 						blockCount += uint64(vb.BlockSize)
@@ -1963,7 +1961,7 @@ func TestPendingBackendWritesDeduplication(t *testing.T) {
 					expected := make([]byte, DefaultBlockSize)
 					msg := fmt.Sprintf("cache_block_%d", i)
 					copy(expected[:len(msg)], msg)
-					assert.Equal(t, expected, cachedData, "Cached block %d data mismatch", i)
+					assert.Equal(t, expected, cachedData.data, "Cached block %d data mismatch", i)
 				}
 			}
 		})

--- a/viperblock/viperblock_test.go
+++ b/viperblock/viperblock_test.go
@@ -823,7 +823,7 @@ func TestWriteAndRead(t *testing.T) {
 		if vb.UseShardedWAL && vb.ShardedWAL != nil {
 			prevWALNum = vb.ShardedWAL.WallNum.Load()
 		}
-		compareState := vb.BlocksToObject.BlockLookup
+		compareState := lookupMap(&vb.BlocksToObject)
 
 		// Gracefully close VB and save state to disk (only once after all subtests)
 		// Note: Close() removes local files after uploading state to backend
@@ -848,7 +848,7 @@ func TestWriteAndRead(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Compare they are the same
-		assert.Equal(t, compareState, vb.BlocksToObject.BlockLookup)
+		assert.Equal(t, compareState, lookupMap(&vb.BlocksToObject))
 	})
 }
 
@@ -1989,7 +1989,7 @@ func TestRecoverLocalWALs(t *testing.T) {
 			// At this point blocks are in WAL file on disk but NOT in chunks/S3.
 			// Simulate a crash: reset in-memory state without calling Close/WriteWALToChunk.
 			vb.BlocksToObject.mu.Lock()
-			vb.BlocksToObject.BlockLookup = make(map[uint64]BlockLookup)
+			vb.BlocksToObject.lookup.clear()
 			vb.BlocksToObject.mu.Unlock()
 
 			vb.PendingBackendWrites.mu.Lock()
@@ -2038,7 +2038,7 @@ func TestRecoverLocalWALsEmpty(t *testing.T) {
 
 			// BlocksToObject should be empty
 			vb.BlocksToObject.mu.RLock()
-			count := len(vb.BlocksToObject.BlockLookup)
+			count := vb.BlocksToObject.lookup.len()
 			vb.BlocksToObject.mu.RUnlock()
 			assert.Equal(t, 0, count, "BlocksToObject should remain empty")
 		})
@@ -2077,7 +2077,7 @@ func TestRecoverLocalWALsPartialRecord(t *testing.T) {
 
 			// Reset in-memory state (simulate crash)
 			vb.BlocksToObject.mu.Lock()
-			vb.BlocksToObject.BlockLookup = make(map[uint64]BlockLookup)
+			vb.BlocksToObject.lookup.clear()
 			vb.BlocksToObject.mu.Unlock()
 
 			vb.PendingBackendWrites.mu.Lock()
@@ -2131,7 +2131,7 @@ func TestRecoverLocalWALsDedup(t *testing.T) {
 
 			// Reset in-memory state (simulate crash)
 			vb.BlocksToObject.mu.Lock()
-			vb.BlocksToObject.BlockLookup = make(map[uint64]BlockLookup)
+			vb.BlocksToObject.lookup.clear()
 			vb.BlocksToObject.mu.Unlock()
 
 			vb.PendingBackendWrites.mu.Lock()
@@ -2178,7 +2178,7 @@ func TestRecoverLocalWALsSeqNumAdvancement(t *testing.T) {
 
 			// Simulate crash: reset in-memory state
 			vb.BlocksToObject.mu.Lock()
-			vb.BlocksToObject.BlockLookup = make(map[uint64]BlockLookup)
+			vb.BlocksToObject.lookup.clear()
 			vb.BlocksToObject.mu.Unlock()
 
 			vb.PendingBackendWrites.mu.Lock()
@@ -2248,7 +2248,7 @@ func TestRecoverLocalWALsChecksumCorruption(t *testing.T) {
 
 			// Reset in-memory state (simulate crash)
 			vb.BlocksToObject.mu.Lock()
-			vb.BlocksToObject.BlockLookup = make(map[uint64]BlockLookup)
+			vb.BlocksToObject.lookup.clear()
 			vb.BlocksToObject.mu.Unlock()
 
 			vb.PendingBackendWrites.mu.Lock()
@@ -2296,7 +2296,7 @@ func TestRecoverLocalWALsFileCleanup(t *testing.T) {
 
 			// Simulate crash
 			vb.BlocksToObject.mu.Lock()
-			vb.BlocksToObject.BlockLookup = make(map[uint64]BlockLookup)
+			vb.BlocksToObject.lookup.clear()
 			vb.BlocksToObject.mu.Unlock()
 
 			vb.PendingBackendWrites.mu.Lock()
@@ -2340,7 +2340,7 @@ func TestRecoverLocalWALsBlockStoreSync(t *testing.T) {
 
 			// Simulate crash
 			vb.BlocksToObject.mu.Lock()
-			vb.BlocksToObject.BlockLookup = make(map[uint64]BlockLookup)
+			vb.BlocksToObject.lookup.clear()
 			vb.BlocksToObject.mu.Unlock()
 
 			vb.PendingBackendWrites.mu.Lock()
@@ -2387,7 +2387,7 @@ func TestRecoverLocalWALsCorruptHeaderWithValidFile(t *testing.T) {
 
 			// Simulate crash
 			vb.BlocksToObject.mu.Lock()
-			vb.BlocksToObject.BlockLookup = make(map[uint64]BlockLookup)
+			vb.BlocksToObject.lookup.clear()
 			vb.BlocksToObject.mu.Unlock()
 
 			vb.PendingBackendWrites.mu.Lock()
@@ -2439,7 +2439,7 @@ func TestRecoverLocalWALsAllCorruptHeaders(t *testing.T) {
 
 			// BlocksToObject should be empty
 			vb.BlocksToObject.mu.RLock()
-			count := len(vb.BlocksToObject.BlockLookup)
+			count := vb.BlocksToObject.lookup.len()
 			vb.BlocksToObject.mu.RUnlock()
 			assert.Equal(t, 0, count, "BlocksToObject should remain empty when all WALs are corrupt")
 

--- a/viperblock/wal_space_other.go
+++ b/viperblock/wal_space_other.go
@@ -1,0 +1,7 @@
+//go:build !unix
+
+package viperblock
+
+// walDeviceFreeBytes has no portable implementation off unix. Zero means
+// "unknown", so the backpressure budget is left at its configured value.
+func walDeviceFreeBytes(_ string) uint64 { return 0 }

--- a/viperblock/wal_space_unix.go
+++ b/viperblock/wal_space_unix.go
@@ -1,0 +1,19 @@
+//go:build unix
+
+package viperblock
+
+import "golang.org/x/sys/unix"
+
+// walDeviceFreeBytes reports the space available to an unprivileged writer on
+// the filesystem holding path. Zero means "unknown" -- callers must treat that
+// as "do not clamp" rather than as "no space".
+func walDeviceFreeBytes(path string) uint64 {
+	var st unix.Statfs_t
+	if err := unix.Statfs(path, &st); err != nil {
+		return 0
+	}
+	if st.Bsize <= 0 {
+		return 0
+	}
+	return st.Bavail * uint64(st.Bsize)
+}


### PR DESCRIPTION
## Summary

EBS read/attach performance work. Both block indexes answered range queries
against unordered Go maps, so any lookup that missed a coalesced run's exact
start block degraded to a full scan. At a million extents a single 4 KiB lookup
cost 35 ms and an insert 150-190 ms under the global write lock — a 1 MiB guest
read took nine seconds, and volume attach was quadratic in extent count.

## Changes

- **Ordered extent index.** `extentIndex` is a B-tree keyed on start block.
  `find()` seeks the single candidate; `overlaps()` walks only the entries a
  range actually touches. Fracturing collects into a reused scratch buffer,
  since the index cannot be mutated mid-walk, and head/tail entries sub-slice
  the parent's `SeqNums` rather than copying.
- **Lookups resolve by coverage, not exact key.** Ancestor and base-map probes
  go through `resolveBlockLookup`, so a coalesced entry is found from any block
  it covers instead of falling through to a zero block.
- **Batched read resolution.** `readBlockStore` took `persistedMu` once per
  4 KiB block — 256 times for a 1 MiB read, each a chance to stall behind a
  chunk upload under Go's writer-priority RWMutex. `ReadEntryRun` resolves a
  whole run: sharded overlay per block, then one locked walk of the persisted
  index for the gaps.
- **Repaired the persisted-data cache.** It was dead code: `MarkPersistedRange`
  drops a block's shard entry once it coalesces, so `BlockStore.Cache()` always
  returned false and the bounded LRU was populated but never read — every
  persisted read was a backend round trip. Cached plaintext now lives in the
  LRU beside the authoritative index, tagged with the sequence number it was
  cached under, so a superseded copy fails lookup instead of being served. The
  dead `Cache`/`EvictCache` methods are removed.
- Merged `dev` (gp3 `Throughput` field, concurrent-open WAL lock). No conflicts.

## Testing

`make preflight` passes: golangci-lint 0 issues, govulncheck clean, race
detector clean, diff coverage 93.5% against the 60% threshold.

Note: this repo's CI has no `pull_request` trigger, so the four workflow jobs
only run after merge to `dev`.