### PR TITLE
fix: retry a transient VBState backend read instead of failing closed

### DIFF
--- a/viperblock/backends/s3/s3.go
+++ b/viperblock/backends/s3/s3.go
@@ -355,6 +355,18 @@ func (backend *Backend) ReadCtx(ctx context.Context, fileType types.FileType, ob
 			types.ErrShortRead, filename, offset, len(res), length)
 	}
 
+	// A full-object read (length == 0, used for config.json and other
+	// metadata) has no range to compare against, so a connection that drops
+	// mid-body previously went unnoticed: io.ReadAll returns the truncated
+	// bytes with no error. Compare against the response's own Content-Length
+	// when the server supplied one. ContentLength is nil/negative for a
+	// chunked response, which carries no such promise to check against.
+	if length == 0 && textResult.ContentLength != nil && *textResult.ContentLength >= 0 &&
+		len(res) != int(*textResult.ContentLength) {
+		return nil, fmt.Errorf("%w: %s: backend returned %d bytes, expected %d",
+			types.ErrShortRead, filename, len(res), *textResult.ContentLength)
+	}
+
 	return res, nil
 }
 

--- a/viperblock/backends/s3/s3.go
+++ b/viperblock/backends/s3/s3.go
@@ -355,12 +355,9 @@ func (backend *Backend) ReadCtx(ctx context.Context, fileType types.FileType, ob
 			types.ErrShortRead, filename, offset, len(res), length)
 	}
 
-	// A full-object read (length == 0, used for config.json and other
-	// metadata) has no range to compare against, so a connection that drops
-	// mid-body previously went unnoticed: io.ReadAll returns the truncated
-	// bytes with no error. Compare against the response's own Content-Length
-	// when the server supplied one. ContentLength is nil/negative for a
-	// chunked response, which carries no such promise to check against.
+	// A full-object read has no range to check against, so a body truncated
+	// mid-transfer reads back clean. Compare against the response's own
+	// Content-Length; a chunked response has none and promises nothing.
 	if length == 0 && textResult.ContentLength != nil && *textResult.ContentLength >= 0 &&
 		len(res) != int(*textResult.ContentLength) {
 		return nil, fmt.Errorf("%w: %s: backend returned %d bytes, expected %d",

--- a/viperblock/backends/s3/s3_test.go
+++ b/viperblock/backends/s3/s3_test.go
@@ -1,14 +1,19 @@
 package s3
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
+	"strconv"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsmiddleware "github.com/aws/aws-sdk-go-v2/aws/middleware"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
 	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/aws/smithy-go"
 	"github.com/aws/smithy-go/middleware"
@@ -340,4 +345,97 @@ func TestPoolPressureMiddlewareClearsOnFailedPutObject(t *testing.T) {
 	})
 	assert.Same(t, wantErr, err, "the middleware must pass the underlying error through unchanged")
 	assert.False(t, backend.NearFull(), "a failed PutObject with no pool-pressure header must clear NearFull")
+}
+
+// roundTripFunc adapts a plain function to http.RoundTripper so tests can
+// hand ReadCtx a canned response without a real network or predastore server.
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+// newTestBackend builds an S3 backend whose s3Client is wired to rt instead
+// of a real network. It bypasses InitCtx (which issues a ListObjectsV2
+// existence check the fake transport does not model) and constructs the SDK
+// client directly, mirroring InitCtx's own s3.New call.
+func newTestBackend(rt http.RoundTripper) *Backend {
+	backend := New(S3Config{VolumeName: "vol", Bucket: "bucket", Region: "us-east-1"})
+	backend.config.s3Client = s3.New(s3.Options{
+		BaseEndpoint: aws.String("https://s3.test"),
+		UsePathStyle: true,
+		Region:       "us-east-1",
+		HTTPClient:   &http.Client{Transport: rt},
+		Credentials:  credentials.NewStaticCredentialsProvider("ak", "sk", ""),
+	})
+	return backend
+}
+
+// TestReadCtx_FullObjectShortBodyIsRefused pins that a full-object GET
+// (length == 0, the path VBState config.json reads use) whose body arrives
+// shorter than the server's own Content-Length is surfaced as
+// types.ErrShortRead rather than silently accepted as the whole object. This
+// is the transport-side half of the config.json truncation that a single
+// unretried recovery read used to misclassify as permanent corruption.
+func TestReadCtx_FullObjectShortBodyIsRefused(t *testing.T) {
+	full := []byte("this is the complete config.json body")
+	short := full[:len(full)-10]
+
+	backend := newTestBackend(roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		header := http.Header{}
+		header.Set("Content-Length", strconv.Itoa(len(full)))
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     header,
+			Body:       io.NopCloser(bytes.NewReader(short)),
+			Request:    req,
+		}, nil
+	}))
+
+	_, err := backend.ReadCtx(context.Background(), types.FileTypeConfig, 0, 0, 0)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, types.ErrShortRead)
+}
+
+// TestReadCtx_FullObjectChunkedResponseSkipsGuard pins that a chunked
+// response (no Content-Length header, so the SDK leaves ContentLength nil)
+// still succeeds -- there is nothing to compare the body against, so the
+// guard must not guess and must not reject a legitimate chunked read.
+func TestReadCtx_FullObjectChunkedResponseSkipsGuard(t *testing.T) {
+	full := []byte("this is the complete config.json body")
+
+	backend := newTestBackend(roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{},
+			Body:       io.NopCloser(bytes.NewReader(full)),
+			Request:    req,
+		}, nil
+	}))
+
+	got, err := backend.ReadCtx(context.Background(), types.FileTypeConfig, 0, 0, 0)
+	require.NoError(t, err)
+	assert.Equal(t, full, got)
+}
+
+// TestReadCtx_FullObjectMatchingContentLengthSucceeds is the control case:
+// a full-object body whose length matches Content-Length must not trip the
+// new guard.
+func TestReadCtx_FullObjectMatchingContentLengthSucceeds(t *testing.T) {
+	full := []byte("this is the complete config.json body")
+
+	backend := newTestBackend(roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		header := http.Header{}
+		header.Set("Content-Length", strconv.Itoa(len(full)))
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     header,
+			Body:       io.NopCloser(bytes.NewReader(full)),
+			Request:    req,
+		}, nil
+	}))
+
+	got, err := backend.ReadCtx(context.Background(), types.FileTypeConfig, 0, 0, 0)
+	require.NoError(t, err)
+	assert.Equal(t, full, got)
 }

--- a/viperblock/state_retry_test.go
+++ b/viperblock/state_retry_test.go
@@ -1,0 +1,205 @@
+// Unit tests for LoadStateRequestCtx's backend-path retry: a bounded,
+// backed-off re-attempt of the VBState backend read that distinguishes a
+// transient/truncated read from genuinely-missing state or a fail-closed
+// crypto failure. See docs/development/bugs/recovery-vbstate-transient-read-misclassified.md.
+
+package viperblock
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/mulgadc/viperblock/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// flakyConfigBackend wraps a real backend and hands every FileTypeConfig
+// ReadCtx call to mutate, which decides what the caller sees based on the
+// 1-based call number. Every other file type, and any call once mutate is
+// nil, passes straight through. Safe for concurrent use since only
+// LoadStateRequestCtx's own retry loop calls it, but the counter is still
+// mutex-guarded for clarity.
+type flakyConfigBackend struct {
+	types.Backend
+
+	mu     sync.Mutex
+	calls  int
+	mutate func(call int, data []byte, err error) ([]byte, error)
+}
+
+func (b *flakyConfigBackend) ReadCtx(ctx context.Context, fileType types.FileType, objectID uint64, offset, length uint32) ([]byte, error) {
+	data, err := b.Backend.ReadCtx(ctx, fileType, objectID, offset, length)
+	if fileType != types.FileTypeConfig {
+		return data, err
+	}
+
+	b.mu.Lock()
+	b.calls++
+	n := b.calls
+	b.mu.Unlock()
+
+	if b.mutate != nil {
+		return b.mutate(n, data, err)
+	}
+	return data, err
+}
+
+func (b *flakyConfigBackend) Read(fileType types.FileType, objectID uint64, offset, length uint32) ([]byte, error) {
+	return b.ReadCtx(context.Background(), fileType, objectID, offset, length)
+}
+
+func (b *flakyConfigBackend) callCount() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.calls
+}
+
+// TestLoadStateRequestCtx_RetriesTruncatedBackendRead is the direct
+// regression test for the recovery bug: a backend read that comes back
+// truncated on the first attempt (the shape a single unretried GET raced
+// against a warming-up predastore produces) must be retried, not
+// immediately misclassified as permanent ErrIntegrity.
+func TestLoadStateRequestCtx_RetriesTruncatedBackendRead(t *testing.T) {
+	key := testKey(t, 0x42)
+	vb := newFileBackedVB(t, "vol-retry-succeed", key)
+	vb.BlockSize = DefaultBlockSize
+	require.NoError(t, vb.SaveState())
+
+	flaky := &flakyConfigBackend{Backend: vb.Backend}
+	flaky.mutate = func(call int, data []byte, err error) ([]byte, error) {
+		if err != nil || call != 1 {
+			return data, err
+		}
+		// Truncate the envelope so it fails JSON parsing, exactly like a
+		// connection dropped mid-body -- not a bit flip, a short read.
+		return data[:len(data)-5], nil
+	}
+	vb.Backend = flaky
+
+	state, err := vb.LoadStateRequestCtx(context.Background(), "")
+	require.NoError(t, err)
+	assert.Equal(t, vb.VolumeName, state.VolumeName)
+	assert.Equal(t, 2, flaky.callCount(), "must succeed on the second attempt, not the first")
+}
+
+// TestLoadStateRequestCtx_ExhaustsRetriesOnPersistentTruncation pins the
+// exhaustion budget: a backend that always returns a truncated body burns
+// exactly stateReadMaxAttempts attempts and the final error still wraps
+// ErrIntegrity, so existing callers (errors.Is checks) are unaffected.
+func TestLoadStateRequestCtx_ExhaustsRetriesOnPersistentTruncation(t *testing.T) {
+	key := testKey(t, 0x42)
+	vb := newFileBackedVB(t, "vol-retry-exhaust", key)
+	vb.BlockSize = DefaultBlockSize
+	require.NoError(t, vb.SaveState())
+
+	flaky := &flakyConfigBackend{Backend: vb.Backend}
+	flaky.mutate = func(call int, data []byte, err error) ([]byte, error) {
+		if err != nil {
+			return data, err
+		}
+		return data[:len(data)-5], nil
+	}
+	vb.Backend = flaky
+
+	_, err := vb.LoadStateRequestCtx(context.Background(), "")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrIntegrity)
+	assert.Equal(t, stateReadMaxAttempts, flaky.callCount())
+}
+
+// TestLoadStateRequestCtx_NoRetryOnEncryptionMismatch pins that a wrong-key
+// open makes exactly one attempt: the key is wrong on every retry too, so
+// retrying only burns the recovery window for a deterministic failure.
+func TestLoadStateRequestCtx_NoRetryOnEncryptionMismatch(t *testing.T) {
+	keyA := testKey(t, 0x01)
+	keyB := testKey(t, 0x02)
+	require.NotEqual(t, keyA.Fingerprint, keyB.Fingerprint)
+
+	vb := newFileBackedVB(t, "vol-retry-fp-mismatch", keyA)
+	vb.BlockSize = DefaultBlockSize
+	require.NoError(t, vb.SaveState())
+
+	flaky := &flakyConfigBackend{Backend: vb.Backend}
+	vb.Backend = flaky
+
+	// Swap in the wrong key after the sealed state is on the backend, same
+	// shape as a node opening a volume it does not hold the right key for.
+	vb.MasterKey = keyB
+
+	_, err := vb.LoadStateRequestCtx(context.Background(), "")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrEncryptionMismatch)
+	assert.Equal(t, 1, flaky.callCount())
+}
+
+// TestLoadStateRequestCtx_NoRetryOnTagVerifyFailure pins that a genuine
+// tag-verify failure (payload/tag tampering, not truncation) fails closed on
+// the first attempt.
+func TestLoadStateRequestCtx_NoRetryOnTagVerifyFailure(t *testing.T) {
+	key := testKey(t, 0x42)
+	vb := newFileBackedVB(t, "vol-retry-tag-fail", key)
+	vb.BlockSize = DefaultBlockSize
+	require.NoError(t, vb.SaveState())
+
+	flaky := &flakyConfigBackend{Backend: vb.Backend}
+	flaky.mutate = func(call int, data []byte, err error) ([]byte, error) {
+		if err != nil || len(data) <= metaPayloadOffset {
+			return data, err
+		}
+		// Flip a byte inside the verbatim payload (metaPayloadOffset, shared
+		// with encryption_meta_test.go's bit-flip test) rather than the
+		// base64-encoded authtag: the tag's trailing char has unused
+		// low-order bits that Go's permissive base64 decoder discards, so a
+		// substitution there can silently decode back to the same tag bytes
+		// and the AEAD open, verifyMeta, and the retry classification this
+		// test exercises. The payload ships as raw JSON text, so any byte
+		// flip there deterministically changes the AAD input without
+		// touching JSON syntax (it lands inside a field name, not a
+		// structural character) or affecting KeyFingerprint.
+		tampered := append([]byte(nil), data...)
+		tampered[metaPayloadOffset] ^= 0x01
+		return tampered, nil
+	}
+	vb.Backend = flaky
+
+	_, err := vb.LoadStateRequestCtx(context.Background(), "")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrIntegrity)
+	assert.Equal(t, 1, flaky.callCount())
+}
+
+// TestLoadStateRequestCtx_ContextCancelledDuringBackoffAbortsPromptly pins
+// that a cancelled context aborts the retry loop during backoff rather than
+// waiting out the full budget, and that the context error is returned.
+func TestLoadStateRequestCtx_ContextCancelledDuringBackoffAbortsPromptly(t *testing.T) {
+	key := testKey(t, 0x42)
+	vb := newFileBackedVB(t, "vol-retry-cancel", key)
+	vb.BlockSize = DefaultBlockSize
+	require.NoError(t, vb.SaveState())
+
+	flaky := &flakyConfigBackend{Backend: vb.Backend}
+	flaky.mutate = func(call int, data []byte, err error) ([]byte, error) {
+		// Always a retryable transport-shaped failure so the loop enters
+		// backoff (100ms) after the first attempt.
+		return nil, fmt.Errorf("simulated transport error: %w", errors.New("connection reset"))
+	}
+	vb.Backend = flaky
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	_, err := vb.LoadStateRequestCtx(ctx, "")
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, flaky.callCount(), "cancellation must land during the first backoff, before a second attempt")
+	assert.Less(t, elapsed, 400*time.Millisecond,
+		"cancellation must abort promptly, not wait out the full retry budget (~700ms)")
+}

--- a/viperblock/state_retry_test.go
+++ b/viperblock/state_retry_test.go
@@ -1,7 +1,7 @@
 // Unit tests for LoadStateRequestCtx's backend-path retry: a bounded,
 // backed-off re-attempt of the VBState backend read that distinguishes a
 // transient/truncated read from genuinely-missing state or a fail-closed
-// crypto failure. See docs/development/bugs/recovery-vbstate-transient-read-misclassified.md.
+// crypto failure.
 
 package viperblock
 
@@ -77,6 +77,29 @@ func TestLoadStateRequestCtx_RetriesTruncatedBackendRead(t *testing.T) {
 		}
 		// Truncate the envelope so it fails JSON parsing, exactly like a
 		// connection dropped mid-body -- not a bit flip, a short read.
+		return data[:len(data)-5], nil
+	}
+	vb.Backend = flaky
+
+	state, err := vb.LoadStateRequestCtx(context.Background(), "")
+	require.NoError(t, err)
+	assert.Equal(t, vb.VolumeName, state.VolumeName)
+	assert.Equal(t, 2, flaky.callCount(), "must succeed on the second attempt, not the first")
+}
+
+// TestLoadStateRequestCtx_RetriesTruncatedPlainBackendRead covers the
+// unencrypted path, where nothing inspects the payload before the final JSON
+// decode — so truncation first surfaces there and must still be retried.
+func TestLoadStateRequestCtx_RetriesTruncatedPlainBackendRead(t *testing.T) {
+	vb := newFileBackedVB(t, "vol-retry-plain", nil)
+	vb.BlockSize = DefaultBlockSize
+	require.NoError(t, vb.SaveState())
+
+	flaky := &flakyConfigBackend{Backend: vb.Backend}
+	flaky.mutate = func(call int, data []byte, err error) ([]byte, error) {
+		if err != nil || call != 1 {
+			return data, err
+		}
 		return data[:len(data)-5], nil
 	}
 	vb.Backend = flaky

--- a/viperblock/viperblock.go
+++ b/viperblock/viperblock.go
@@ -5319,21 +5319,76 @@ func (vb *VB) LoadStateRequest(filename string) (state VBState, err error) {
 	return vb.LoadStateRequestCtx(context.Background(), filename)
 }
 
+// stateReadMaxAttempts and stateReadInitialBackoff bound the backend-path
+// retry in LoadStateRequestCtx: 4 attempts, exponential backoff from 100ms
+// (100ms/200ms/400ms between attempts), comfortably covering a predastore
+// warm-up window of ~1s without materially slowing a genuine failure.
+const stateReadMaxAttempts = 4
+
+const stateReadInitialBackoff = 100 * time.Millisecond
+
 // LoadStateRequestCtx is LoadStateRequest with a caller-supplied context
-// threaded through the backend fetch.
+// threaded through the backend fetch. A local file read (filename != "") is
+// single-shot — it is not racing anything. A backend read (filename == "")
+// retries transport- and truncation-shaped failures with bounded backoff,
+// since post-reboot recovery races the backend's own startup and a single
+// unretried short read would otherwise be misclassified as permanent
+// corruption. The final error keeps the same ErrIntegrity/ErrEncryptionMismatch
+// contract existing callers match on.
 func (vb *VB) LoadStateRequestCtx(ctx context.Context, filename string) (state VBState, err error) {
+	if filename != "" {
+		state, _, err = vb.loadStateAttemptCtx(ctx, filename)
+		return state, err
+	}
+
+	backoff := stateReadInitialBackoff
+	var retryable bool
+	for attempt := 1; attempt <= stateReadMaxAttempts; attempt++ {
+		state, retryable, err = vb.loadStateAttemptCtx(ctx, "")
+		if err == nil {
+			return state, nil
+		}
+		if !retryable || attempt == stateReadMaxAttempts {
+			return state, err
+		}
+
+		vb.logger().WarnContext(ctx, "LoadStateRequestCtx: transient VBState backend read failed, retrying",
+			"volume", vb.GetVolume(), "attempt", attempt, "err", err)
+
+		timer := time.NewTimer(backoff)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return state, ctx.Err()
+		case <-timer.C:
+		}
+		backoff *= 2
+	}
+
+	return state, err
+}
+
+// loadStateAttemptCtx performs a single VBState read-and-parse attempt,
+// either from filename (if non-empty) or from vb.Backend, and reports
+// whether a failure is transient/truncation-shaped and therefore safe to
+// retry. Object-not-found, a wrong-key KeyFingerprint, and a tag-verify
+// failure are never retryable: they are either genuinely missing state or a
+// fail-closed crypto failure, not a race with a warming-up backend.
+func (vb *VB) loadStateAttemptCtx(ctx context.Context, filename string) (state VBState, retryable bool, err error) {
 	var jsonData []byte
 
 	// Read from file
 	if filename != "" {
 		jsonData, err = os.ReadFile(filename)
 		if err != nil {
-			return state, err
+			return state, false, err
 		}
 	} else {
 		jsonData, err = vb.Backend.ReadCtx(ctx, types.FileTypeConfig, 0, 0, 0)
 		if err != nil {
-			return state, err
+			// Object-not-found is genuinely missing state, not a transient
+			// backend hiccup — retrying it only burns the recovery window.
+			return state, !errors.Is(err, os.ErrNotExist), err
 		}
 	}
 
@@ -5352,7 +5407,9 @@ func (vb *VB) LoadStateRequestCtx(ctx context.Context, filename string) (state V
 	if vb.EncryptionEnabled {
 		payload, tag, splitErr := splitEnvelope(jsonData)
 		if splitErr != nil {
-			return state, fmt.Errorf("%w: VBState envelope: %w", ErrIntegrity, splitErr)
+			// A malformed envelope is what a partially-served/truncated blob
+			// looks like from here, not necessarily tampering — retryable.
+			return state, true, fmt.Errorf("%w: VBState envelope: %w", ErrIntegrity, splitErr)
 		}
 		var peek struct {
 			VolumeUUID     [4]byte `json:"VolumeUUID"`
@@ -5360,16 +5417,18 @@ func (vb *VB) LoadStateRequestCtx(ctx context.Context, filename string) (state V
 			KeyFingerprint string  `json:"KeyFingerprint"`
 		}
 		if err := json.Unmarshal(payload, &peek); err != nil {
-			return state, fmt.Errorf("%w: VBState peek parse: %w", ErrIntegrity, err)
+			// Same reasoning as the envelope split above: truncation-shaped.
+			return state, true, fmt.Errorf("%w: VBState peek parse: %w", ErrIntegrity, err)
 		}
 		if peek.KeyFingerprint != vb.MasterKey.Fingerprint {
-			return state, fmt.Errorf("%w: volume %s sealed under key %s, supplied key is %s",
+			return state, false, fmt.Errorf("%w: volume %s sealed under key %s, supplied key is %s",
 				ErrEncryptionMismatch, vb.VolumeName, peek.KeyFingerprint, vb.MasterKey.Fingerprint)
 		}
 		nonce := makeNonce(peek.StateSeqNum, peek.VolumeUUID, DomainVBStateMeta)
 		aad := makeMetaAAD(vb.volumeNameHash, "vbstate", peek.StateSeqNum)
 		if err := verifyMeta(vb.aead, payload, tag, aad, nonce); err != nil {
-			return state, fmt.Errorf("%w: VBState tag verify: %w", ErrIntegrity, err)
+			// A genuine tag-verify failure is fail-closed, not retried.
+			return state, false, fmt.Errorf("%w: VBState tag verify: %w", ErrIntegrity, err)
 		}
 		jsonData = payload
 	}
@@ -5382,7 +5441,7 @@ func (vb *VB) LoadStateRequestCtx(ctx context.Context, filename string) (state V
 	// jsonData is already the verified payload, so StateBody is a no-op.
 	err = json.NewDecoder(bytes.NewReader(StateBody(jsonData))).Decode(&state)
 
-	return state, err
+	return state, false, err
 }
 
 // Private function to read a block from the storage backend, use ReadAt for public access.

--- a/viperblock/viperblock.go
+++ b/viperblock/viperblock.go
@@ -5320,10 +5320,9 @@ func (vb *VB) LoadStateRequest(filename string) (state VBState, err error) {
 }
 
 // stateReadMaxAttempts and stateReadInitialBackoff bound the backend-path
-// retry in LoadStateRequestCtx: 4 attempts, exponential backoff from 100ms
-// (100ms/200ms/400ms between attempts), comfortably covering a predastore
-// warm-up window of ~1s without materially slowing a genuine failure.
-const stateReadMaxAttempts = 4
+// retry in LoadStateRequestCtx: 5 attempts over ~1.5s of backoff, covering an
+// observed ~1s backend warm-up with margin.
+const stateReadMaxAttempts = 5
 
 const stateReadInitialBackoff = 100 * time.Millisecond
 
@@ -5441,7 +5440,10 @@ func (vb *VB) loadStateAttemptCtx(ctx context.Context, filename string) (state V
 	// jsonData is already the verified payload, so StateBody is a no-op.
 	err = json.NewDecoder(bytes.NewReader(StateBody(jsonData))).Decode(&state)
 
-	return state, false, err
+	// On a plain volume nothing above inspects the payload, so a truncated
+	// blob first surfaces here as a JSON error — the same truncation shape
+	// the envelope split catches for encrypted volumes, so retry it too.
+	return state, err != nil, err
 }
 
 // Private function to read a block from the storage backend, use ReadAt for public access.


### PR DESCRIPTION
## Summary

Post-reboot instance recovery races predastore's startup. `LoadStateRequestCtx` issued exactly one unretried full-object GET of a volume's `config.json`; when that read came back short/truncated, the resulting parse failure (`unexpected end of JSON input`) was misclassified as permanent `ErrIntegrity`, and the instance was marked `recovery_failed` on a single shot.

Implements sections 1 and 2 of `docs/development/bugs/recovery-vbstate-transient-read-misclassified.md` (section 3, the spinifex daemon readiness probe, is a separate PR).

## Changes

- **`viperblock/viperblock.go`**: `LoadStateRequestCtx`'s backend path (`filename == ""`) now retries through a new `loadStateAttemptCtx` helper with bounded backoff (4 attempts, exponential from 100ms). Each attempt classifies its failure as retryable (transport error, `types.ErrShortRead`, envelope-split/peek-parse failure — all truncation-shaped) or terminal (object-not-found, `ErrEncryptionMismatch`, tag-verify failure — genuinely missing state or a fail-closed crypto failure). The local-file path (`filename != ""`) stays single-shot since it isn't racing anything. Backoff honours `ctx` cancellation. Each retry logs at WARN with volume/attempt/error. The final error keeps the same `ErrIntegrity`/`ErrEncryptionMismatch` values existing callers match on.
- **`viperblock/backends/s3/s3.go`**: `ReadCtx` now guards full-object reads (`length == 0`) against a short body by comparing `len(res)` to the response's own `Content-Length`, returning `types.ErrShortRead` on mismatch. A nil/negative `Content-Length` (chunked response) skips the check. This turns the truncated-body case into an honest, retryable transport error instead of silently handing back a short blob that fails downstream JSON parsing.

## Testing

- New `viperblock/state_retry_test.go`: retry-then-succeed (2 attempts), exhaustion (4 attempts, final error still wraps `ErrIntegrity`), no-retry on `ErrEncryptionMismatch` (1 attempt), no-retry on tag-verify failure (1 attempt), and context cancellation aborting promptly during backoff.
- New tests in `viperblock/backends/s3/s3_test.go`: full-object short body vs `Content-Length` → `ErrShortRead`; nil `Content-Length` (chunked) → success; matching `Content-Length` control case.
- `make preflight` passes (lint, govulncheck, test-cover, diff-coverage, test-race).

## Test plan

- [x] `make preflight` green in viperblock
- [ ] Live: delay `spinifex-predastore.service` start on a dev single-node so the daemon's gate races it, reboot with running instances, confirm recovery succeeds with the new retry WARN visible in the viperblock journal (tracked separately alongside the section-3 readiness-probe PR)