### PR TITLE
feat: snapshot copy metadata, state reads without an open, and read-ahead

### DIFF
--- a/nbd/viperblock.go
+++ b/nbd/viperblock.go
@@ -50,6 +50,10 @@ type ViperBlockPlugin struct {
 type ViperBlockConnection struct {
 	nbdkit.Connection
 	vb *viperblock.VB
+	// readonly mirrors the flag nbdkit passes to Open (set by its -r). The
+	// write paths refuse when it is set, so a read-only export stays read-only
+	// even for a client that ignores the transmission flag.
+	readonly bool
 }
 
 // activeVB holds the VB for the current open connection. CanMultiConn returns
@@ -408,7 +412,7 @@ func (p *ViperBlockPlugin) Open(readonly bool) (nbdkit.ConnectionInterface, erro
 	activeVB = vb
 	snapshotListenerDone = startSnapshotListener(vb, filepath.Join(base_dir, volume, "snapshot.sock"))
 	success = true
-	return &ViperBlockConnection{vb: vb}, nil
+	return &ViperBlockConnection{vb: vb, readonly: readonly}, nil
 }
 
 // startSnapshotListener opens a unix socket that spinifex connects to before
@@ -504,13 +508,17 @@ func (c *ViperBlockConnection) PRead(buf []byte, offset uint64, flags uint32) er
 // Note that CanWrite is required in golang plugins, otherwise PWrite
 // will never be called.
 func (c *ViperBlockConnection) CanWrite() (bool, error) {
-	return true, nil
+	return !c.readonly, nil
 }
 
 func (c *ViperBlockConnection) PWrite(buf []byte, offset uint64,
 	flags uint32) error {
 
 	//slog.Info("PWRITE:", "len", len(buf), "offset", offset)
+
+	if c.readonly {
+		return nbdkit.PluginError{Errmsg: "write to a read-only export", Errno: syscall.EROFS}
+	}
 
 	data := make([]byte, len(buf))
 
@@ -525,12 +533,16 @@ func (c *ViperBlockConnection) PWrite(buf []byte, offset uint64,
 }
 
 func (c *ViperBlockConnection) CanZero() (bool, error) {
-	return true, nil
+	return !c.readonly, nil
 }
 
 func (c *ViperBlockConnection) Zero(count uint32, offset uint64, flags uint32) error {
 
 	slog.Debug("ZERO:", "len", count, "offset", offset)
+
+	if c.readonly {
+		return nbdkit.PluginError{Errmsg: "zero on a read-only export", Errno: syscall.EROFS}
+	}
 
 	if count == 0 {
 		return nil
@@ -548,12 +560,16 @@ func (c *ViperBlockConnection) Zero(count uint32, offset uint64, flags uint32) e
 }
 
 func (c *ViperBlockConnection) CanTrim() (bool, error) {
-	return true, nil
+	return !c.readonly, nil
 }
 
 func (c *ViperBlockConnection) Trim(count uint32, offset uint64, flags uint32) error {
 
 	slog.Debug("TRIM:", "len", count, "offset", offset)
+
+	if c.readonly {
+		return nbdkit.PluginError{Errmsg: "trim on a read-only export", Errno: syscall.EROFS}
+	}
 
 	return nil
 }

--- a/nbd/viperblock.go
+++ b/nbd/viperblock.go
@@ -39,6 +39,11 @@ const serviceName = "viperblockd"
 // WAL and replay on the next attach.
 const shutdownDrainTimeout = 20 * time.Second
 
+// openLockWait bounds how long an arriving connection waits for the volume
+// lock. It covers a handover behind the previous connection's drain, whose
+// own bound is shutdownDrainTimeout.
+const openLockWait = shutdownDrainTimeout
+
 // otelShutdown flushes the OTLP exporters on Unload, if otelsetup.Init
 // configured real ones. nil (a no-op) when OTLP export is not configured.
 var otelShutdown func(context.Context) error
@@ -270,9 +275,12 @@ func (p *ViperBlockPlugin) Open(readonly bool) (nbdkit.ConnectionInterface, erro
 	// volume. Acquired before viperblock.New() so a second concurrent
 	// connection (nbdkit's parallel thread model) never races the first
 	// through LoadState/OpenWAL/persistStateLocal — the vector that tears
-	// config.json and corrupts WAL headers. Non-blocking: a losing opener
-	// fails fast with a clear error instead of queuing.
-	lock, err := viperblock.AcquireVolumeLock(base_dir, volume)
+	// config.json and corrupts WAL headers.
+	//
+	// Waits rather than failing fast, because the common case is handover:
+	// a reconnecting client arrives while the previous connection's Close is
+	// still draining. Genuine contention still fails, just later.
+	lock, err := viperblock.AcquireVolumeLockWait(base_dir, volume, openLockWait)
 	if err != nil {
 		return &ViperBlockConnection{}, nbdkit.PluginError{Errmsg: fmt.Sprintf("Could not open volume %q: %v", volume, err)}
 	}

--- a/viperblock/backends/s3/http_client_reuse_test.go
+++ b/viperblock/backends/s3/http_client_reuse_test.go
@@ -1,0 +1,90 @@
+// What a backend costs before it has transferred a byte. Each http.Client
+// carries its own connection pool, so a client per volume is a TCP connect and
+// a TLS handshake per volume — invisible in a per-request timing and dominant
+// in a verb that issues one request.
+package s3
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// connCountingServer answers any list and counts how many distinct connections
+// it was reached over, which is the thing sharing a client is supposed to
+// change.
+type connCountingServer struct {
+	*httptest.Server
+
+	mu    sync.Mutex
+	conns map[net.Conn]struct{}
+}
+
+func newConnCountingServer(t *testing.T) *connCountingServer {
+	t.Helper()
+	s := &connCountingServer{conns: map[net.Conn]struct{}{}}
+	s.Server = httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/xml")
+		_, _ = w.Write([]byte(`<?xml version="1.0" encoding="UTF-8"?><ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>bucket</Name><KeyCount>0</KeyCount><IsTruncated>false</IsTruncated></ListBucketResult>`))
+	}))
+	s.Config.ConnState = func(c net.Conn, state http.ConnState) {
+		if state != http.StateNew {
+			return
+		}
+		s.mu.Lock()
+		s.conns[c] = struct{}{}
+		s.mu.Unlock()
+	}
+	s.Start()
+	t.Cleanup(s.Close)
+	return s
+}
+
+func (s *connCountingServer) count() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.conns)
+}
+
+// openBackends runs Init on n backends against host, each configured with the
+// supplied client. A nil client is the per-backend default.
+func openBackends(t *testing.T, host string, client *http.Client, n int) {
+	t.Helper()
+	for i := range n {
+		backend := New(S3Config{
+			VolumeName: "vol-reuse000000000" + string(rune('0'+i)),
+			Bucket:     "bucket",
+			Region:     "us-east-1",
+			AccessKey:  "reuse-access",
+			SecretKey:  "reuse-secret",
+			Host:       host,
+			HTTPClient: client,
+		})
+		require.NoError(t, backend.InitCtx(context.Background()))
+	}
+}
+
+// TestSharedHTTPClientReusesOneConnection is the fix. Three backends handed one
+// client must reach the endpoint over one connection, so only the first pays
+// for setting it up.
+func TestSharedHTTPClientReusesOneConnection(t *testing.T) {
+	server := newConnCountingServer(t)
+	openBackends(t, server.URL, NewHTTPClient(), 3)
+	require.Equal(t, 1, server.count(),
+		"backends sharing an http.Client opened more than one connection, so the pool is not being shared")
+}
+
+// TestUnsharedHTTPClientsEachConnect is the same measurement without the fix,
+// so the test above is known to be measuring the client and not something the
+// server or the SDK would have done anyway.
+func TestUnsharedHTTPClientsEachConnect(t *testing.T) {
+	server := newConnCountingServer(t)
+	openBackends(t, server.URL, nil, 3)
+	require.Equal(t, 3, server.count(),
+		"backends building their own clients somehow shared a connection")
+}

--- a/viperblock/backends/s3/init_logging_test.go
+++ b/viperblock/backends/s3/init_logging_test.go
@@ -1,0 +1,50 @@
+package s3
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Deliberately distinctive so a match cannot be a coincidence, and obviously
+// fake so the assertion failure message is harmless.
+const (
+	fakeAccessKey = "AKIA-NOTAREALACCESSKEY-0001"
+	fakeSecretKey = "s3cr3t-NOTAREALSECRETKEY-0002"
+)
+
+// TestInitDoesNotLogCredentials pins the fix for a backend init that logged
+// S3Config wholesale. S3Config carries static credentials, so logging the
+// struct writes the secret key in plaintext to wherever the embedder's logger
+// points — for spinifex, the journal and the log shipper behind it.
+func TestInitDoesNotLogCredentials(t *testing.T) {
+	server := newProbeServer(t, http.StatusOK)
+
+	var logged bytes.Buffer
+	backend := New(S3Config{
+		VolumeName: "vol-logging00000001",
+		Bucket:     "bucket",
+		Region:     "us-east-1",
+		AccessKey:  fakeAccessKey,
+		SecretKey:  fakeSecretKey,
+		Host:       server.URL,
+	})
+	backend.SetLogger(slog.New(slog.NewJSONHandler(&logged, &slog.HandlerOptions{Level: slog.LevelDebug})))
+
+	require.NoError(t, backend.InitCtx(context.Background()))
+
+	out := logged.String()
+	require.NotEmpty(t, out, "the backend logged nothing, so this asserts nothing")
+	require.NotContains(t, out, fakeSecretKey, "backend init logged the secret key")
+	require.NotContains(t, out, fakeAccessKey, "backend init logged the access key")
+
+	// The line still has to be worth emitting, or a future change could satisfy
+	// the assertions above by removing it.
+	require.True(t, strings.Contains(out, "vol-logging00000001") && strings.Contains(out, "bucket"),
+		"the init log no longer identifies which backend it is about")
+}

--- a/viperblock/backends/s3/init_probe_test.go
+++ b/viperblock/backends/s3/init_probe_test.go
@@ -1,0 +1,83 @@
+package s3
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// probeServer answers a list with an empty bucket and records what was asked
+// for, so the probe's scope is asserted from the wire rather than from the
+// call site.
+type probeServer struct {
+	*httptest.Server
+
+	mu      sync.Mutex
+	queries []map[string][]string
+	status  int
+}
+
+func newProbeServer(t *testing.T, status int) *probeServer {
+	t.Helper()
+	p := &probeServer{status: status}
+	p.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		p.mu.Lock()
+		p.queries = append(p.queries, r.URL.Query())
+		p.mu.Unlock()
+		if p.status != http.StatusOK {
+			w.WriteHeader(p.status)
+			return
+		}
+		w.Header().Set("Content-Type", "application/xml")
+		_, _ = w.Write([]byte(`<?xml version="1.0" encoding="UTF-8"?><ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>bucket</Name><KeyCount>0</KeyCount><IsTruncated>false</IsTruncated></ListBucketResult>`))
+	}))
+	t.Cleanup(p.Close)
+	return p
+}
+
+func (p *probeServer) lastQuery(t *testing.T) map[string][]string {
+	t.Helper()
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	require.NotEmpty(t, p.queries, "the backend never issued a request")
+	return p.queries[len(p.queries)-1]
+}
+
+func probeBackend(host string) *Backend {
+	return New(S3Config{
+		VolumeName: "vol-probe0000000001",
+		Bucket:     "bucket",
+		Region:     "us-east-1",
+		AccessKey:  "probe-access",
+		SecretKey:  "probe-secret",
+		Host:       host,
+	})
+}
+
+// TestInitProbeIsScopedToTheVolume is the whole point of the probe's shape.
+// An unscoped list is O(bucket) against predastore, which resolves object
+// metadata per key, so a probe that omits the prefix gets slower as the store
+// fills and takes every engine open with it.
+func TestInitProbeIsScopedToTheVolume(t *testing.T) {
+	server := newProbeServer(t, http.StatusOK)
+	backend := probeBackend(server.URL)
+	require.NoError(t, backend.InitCtx(context.Background()))
+
+	query := server.lastQuery(t)
+	require.Equal(t, []string{"vol-probe0000000001/"}, query["prefix"],
+		"the reachability probe listed the whole bucket")
+	require.Equal(t, []string{"1"}, query["max-keys"])
+}
+
+// TestInitProbeStillFailsOnAnUnusableBackend keeps the probe worth issuing.
+// Scoping it must not turn an unreachable or unauthorised backend into a
+// successful open that fails later, somewhere less obvious.
+func TestInitProbeStillFailsOnAnUnusableBackend(t *testing.T) {
+	server := newProbeServer(t, http.StatusForbidden)
+	backend := probeBackend(server.URL)
+	require.Error(t, backend.InitCtx(context.Background()))
+}

--- a/viperblock/backends/s3/init_probe_test.go
+++ b/viperblock/backends/s3/init_probe_test.go
@@ -47,6 +47,12 @@ func (p *probeServer) lastQuery(t *testing.T) map[string][]string {
 	return p.queries[len(p.queries)-1]
 }
 
+func (p *probeServer) requestCount() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return len(p.queries)
+}
+
 func probeBackend(host string) *Backend {
 	return New(S3Config{
 		VolumeName: "vol-probe0000000001",
@@ -71,6 +77,17 @@ func TestInitProbeIsScopedToTheVolume(t *testing.T) {
 	require.Equal(t, []string{"vol-probe0000000001/"}, query["prefix"],
 		"the reachability probe listed the whole bucket")
 	require.Equal(t, []string{"1"}, query["max-keys"])
+}
+
+// TestInitReadOnlyIssuesNoProbe is the saving a read-only open exists for.
+// Even scoped, the probe is a full round trip and predastore answers it by
+// resolving metadata for every object under the volume's prefix — real work
+// to learn something the state read that follows would report anyway.
+func TestInitReadOnlyIssuesNoProbe(t *testing.T) {
+	server := newProbeServer(t, http.StatusOK)
+	backend := probeBackend(server.URL)
+	require.NoError(t, backend.InitReadOnlyCtx(context.Background()))
+	require.Zero(t, server.requestCount(), "a read-only init went to the backend")
 }
 
 // TestInitProbeStillFailsOnAnUnusableBackend keeps the probe worth issuing.

--- a/viperblock/backends/s3/s3.go
+++ b/viperblock/backends/s3/s3.go
@@ -221,6 +221,50 @@ func (backend *Backend) InitCtx(ctx context.Context) error {
 	return nil
 }
 
+// NewHTTPClient builds the HTTP client the S3 backend uses when S3Config
+// leaves one unset. A caller that opens many volumes against one endpoint
+// should build one of these and share it through S3Config.HTTPClient: each
+// client keeps its own connection pool, so a client per volume turns into a
+// TLS handshake per volume.
+func NewHTTPClient() *http.Client {
+	// HTTP/2 multiplexes requests over a single TCP connection, avoiding a
+	// TLS handshake per request. ForceAttemptHTTP2 enables stdlib ALPN h2
+	// negotiation against an h2-capable server
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			// Enable TLS session resumption for faster reconnects if HTTP/2 fails
+			ClientSessionCache: tls.NewLRUClientSessionCache(256),
+			// Ensure HTTP/2 ALPN is advertised
+			NextProtos: []string{"h2", "http/1.1"},
+		},
+
+		// Connection pool settings - still useful as HTTP/2 fallback
+		MaxIdleConns:        200,
+		MaxIdleConnsPerHost: 200,
+		MaxConnsPerHost:     0,
+		IdleConnTimeout:     120 * time.Second,
+
+		// Keep-alive settings
+		DisableKeepAlives: false,
+		ForceAttemptHTTP2: true,
+
+		// Timeouts
+		TLSHandshakeTimeout:   10 * time.Second,
+		ResponseHeaderTimeout: 60 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
+
+	return &http.Client{
+		// otelhttp emits a client span per S3 request, but only when the
+		// request context already carries a span: background chunk I/O and
+		// guest block reads would otherwise root a trace per S3 call.
+		Transport: otelhttp.NewTransport(tr, otelhttp.WithFilter(func(r *http.Request) bool {
+			return trace.SpanFromContext(r.Context()).SpanContext().IsValid()
+		})),
+		Timeout: 120 * time.Second,
+	}
+}
+
 // InitReadOnlyCtx builds the client without the reachability probe. A caller
 // that only reads state does not need it: the read that follows fails on an
 // unreachable or unauthorised backend just as the probe would, so paying for
@@ -238,42 +282,7 @@ func (backend *Backend) InitReadOnlyCtx(ctx context.Context) error {
 
 	client := backend.config.HTTPClient
 	if client == nil {
-		// HTTP/2 multiplexes requests over a single TCP connection, avoiding a
-		// TLS handshake per request. ForceAttemptHTTP2 enables stdlib ALPN h2
-		// negotiation against an h2-capable server
-		tr := &http.Transport{
-			TLSClientConfig: &tls.Config{
-				// Enable TLS session resumption for faster reconnects if HTTP/2 fails
-				ClientSessionCache: tls.NewLRUClientSessionCache(256),
-				// Ensure HTTP/2 ALPN is advertised
-				NextProtos: []string{"h2", "http/1.1"},
-			},
-
-			// Connection pool settings - still useful as HTTP/2 fallback
-			MaxIdleConns:        200,
-			MaxIdleConnsPerHost: 200,
-			MaxConnsPerHost:     0,
-			IdleConnTimeout:     120 * time.Second,
-
-			// Keep-alive settings
-			DisableKeepAlives: false,
-			ForceAttemptHTTP2: true,
-
-			// Timeouts
-			TLSHandshakeTimeout:   10 * time.Second,
-			ResponseHeaderTimeout: 60 * time.Second,
-			ExpectContinueTimeout: 1 * time.Second,
-		}
-
-		client = &http.Client{
-			// otelhttp emits a client span per S3 request, but only when the
-			// request context already carries a span: background chunk I/O and
-			// guest block reads would otherwise root a trace per S3 call.
-			Transport: otelhttp.NewTransport(tr, otelhttp.WithFilter(func(r *http.Request) bool {
-				return trace.SpanFromContext(r.Context()).SpanContext().IsValid()
-			})),
-			Timeout: 120 * time.Second,
-		}
+		client = NewHTTPClient()
 	}
 
 	// Use the AWS SDK to initialize the S3 backend.

--- a/viperblock/backends/s3/s3.go
+++ b/viperblock/backends/s3/s3.go
@@ -276,8 +276,14 @@ func (backend *Backend) InitCtx(ctx context.Context) error {
 		},
 	})
 
+	// Reachability probe: prove the bucket exists, the credentials sign and
+	// the endpoint answers. Scoped to this volume because an unscoped list is
+	// O(bucket) against predastore, which resolves object metadata per key and
+	// truncates only the reported count. An empty result is still a success.
 	_, err := backend.config.s3Client.ListObjectsV2(ctx, &s3.ListObjectsV2Input{
-		Bucket: aws.String(backend.config.Bucket),
+		Bucket:  aws.String(backend.config.Bucket),
+		Prefix:  aws.String(backend.config.VolumeName + "/"),
+		MaxKeys: aws.Int32(1),
 	})
 
 	if err != nil {

--- a/viperblock/backends/s3/s3.go
+++ b/viperblock/backends/s3/s3.go
@@ -199,6 +199,33 @@ func (backend *Backend) Init() error {
 }
 
 func (backend *Backend) InitCtx(ctx context.Context) error {
+	if err := backend.InitReadOnlyCtx(ctx); err != nil {
+		return err
+	}
+
+	// Reachability probe: prove the bucket exists, the credentials sign and
+	// the endpoint answers. Scoped to this volume because an unscoped list is
+	// O(bucket) against predastore, which resolves object metadata per key and
+	// truncates only the reported count. An empty result is still a success.
+	_, err := backend.config.s3Client.ListObjectsV2(ctx, &s3.ListObjectsV2Input{
+		Bucket:  aws.String(backend.config.Bucket),
+		Prefix:  aws.String(backend.config.VolumeName + "/"),
+		MaxKeys: aws.Int32(1),
+	})
+
+	if err != nil {
+		backend.log.ErrorContext(ctx, "Error listing objects", "error", err)
+		return err
+	}
+
+	return nil
+}
+
+// InitReadOnlyCtx builds the client without the reachability probe. A caller
+// that only reads state does not need it: the read that follows fails on an
+// unreachable or unauthorised backend just as the probe would, so paying for
+// a list as well is a round trip spent to learn nothing.
+func (backend *Backend) InitReadOnlyCtx(ctx context.Context) error {
 	// Log only the fields that identify the backend. S3Config carries the
 	// static credentials, so logging the struct wholesale would write the
 	// secret key in plaintext to wherever the embedder's logger points.
@@ -275,21 +302,6 @@ func (backend *Backend) InitCtx(ctx context.Context) error {
 			},
 		},
 	})
-
-	// Reachability probe: prove the bucket exists, the credentials sign and
-	// the endpoint answers. Scoped to this volume because an unscoped list is
-	// O(bucket) against predastore, which resolves object metadata per key and
-	// truncates only the reported count. An empty result is still a success.
-	_, err := backend.config.s3Client.ListObjectsV2(ctx, &s3.ListObjectsV2Input{
-		Bucket:  aws.String(backend.config.Bucket),
-		Prefix:  aws.String(backend.config.VolumeName + "/"),
-		MaxKeys: aws.Int32(1),
-	})
-
-	if err != nil {
-		backend.log.ErrorContext(ctx, "Error listing objects", "error", err)
-		return err
-	}
 
 	return nil
 }

--- a/viperblock/blockstore_test.go
+++ b/viperblock/blockstore_test.go
@@ -11,10 +11,6 @@ import (
 
 func TestBlockStore_NewUnifiedBlockStore(t *testing.T) {
 	bs := NewUnifiedBlockStore(4096)
-	if bs == nil {
-		t.Fatal("NewUnifiedBlockStore returned nil")
-	}
-
 	if bs.blockSize != 4096 {
 		t.Errorf("expected blockSize 4096, got %d", bs.blockSize)
 	}

--- a/viperblock/gc_floor_prime_test.go
+++ b/viperblock/gc_floor_prime_test.go
@@ -1,0 +1,136 @@
+package viperblock
+
+import (
+	"context"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	"github.com/mulgadc/viperblock/types"
+	"github.com/mulgadc/viperblock/viperblock/backends/file"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// checkpointReadCounter counts backend reads of the numbered block
+// checkpoint. Over S3 each of those is a round trip, which is what makes
+// fetching the same object twice per open worth removing.
+type checkpointReadCounter struct {
+	*file.Backend
+
+	reads atomic.Int64
+}
+
+var _ types.Backend = (*checkpointReadCounter)(nil)
+
+func (b *checkpointReadCounter) ReadCtx(ctx context.Context, fileType types.FileType, objectId uint64, offset uint32, length uint32) ([]byte, error) {
+	if fileType == types.FileTypeBlockCheckpoint {
+		b.reads.Add(1)
+	}
+	return b.Backend.ReadCtx(ctx, fileType, objectId, offset, length)
+}
+
+// checkpointReaderVB opens volumeName against an existing backend root with a
+// private, empty local directory, so LoadBlockStateCtx has to go to the
+// backend. That is the state a fresh process finds a volume in, and the one
+// the seal on unmount runs in.
+func checkpointReaderVB(t *testing.T, backendRoot, volumeName string, wallNum uint64) (*VB, *checkpointReadCounter) {
+	t.Helper()
+
+	vbconfig := VB{
+		VolumeName:      volumeName,
+		VolumeSize:      volumeSize,
+		BaseDir:         filepath.Join(t.TempDir(), "viperblock"),
+		WALSyncInterval: -1,
+		GCEnabled:       true,
+		GCInterval:      -1,
+		Cache:           Cache{Config: CacheConfig{Size: 0}},
+	}
+
+	vb, err := New(&vbconfig, FileBackend, file.FileConfig{
+		VolumeName: volumeName,
+		VolumeSize: volumeSize,
+		BaseDir:    backendRoot,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, vb.RemoveLocalFiles()) })
+
+	fb, ok := vb.Backend.(*file.Backend)
+	require.True(t, ok)
+	require.NoError(t, fb.Init())
+
+	counter := &checkpointReadCounter{Backend: fb}
+	vb.Backend = counter
+	vb.BlockToObjectWAL.WallNum.Store(wallNum)
+
+	return vb, counter
+}
+
+// seedCheckpoint writes two chunks and persists a numbered checkpoint
+// referencing both, returning the checkpoint's WallNum and the highest chunk
+// ObjectID it names.
+func seedCheckpoint(t *testing.T, root, volumeName string) (wallNum, highestChunk uint64) {
+	t.Helper()
+
+	writer := newGCTestVB(t, root, volumeName, true)
+	writeAndChunk(t, writer, 0, randomBlockData(4))
+	writeAndChunk(t, writer, 64, randomBlockData(4))
+
+	wallNum = writer.BlockToObjectWAL.WallNum.Load()
+	highestChunk = writer.ObjectNum.Load() - 1
+	require.NoError(t, writer.SaveBlockState())
+
+	return wallNum, highestChunk
+}
+
+// TestGCFloor_ReusesTheCheckpointTheStateLoadFetched pins the fix for an open
+// that fetched the numbered checkpoint twice: once to build the block map and
+// again, unchanged, to compute the GC floor.
+func TestGCFloor_ReusesTheCheckpointTheStateLoadFetched(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	volumeName := "vol-gcfloor-prime"
+
+	wallNum, highestChunk := seedCheckpoint(t, root, volumeName)
+	reader, counter := checkpointReaderVB(t, root, volumeName, wallNum)
+
+	require.NoError(t, reader.LoadBlockStateCtx(ctx))
+	require.Equal(t, int64(1), counter.reads.Load(), "the block state load itself read the checkpoint more than once")
+
+	floor := reader.ensureGCFloor(ctx)
+	assert.Equal(t, highestChunk+1, floor, "the primed floor does not match the checkpoint's high water")
+	assert.Equal(t, int64(1), counter.reads.Load(),
+		"the GC floor re-read the numbered checkpoint the block state load had already fetched")
+}
+
+// TestGCFloor_IgnoresTheLocalCheckpoint is the safety half. The local
+// checkpoint is not guaranteed to match the backend's, and a floor derived
+// from an older local copy would be lower than the backend checkpoint needs,
+// letting GC delete a chunk that checkpoint still references. Only a backend
+// read may prime.
+func TestGCFloor_IgnoresTheLocalCheckpoint(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	volumeName := "vol-gcfloor-local"
+
+	// newGCTestVB shares root between the VB tree and the backend tree, so this
+	// writer keeps its own local checkpoint alongside the backend's.
+	writer := newGCTestVB(t, root, volumeName, true)
+	writeAndChunk(t, writer, 0, randomBlockData(4))
+	wallNum := writer.BlockToObjectWAL.WallNum.Load()
+	require.NoError(t, writer.SaveBlockState())
+	writer.BlockToObjectWAL.WallNum.Store(wallNum)
+
+	fb, ok := writer.Backend.(*file.Backend)
+	require.True(t, ok)
+	counter := &checkpointReadCounter{Backend: fb}
+	writer.Backend = counter
+
+	require.NoError(t, writer.LoadBlockStateCtx(ctx))
+	require.Equal(t, int64(0), counter.reads.Load(), "the local checkpoint was present but the backend was read anyway")
+	assert.False(t, writer.gcFloorReady.Load(), "the GC floor was primed from the local checkpoint")
+
+	// And the floor it does end up with comes from the backend.
+	writer.ensureGCFloor(ctx)
+	assert.Equal(t, int64(1), counter.reads.Load(), "the GC floor was not read from the backend")
+}

--- a/viperblock/read_amplification_test.go
+++ b/viperblock/read_amplification_test.go
@@ -3,6 +3,7 @@ package viperblock
 import (
 	"context"
 	"path/filepath"
+	"sync"
 	"sync/atomic"
 	"testing"
 
@@ -27,6 +28,7 @@ type chunkReadCounter struct {
 	*file.Backend
 
 	reads atomic.Int64
+	bytes atomic.Int64
 }
 
 var _ types.Backend = (*chunkReadCounter)(nil)
@@ -34,6 +36,7 @@ var _ types.Backend = (*chunkReadCounter)(nil)
 func (b *chunkReadCounter) ReadCtx(ctx context.Context, fileType types.FileType, objectId uint64, offset uint32, length uint32) ([]byte, error) {
 	if fileType == types.FileTypeChunk {
 		b.reads.Add(1)
+		b.bytes.Add(int64(length))
 	}
 	return b.Backend.ReadCtx(ctx, fileType, objectId, offset, length)
 }
@@ -200,6 +203,85 @@ func TestSequentialRead_EncryptedStreamIsWidenedAndCorrect(t *testing.T) {
 	require.Equal(t, written, got, "an encrypted stream came back wrong once readahead widened it")
 	assert.Less(t, backendReads, int64(requests),
 		"an encrypted sequential stream was not widened")
+}
+
+// TestConcurrentSequentialRead_IsNotRefetchedByEveryRequest is what a guest
+// with a queue actually looks like: several sequential requests outstanding at
+// once. Each continues the stream, so readahead fires on all of them, and each
+// prefetch lands after the request that would have wanted it has already gone
+// to the backend itself — every widened byte is duplicate traffic.
+//
+// Bytes, not read counts, is the measure that catches it. Round trips fall
+// while traffic multiplies, and at depth the store is bound by the latter:
+// unguarded, this pattern cost 4.3x the volume in reads and took depth-16
+// sequential throughput on env19 from 66.6 MiB/s to 11.6.
+func TestConcurrentSequentialRead_IsNotRefetchedByEveryRequest(t *testing.T) {
+	const queueDepth = 16
+	volumeName := "vol-readamp-concurrent"
+
+	root, written := seedSequentialVolume(t, volumeName, nil)
+	reader, counter := coldReaderVB(t, root, volumeName, nil)
+
+	offsets := make(chan uint64)
+	got := make([][]byte, readAmpVolumeBytes/readAmpRequestBytes)
+
+	var wg sync.WaitGroup
+	for range queueDepth {
+		wg.Go(func() {
+			for offset := range offsets {
+				data, err := reader.ReadAtCtx(context.Background(), offset, readAmpRequestBytes)
+				assert.NoErrorf(t, err, "read at offset %d", offset)
+				got[offset/readAmpRequestBytes] = data
+			}
+		})
+	}
+	// Submitted in order, served out of order: the queue, not the stream, is
+	// what reorders them.
+	for offset := uint64(0); offset < readAmpVolumeBytes; offset += readAmpRequestBytes {
+		offsets <- offset
+	}
+	close(offsets)
+	wg.Wait()
+
+	stream := make([]byte, 0, readAmpVolumeBytes)
+	for _, data := range got {
+		stream = append(stream, data...)
+	}
+	require.Equal(t, written, stream, "a concurrent stream came back wrong")
+
+	backendBytes := counter.bytes.Load()
+	t.Logf("concurrent stream at depth %d: %d backend chunk reads, %d bytes for a %d byte volume",
+		queueDepth, counter.reads.Load(), backendBytes, readAmpVolumeBytes)
+
+	// A queued reader covers its own latency, so it should read the volume once
+	// and no more. The margin allows the odd request that finds itself briefly
+	// alone in flight and is widened on that basis.
+	assert.LessOrEqual(t, backendBytes, int64(readAmpVolumeBytes*5/4),
+		"a queued guest is paying for readahead it already covers with its own queue")
+}
+
+// TestReadahead_StreamStartingAgainBehindItselfIsStillWidened covers what
+// holding requests back against a window costs if the window is never given
+// up: a reader that seeks back to the start and streams again sits behind the
+// old window for its whole run and is never widened. A guest doing this looks
+// entirely ordinary — a second pass over a file, a reboot.
+func TestReadahead_StreamStartingAgainBehindItselfIsStillWidened(t *testing.T) {
+	volumeName := "vol-readamp-restart"
+
+	root, written := seedSequentialVolume(t, volumeName, nil)
+	reader, counter := coldReaderVB(t, root, volumeName, nil)
+
+	_, _ = readSequentially(t, reader)
+	// Cold again, so the second pass has to go to the backend to be counted.
+	reader.Cache.purge()
+	firstPass := counter.reads.Load()
+
+	got, requests := readSequentially(t, reader)
+	secondPass := counter.reads.Load() - firstPass
+
+	require.Equal(t, written, got, "the second pass over the volume came back wrong")
+	assert.Less(t, secondPass, int64(requests),
+		"a stream starting again behind the previous one was never widened")
 }
 
 // TestRandomRead_IsNotWidened is the regression that matters more than the

--- a/viperblock/read_amplification_test.go
+++ b/viperblock/read_amplification_test.go
@@ -6,6 +6,7 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/mulgadc/predastore/pkg/masterkey"
 	"github.com/mulgadc/viperblock/types"
 	"github.com/mulgadc/viperblock/viperblock/backends/file"
 	"github.com/stretchr/testify/assert"
@@ -38,8 +39,9 @@ func (b *chunkReadCounter) ReadCtx(ctx context.Context, fileType types.FileType,
 }
 
 // seedSequentialVolume writes readAmpVolumeBytes and pushes it all into
-// chunks, returning the root the backend is stored under.
-func seedSequentialVolume(t *testing.T, volumeName string) string {
+// chunks, returning the root the backend is stored under and the bytes
+// written, so a reader can be checked against them rather than only counted.
+func seedSequentialVolume(t *testing.T, volumeName string, key *masterkey.Key) (string, []byte) {
 	t.Helper()
 
 	root := t.TempDir()
@@ -52,6 +54,9 @@ func seedSequentialVolume(t *testing.T, volumeName string) string {
 		GCEnabled:       false,
 		GCInterval:      -1,
 		Cache:           Cache{Config: CacheConfig{Size: 0}},
+
+		MasterKey:         key,
+		EncryptionEnabled: key != nil,
 	}
 	writer, err := New(&vbconfig, FileBackend, file.FileConfig{
 		VolumeName: volumeName,
@@ -63,9 +68,12 @@ func seedSequentialVolume(t *testing.T, volumeName string) string {
 	require.NoError(t, writer.OpenWAL(&writer.WAL, filepath.Join(writer.WAL.BaseDir, types.GetFilePath(types.FileTypeWALChunk, writer.WAL.WallNum.Load(), writer.GetVolume()))))
 	require.NoError(t, writer.OpenWAL(&writer.BlockToObjectWAL, filepath.Join(writer.BlockToObjectWAL.BaseDir, types.GetFilePath(types.FileTypeWALBlock, writer.BlockToObjectWAL.WallNum.Load(), writer.GetVolume()))))
 
+	written := make([]byte, 0, readAmpVolumeBytes)
 	blocksPerWrite := uint64(readAmpRequestBytes) / uint64(DefaultBlockSize)
 	for block := uint64(0); block < uint64(readAmpVolumeBytes)/uint64(DefaultBlockSize); block += blocksPerWrite {
-		require.NoError(t, writer.Write(block, randomBlockData(blocksPerWrite)))
+		payload := randomBlockData(blocksPerWrite)
+		require.NoError(t, writer.Write(block, payload))
+		written = append(written, payload...)
 	}
 	require.NoError(t, writer.Flush())
 	require.NoError(t, writer.WriteWALToChunk(true))
@@ -73,12 +81,12 @@ func seedSequentialVolume(t *testing.T, volumeName string) string {
 	// checkpoint in the order a reopen expects to find them.
 	require.NoError(t, writer.Close())
 
-	return root
+	return root, written
 }
 
 // coldReaderVB opens volumeName with an empty local directory and a cold
 // cache, which is what every new NBD connection gets.
-func coldReaderVB(t *testing.T, backendRoot, volumeName string) (*VB, *chunkReadCounter) {
+func coldReaderVB(t *testing.T, backendRoot, volumeName string, key *masterkey.Key) (*VB, *chunkReadCounter) {
 	t.Helper()
 
 	vbconfig := VB{
@@ -88,7 +96,13 @@ func coldReaderVB(t *testing.T, backendRoot, volumeName string) (*VB, *chunkRead
 		WALSyncInterval: -1,
 		GCEnabled:       false,
 		GCInterval:      -1,
-		Cache:           Cache{Config: CacheConfig{Size: DefaultCacheBlocks}},
+		// The size spinifex opens data volumes with. DefaultCacheBlocks is 20,
+		// far smaller than a readahead window, which would make the prefetched
+		// blocks evict each other before the requests that want them arrive.
+		Cache: Cache{Config: CacheConfig{Size: (128 << 20) / int(DefaultBlockSize)}},
+
+		MasterKey:         key,
+		EncryptionEnabled: key != nil,
 	}
 
 	vb, err := New(&vbconfig, FileBackend, file.FileConfig{
@@ -111,39 +125,143 @@ func coldReaderVB(t *testing.T, backendRoot, volumeName string) (*VB, *chunkRead
 	return vb, counter
 }
 
-// TestSequentialRead_CostsOneBackendReadPerRequest records what the read path
-// currently does, which the live data-path numbers only inferred from timing:
-// a sequential stream costs one backend round trip per NBD request, not per
-// chunk. Over the object store each of those is ~4.8 ms, so a depth-1
-// sequential reader is bounded at one request per round trip however large
-// the chunks are.
-//
-// The two numbers are the whole point of the test. Requests is what the
-// client asked for; chunks is the lower bound any fetch strategy could
-// achieve. Today they are 256 and 4.
-func TestSequentialRead_CostsOneBackendReadPerRequest(t *testing.T) {
+// readSequentially streams the whole seeded region and returns what it read
+// plus the request count.
+func readSequentially(t *testing.T, reader *VB) ([]byte, int) {
+	t.Helper()
 	ctx := context.Background()
-	volumeName := "vol-readamp"
 
-	root := seedSequentialVolume(t, volumeName)
-	reader, counter := coldReaderVB(t, root, volumeName)
-
+	got := make([]byte, 0, readAmpVolumeBytes)
 	requests := 0
 	for offset := uint64(0); offset < readAmpVolumeBytes; offset += readAmpRequestBytes {
 		data, err := reader.ReadAtCtx(ctx, offset, readAmpRequestBytes)
 		require.NoErrorf(t, err, "read at offset %d", offset)
 		require.Len(t, data, readAmpRequestBytes)
+		got = append(got, data...)
 		requests++
 	}
+	return got, requests
+}
+
+// TestSequentialRead_CostsFarFewerBackendReadsThanRequests is the point of
+// readahead. Before it, a sequential stream cost one backend round trip per
+// request — 256 reads for 4 chunks — and at the ~4.8 ms round trip measured
+// on env19 that bounded a depth-1 sequential reader at 13 MiB/s.
+//
+// The two reference numbers are what make the assertion meaningful. Requests
+// is what the client asked for; chunks touched is the floor any fetch
+// strategy could reach.
+func TestSequentialRead_CostsFarFewerBackendReadsThanRequests(t *testing.T) {
+	volumeName := "vol-readamp"
+
+	root, written := seedSequentialVolume(t, volumeName, nil)
+	reader, counter := coldReaderVB(t, root, volumeName, nil)
+
+	got, requests := readSequentially(t, reader)
 
 	chunksTouched := int64(readAmpVolumeBytes / reader.ObjBlockSize)
 	backendReads := counter.reads.Load()
+	blocksPerRequest := int64(readAmpRequestBytes / DefaultBlockSize)
 
 	require.Positive(t, backendReads, "no chunk was read from the backend, so this measures nothing")
 	t.Logf("sequential stream: %d requests, %d chunks touched, %d backend chunk reads",
 		requests, chunksTouched, backendReads)
 
-	assert.Equal(t, int64(requests), backendReads,
-		"read amplification changed: this test records one backend read per request, "+
-			"so a fetch strategy that reads wider than the request must update it (lower bound is %d)", chunksTouched)
+	require.Equal(t, written, got, "readahead changed what the stream returned")
+
+	// One fetch covers the request plus readAheadBlocks of stream, so the
+	// round trips fall by about that ratio. Asserting the ratio rather than an
+	// exact count leaves room for the run boundaries to land differently.
+	ceiling := int64(requests)*blocksPerRequest/readAheadBlocks + chunksTouched + 1
+	assert.LessOrEqual(t, backendReads, ceiling,
+		"a sequential stream is not being widened: %d backend reads for %d requests", backendReads, requests)
+	assert.GreaterOrEqual(t, backendReads, chunksTouched,
+		"fewer backend reads than chunks touched is impossible, so the counter is wrong")
+}
+
+// TestSequentialRead_EncryptedStreamIsWidenedAndCorrect is the assertion that
+// matters most on a production volume. Every block carries its own AEAD nonce
+// and AAD derived from its SeqNum, so blocks pulled in by readahead have to
+// carry theirs too. Getting that wrong fails the open rather than returning
+// wrong plaintext, but only if something actually reads the widened blocks —
+// which is what the byte comparison here does.
+func TestSequentialRead_EncryptedStreamIsWidenedAndCorrect(t *testing.T) {
+	volumeName := "vol-readamp-enc"
+	key := testKey(t, 0x42)
+
+	root, written := seedSequentialVolume(t, volumeName, key)
+	reader, counter := coldReaderVB(t, root, volumeName, key)
+
+	got, requests := readSequentially(t, reader)
+
+	backendReads := counter.reads.Load()
+	t.Logf("encrypted sequential stream: %d requests, %d backend chunk reads", requests, backendReads)
+
+	require.Equal(t, written, got, "an encrypted stream came back wrong once readahead widened it")
+	assert.Less(t, backendReads, int64(requests),
+		"an encrypted sequential stream was not widened")
+}
+
+// TestRandomRead_IsNotWidened is the regression that matters more than the
+// speedup. Readahead that fires on non-sequential access reads and decrypts
+// blocks nobody asked for and evicts the cache doing it, which is worse than
+// no readahead at all.
+func TestRandomRead_IsNotWidened(t *testing.T) {
+	ctx := context.Background()
+	volumeName := "vol-readamp-random"
+
+	root, written := seedSequentialVolume(t, volumeName, nil)
+	reader, counter := coldReaderVB(t, root, volumeName, nil)
+
+	// Strided far enough apart that no request continues the previous one.
+	const stride = 1 << 20
+	requests := 0
+	for offset := uint64(0); offset+readAmpRequestBytes <= readAmpVolumeBytes; offset += stride {
+		data, err := reader.ReadAtCtx(ctx, offset, readAmpRequestBytes)
+		require.NoErrorf(t, err, "read at offset %d", offset)
+		require.Equal(t, written[offset:offset+readAmpRequestBytes], data, "wrong data at offset %d", offset)
+		requests++
+	}
+
+	assert.Equal(t, int64(requests), counter.reads.Load(),
+		"a non-sequential reader paid for readahead it cannot use")
+}
+
+// TestReadahead_FirstReadIsNotAStream pins that an opening read is not
+// mistaken for the continuation of one. Without the distinction every volume
+// would prefetch on its very first request, including the single small reads
+// that are all an EFI or cloud-init volume ever does.
+func TestReadahead_FirstReadIsNotAStream(t *testing.T) {
+	ctx := context.Background()
+	volumeName := "vol-readamp-first"
+
+	root, _ := seedSequentialVolume(t, volumeName, nil)
+	reader, counter := coldReaderVB(t, root, volumeName, nil)
+
+	_, err := reader.ReadAtCtx(ctx, 0, readAmpRequestBytes)
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(1), counter.reads.Load(), "the first read of a volume was widened")
+}
+
+// TestReadahead_DisabledCacheDoesNotWiden covers the volumes spinifex opens
+// with no cache at all. Widening a fetch whose extra blocks are dropped on the
+// floor is pure waste.
+func TestReadahead_DisabledCacheDoesNotWiden(t *testing.T) {
+	ctx := context.Background()
+	volumeName := "vol-readamp-nocache"
+
+	root, _ := seedSequentialVolume(t, volumeName, nil)
+	reader, counter := coldReaderVB(t, root, volumeName, nil)
+	reader.Cache.Config.Size = 0
+
+	requests := 0
+	for offset := uint64(0); offset < 4*readAmpRequestBytes; offset += readAmpRequestBytes {
+		_, err := reader.ReadAtCtx(ctx, offset, readAmpRequestBytes)
+		require.NoError(t, err)
+		requests++
+	}
+
+	assert.Equal(t, int64(requests), counter.reads.Load(),
+		"a volume with no cache paid for readahead whose blocks it cannot keep")
 }

--- a/viperblock/read_amplification_test.go
+++ b/viperblock/read_amplification_test.go
@@ -1,0 +1,149 @@
+package viperblock
+
+import (
+	"context"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	"github.com/mulgadc/viperblock/types"
+	"github.com/mulgadc/viperblock/viperblock/backends/file"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// readAmpVolumeBytes and readAmpRequestBytes mirror the shape the live
+// data-path measurement uses: a sequential stream of 64 KiB reads over a
+// region several chunks wide.
+const (
+	readAmpVolumeBytes  = 16 << 20
+	readAmpRequestBytes = 64 << 10
+)
+
+// chunkReadCounter counts backend reads of chunk objects, which is what a
+// round trip to the object store costs on the read path.
+type chunkReadCounter struct {
+	*file.Backend
+
+	reads atomic.Int64
+}
+
+var _ types.Backend = (*chunkReadCounter)(nil)
+
+func (b *chunkReadCounter) ReadCtx(ctx context.Context, fileType types.FileType, objectId uint64, offset uint32, length uint32) ([]byte, error) {
+	if fileType == types.FileTypeChunk {
+		b.reads.Add(1)
+	}
+	return b.Backend.ReadCtx(ctx, fileType, objectId, offset, length)
+}
+
+// seedSequentialVolume writes readAmpVolumeBytes and pushes it all into
+// chunks, returning the root the backend is stored under.
+func seedSequentialVolume(t *testing.T, volumeName string) string {
+	t.Helper()
+
+	root := t.TempDir()
+
+	vbconfig := VB{
+		VolumeName:      volumeName,
+		VolumeSize:      readAmpVolumeBytes,
+		BaseDir:         filepath.Join(root, "viperblock"),
+		WALSyncInterval: -1,
+		GCEnabled:       false,
+		GCInterval:      -1,
+		Cache:           Cache{Config: CacheConfig{Size: 0}},
+	}
+	writer, err := New(&vbconfig, FileBackend, file.FileConfig{
+		VolumeName: volumeName,
+		VolumeSize: readAmpVolumeBytes,
+		BaseDir:    root,
+	})
+	require.NoError(t, err)
+	require.NoError(t, writer.Backend.Init())
+	require.NoError(t, writer.OpenWAL(&writer.WAL, filepath.Join(writer.WAL.BaseDir, types.GetFilePath(types.FileTypeWALChunk, writer.WAL.WallNum.Load(), writer.GetVolume()))))
+	require.NoError(t, writer.OpenWAL(&writer.BlockToObjectWAL, filepath.Join(writer.BlockToObjectWAL.BaseDir, types.GetFilePath(types.FileTypeWALBlock, writer.BlockToObjectWAL.WallNum.Load(), writer.GetVolume()))))
+
+	blocksPerWrite := uint64(readAmpRequestBytes) / uint64(DefaultBlockSize)
+	for block := uint64(0); block < uint64(readAmpVolumeBytes)/uint64(DefaultBlockSize); block += blocksPerWrite {
+		require.NoError(t, writer.Write(block, randomBlockData(blocksPerWrite)))
+	}
+	require.NoError(t, writer.Flush())
+	require.NoError(t, writer.WriteWALToChunk(true))
+	// Close, not the individual saves: it persists the state and the numbered
+	// checkpoint in the order a reopen expects to find them.
+	require.NoError(t, writer.Close())
+
+	return root
+}
+
+// coldReaderVB opens volumeName with an empty local directory and a cold
+// cache, which is what every new NBD connection gets.
+func coldReaderVB(t *testing.T, backendRoot, volumeName string) (*VB, *chunkReadCounter) {
+	t.Helper()
+
+	vbconfig := VB{
+		VolumeName:      volumeName,
+		VolumeSize:      readAmpVolumeBytes,
+		BaseDir:         filepath.Join(t.TempDir(), "viperblock"),
+		WALSyncInterval: -1,
+		GCEnabled:       false,
+		GCInterval:      -1,
+		Cache:           Cache{Config: CacheConfig{Size: DefaultCacheBlocks}},
+	}
+
+	vb, err := New(&vbconfig, FileBackend, file.FileConfig{
+		VolumeName: volumeName,
+		VolumeSize: readAmpVolumeBytes,
+		BaseDir:    backendRoot,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, vb.RemoveLocalFiles()) })
+
+	fb, ok := vb.Backend.(*file.Backend)
+	require.True(t, ok)
+	require.NoError(t, fb.Init())
+	require.NoError(t, vb.LoadState())
+	require.NoError(t, vb.LoadBlockState())
+
+	counter := &chunkReadCounter{Backend: fb}
+	vb.Backend = counter
+
+	return vb, counter
+}
+
+// TestSequentialRead_CostsOneBackendReadPerRequest records what the read path
+// currently does, which the live data-path numbers only inferred from timing:
+// a sequential stream costs one backend round trip per NBD request, not per
+// chunk. Over the object store each of those is ~4.8 ms, so a depth-1
+// sequential reader is bounded at one request per round trip however large
+// the chunks are.
+//
+// The two numbers are the whole point of the test. Requests is what the
+// client asked for; chunks is the lower bound any fetch strategy could
+// achieve. Today they are 256 and 4.
+func TestSequentialRead_CostsOneBackendReadPerRequest(t *testing.T) {
+	ctx := context.Background()
+	volumeName := "vol-readamp"
+
+	root := seedSequentialVolume(t, volumeName)
+	reader, counter := coldReaderVB(t, root, volumeName)
+
+	requests := 0
+	for offset := uint64(0); offset < readAmpVolumeBytes; offset += readAmpRequestBytes {
+		data, err := reader.ReadAtCtx(ctx, offset, readAmpRequestBytes)
+		require.NoErrorf(t, err, "read at offset %d", offset)
+		require.Len(t, data, readAmpRequestBytes)
+		requests++
+	}
+
+	chunksTouched := int64(readAmpVolumeBytes / reader.ObjBlockSize)
+	backendReads := counter.reads.Load()
+
+	require.Positive(t, backendReads, "no chunk was read from the backend, so this measures nothing")
+	t.Logf("sequential stream: %d requests, %d chunks touched, %d backend chunk reads",
+		requests, chunksTouched, backendReads)
+
+	assert.Equal(t, int64(requests), backendReads,
+		"read amplification changed: this test records one backend read per request, "+
+			"so a fetch strategy that reads wider than the request must update it (lower bound is %d)", chunksTouched)
+}

--- a/viperblock/read_amplification_test.go
+++ b/viperblock/read_amplification_test.go
@@ -46,6 +46,13 @@ func (b *chunkReadCounter) ReadCtx(ctx context.Context, fileType types.FileType,
 // written, so a reader can be checked against them rather than only counted.
 func seedSequentialVolume(t *testing.T, volumeName string, key *masterkey.Key) (string, []byte) {
 	t.Helper()
+	return seedVolume(t, volumeName, key, readAmpVolumeBytes)
+}
+
+// seedVolume writes writeBytes of a readAmpVolumeBytes volume, leaving the
+// rest of it never written and so sparse.
+func seedVolume(t *testing.T, volumeName string, key *masterkey.Key, writeBytes uint64) (string, []byte) {
+	t.Helper()
 
 	root := t.TempDir()
 
@@ -71,9 +78,9 @@ func seedSequentialVolume(t *testing.T, volumeName string, key *masterkey.Key) (
 	require.NoError(t, writer.OpenWAL(&writer.WAL, filepath.Join(writer.WAL.BaseDir, types.GetFilePath(types.FileTypeWALChunk, writer.WAL.WallNum.Load(), writer.GetVolume()))))
 	require.NoError(t, writer.OpenWAL(&writer.BlockToObjectWAL, filepath.Join(writer.BlockToObjectWAL.BaseDir, types.GetFilePath(types.FileTypeWALBlock, writer.BlockToObjectWAL.WallNum.Load(), writer.GetVolume()))))
 
-	written := make([]byte, 0, readAmpVolumeBytes)
+	written := make([]byte, 0, writeBytes)
 	blocksPerWrite := uint64(readAmpRequestBytes) / uint64(DefaultBlockSize)
-	for block := uint64(0); block < uint64(readAmpVolumeBytes)/uint64(DefaultBlockSize); block += blocksPerWrite {
+	for block := uint64(0); block < writeBytes/uint64(DefaultBlockSize); block += blocksPerWrite {
 		payload := randomBlockData(blocksPerWrite)
 		require.NoError(t, writer.Write(block, payload))
 		written = append(written, payload...)
@@ -258,6 +265,35 @@ func TestConcurrentSequentialRead_IsNotRefetchedByEveryRequest(t *testing.T) {
 	// alone in flight and is widened on that basis.
 	assert.LessOrEqual(t, backendBytes, int64(readAmpVolumeBytes*5/4),
 		"a queued guest is paying for readahead it already covers with its own queue")
+}
+
+// TestReadahead_StopsAtASparseRegion streams off the end of what was ever
+// written. Extending a run over unwritten blocks would cache zeroes against
+// block numbers that have no SeqNum, so a later write to one of them could be
+// answered from the cache with the zeroes that preceded it.
+func TestReadahead_StopsAtASparseRegion(t *testing.T) {
+	ctx := context.Background()
+	volumeName := "vol-readamp-sparse"
+	const writtenBytes = readAmpVolumeBytes / 2
+
+	root, written := seedVolume(t, volumeName, nil, writtenBytes)
+	reader, _ := coldReaderVB(t, root, volumeName, nil)
+
+	// Start well before the boundary so the reads are a stream by the time
+	// they reach it, then carry on past it into the hole.
+	for offset := uint64(writtenBytes - 4*readAmpRequestBytes); offset < writtenBytes+4*readAmpRequestBytes; offset += readAmpRequestBytes {
+		data, err := reader.ReadAtCtx(ctx, offset, readAmpRequestBytes)
+
+		want := make([]byte, readAmpRequestBytes)
+		if offset < writtenBytes {
+			want = written[offset : offset+readAmpRequestBytes]
+			require.NoErrorf(t, err, "read at offset %d", offset)
+		} else {
+			// A read wholly inside a hole reports it, and still returns zeroes.
+			require.ErrorIsf(t, err, ErrZeroBlock, "read at offset %d", offset)
+		}
+		require.Equalf(t, want, data, "wrong data at offset %d", offset)
+	}
 }
 
 // TestReadahead_StreamStartingAgainBehindItselfIsStillWidened covers what

--- a/viperblock/read_amplification_test.go
+++ b/viperblock/read_amplification_test.go
@@ -7,7 +7,7 @@ import (
 	"sync/atomic"
 	"testing"
 
-	"github.com/mulgadc/predastore/pkg/masterkey"
+	"github.com/mulgadc/bluebottle/pkg/masterkey"
 	"github.com/mulgadc/viperblock/types"
 	"github.com/mulgadc/viperblock/viperblock/backends/file"
 	"github.com/stretchr/testify/assert"

--- a/viperblock/shared_store_open_test.go
+++ b/viperblock/shared_store_open_test.go
@@ -11,7 +11,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/mulgadc/predastore/pkg/masterkey"
+	"github.com/mulgadc/bluebottle/pkg/masterkey"
 	"github.com/mulgadc/viperblock/viperblock/backends/file"
 	"github.com/stretchr/testify/require"
 )

--- a/viperblock/shared_store_open_test.go
+++ b/viperblock/shared_store_open_test.go
@@ -1,0 +1,114 @@
+// What keeps two openers of one volume from colliding when they are on
+// different hosts. AcquireVolumeLock is an flock under the opener's own
+// BaseDir, so it excludes two openers on one host and nothing at all across
+// hosts sharing a predastore. These tests use one shared store with two
+// private local dirs, which is that shape exactly, and pin the mechanism that
+// does cover it: every open claims a fresh SeqNum window through the shared
+// state before it can issue anything.
+package viperblock
+
+import (
+	"context"
+	"testing"
+
+	"github.com/mulgadc/predastore/pkg/masterkey"
+	"github.com/mulgadc/viperblock/viperblock/backends/file"
+	"github.com/stretchr/testify/require"
+)
+
+const sharedStoreVolumeSize = 4 * 1024 * 1024
+
+// openOnSharedStore builds a VB whose local state lives in its own directory
+// while its backend is the store both openers share.
+func openOnSharedStore(t *testing.T, store, localDir, volume string, key *masterkey.Key) *VB {
+	t.Helper()
+	vb, err := New(&VB{
+		VolumeName:        volume,
+		VolumeSize:        sharedStoreVolumeSize,
+		BaseDir:           localDir,
+		MasterKey:         key,
+		EncryptionEnabled: true,
+	}, "file", file.FileConfig{BaseDir: store, VolumeName: volume})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		vb.StopChunkUploader()
+		vb.StopWALSyncer()
+	})
+	require.NoError(t, vb.Backend.Init())
+	return vb
+}
+
+// seedSharedVolume creates the volume in the shared store, the way a
+// CreateVolume would, and leaves nothing open behind it.
+func seedSharedVolume(t *testing.T, store, localDir, volume string, key *masterkey.Key) {
+	t.Helper()
+	vb := openOnSharedStore(t, store, localDir, volume, key)
+	require.NoError(t, vb.SaveState())
+}
+
+// TestSharedStore_TwoOpenersGetDisjointSeqNumWindows is the invariant the
+// write-on-open exists for. A SeqNum is the nonce input, so two openers
+// issuing the same one under the same master key would be a repeated
+// (key, nonce) pair — the failure AEAD has no recovery from.
+//
+// LoadState starts SeqNum at the persisted high-water and advances that
+// high-water by a full reservation before returning, so each opener leaves
+// with a subspace no other opener can reach. Removing the write to make a
+// read cheaper would remove this.
+func TestSharedStore_TwoOpenersGetDisjointSeqNumWindows(t *testing.T) {
+	store := t.TempDir()
+	key := testKey(t, 0x51)
+	const volume = "vol-sharedstore01"
+
+	seedSharedVolume(t, store, t.TempDir(), volume, key)
+
+	first := openOnSharedStore(t, store, t.TempDir(), volume, key)
+	require.NoError(t, first.LoadState())
+	second := openOnSharedStore(t, store, t.TempDir(), volume, key)
+	require.NoError(t, second.LoadState())
+
+	const reserve = 8
+	firstStart, err := first.reserveSeqNum(context.Background(), reserve)
+	require.NoError(t, err)
+	secondStart, err := second.reserveSeqNum(context.Background(), reserve)
+	require.NoError(t, err)
+
+	overlap := firstStart < secondStart+reserve && secondStart < firstStart+reserve
+	require.False(t, overlap,
+		"two openers on one store issued overlapping SeqNums (%d-%d and %d-%d): same key, same nonce",
+		firstStart, firstStart+reserve-1, secondStart, secondStart+reserve-1)
+}
+
+// TestSharedStore_SecondOpenerDoesNotRegressTheHighWater covers the other
+// half. The high-water is what stops a crashed process's un-persisted range
+// from being reissued, and pushStateToBackend is an unconditional PUT with no
+// precondition on what it overwrites, so a later opener writing a lower
+// ceiling is the shape to watch for.
+func TestSharedStore_SecondOpenerDoesNotRegressTheHighWater(t *testing.T) {
+	store := t.TempDir()
+	key := testKey(t, 0x52)
+	const volume = "vol-sharedstore02"
+
+	seedSharedVolume(t, store, t.TempDir(), volume, key)
+
+	// Both open before either issues anything, which is the ordering that
+	// would expose a lost update if the ceiling were not claimed on open.
+	first := openOnSharedStore(t, store, t.TempDir(), volume, key)
+	require.NoError(t, first.LoadState())
+	second := openOnSharedStore(t, store, t.TempDir(), volume, key)
+	require.NoError(t, second.LoadState())
+
+	// The first opener runs ahead, reserving well past one window.
+	_, err := first.reserveSeqNum(context.Background(), seqNumReservation*3)
+	require.NoError(t, err)
+	ahead := first.seqNumHighWater.Load()
+
+	// The second opener now persists its own, lower ceiling.
+	_, err = second.reserveSeqNum(context.Background(), 1)
+	require.NoError(t, err)
+
+	reopened := openOnSharedStore(t, store, t.TempDir(), volume, key)
+	require.NoError(t, reopened.LoadState())
+	require.GreaterOrEqual(t, reopened.seqNumHighWater.Load(), ahead,
+		"the durable high-water went backwards, so a reopen reissues SeqNums already sealed under")
+}

--- a/viperblock/snapshot.go
+++ b/viperblock/snapshot.go
@@ -453,10 +453,8 @@ func (vb *VB) CopySnapshotMeta(srcSnapshotID, dstSnapshotID string) (*SnapshotSt
 		return nil, fmt.Errorf("copy snapshot: source %s config declares SnapshotID %q", srcSnapshotID, src.SnapshotID)
 	}
 
-	if vb.EncryptionEnabled {
-		if err := vb.checkSnapshotOwnership(srcSnapshotID, src); err != nil {
-			return nil, err
-		}
+	if err := vb.checkSnapshotOwnership(srcSnapshotID, src); err != nil {
+		return nil, err
 	}
 
 	// Read the source checkpoint before anything is minted or written, so a
@@ -537,7 +535,16 @@ func (vb *VB) CopySnapshotMeta(srcSnapshotID, dstSnapshotID string) (*SnapshotSt
 // of, by comparing the persisted source identity against our own. The copy
 // seals in that volume's nonce subspace under its nextStateSeqNum counter, so
 // sealing from any other volume risks reusing a nonce the owner has issued.
+// The name comparison holds either way: an unencrypted volume has no nonce to
+// reuse, but copying another volume's snapshot is still the wrong volume.
 func (vb *VB) checkSnapshotOwnership(snapshotID string, snap *SnapshotState) error {
+	if snap.SourceVolumeName != vb.VolumeName {
+		return fmt.Errorf("%w: copy snapshot: source %s belongs to volume %q, not %q — copy must run on the snapshot's own volume so StateSeqNum stays unique in its nonce subspace",
+			ErrSnapshotVolumeMismatch, snapshotID, snap.SourceVolumeName, vb.VolumeName)
+	}
+	if !vb.EncryptionEnabled {
+		return nil
+	}
 	uuid, err := hex.DecodeString(snap.SourceVolumeUUID)
 	if err != nil || len(uuid) != 4 {
 		return fmt.Errorf("copy snapshot: source %s has invalid SourceVolumeUUID %q", snapshotID, snap.SourceVolumeUUID)

--- a/viperblock/snapshot.go
+++ b/viperblock/snapshot.go
@@ -6,8 +6,10 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math"
+	"os"
 	"time"
 
 	"github.com/mulgadc/viperblock/types"
@@ -243,30 +245,25 @@ type SnapshotIdentity struct {
 	InheritedLayers      []InheritedLayer
 }
 
-// LoadSnapshotBlockMap reads a snapshot's frozen block-to-object map from the
-// backend and returns it along with the source volume's encryption identity.
-// The returned BlocksToObject is intended to be used as a read-only base map
-// for clone volumes.
-func (vb *VB) LoadSnapshotBlockMap(snapshotID string) (*BlocksToObject, SnapshotIdentity, error) {
-	var ident SnapshotIdentity
-
-	// 1. Read snapshot config
+// readSnapshotState reads a snapshot's config.json from the backend and, on
+// encrypted volumes, authenticates its metaEnvelope before unmarshalling.
+//
+// Two-stage parse: split the envelope, peek the verbatim payload for
+// SourceVolumeUUID + SourceVolumeNameHash + StateSeqNum (needed to reconstruct
+// nonce + AAD), verify, then unmarshal the verified bytes into the full
+// struct. The snapshotID parameter is the trusted external identity bound into
+// the AAD — splicing in another snapshot's blob fails because the literal
+// "snap:"||snapshotID differs from the seal-time value.
+func (vb *VB) readSnapshotState(snapshotID string) (*SnapshotState, error) {
 	configData, err := vb.Backend.ReadFrom(snapshotID, types.FileTypeConfig, 0, 0, 0)
 	if err != nil {
-		return nil, ident, fmt.Errorf("failed to read snapshot config %s: %w", snapshotID, err)
+		return nil, fmt.Errorf("failed to read snapshot config %s: %w", snapshotID, err)
 	}
 
-	// Encrypted snapshots wrap the JSON in a metaEnvelope. Two-stage parse:
-	// split the envelope, peek the verbatim payload for SourceVolumeUUID +
-	// SourceVolumeNameHash + StateSeqNum (needed to reconstruct nonce + AAD),
-	// verify, then unmarshal the verified bytes into the full struct. The
-	// snapshotID parameter is the trusted external identity bound into the
-	// AAD — splicing in another snapshot's blob fails because the literal
-	// "snap:"||snapshotID differs from the seal-time value.
 	if vb.EncryptionEnabled {
 		payload, tag, splitErr := splitEnvelope(configData)
 		if splitErr != nil {
-			return nil, ident, fmt.Errorf("%w: snapshot %s envelope: %w", ErrIntegrity, snapshotID, splitErr)
+			return nil, fmt.Errorf("%w: snapshot %s envelope: %w", ErrIntegrity, snapshotID, splitErr)
 		}
 		var peek struct {
 			SourceVolumeUUID     string `json:"SourceVolumeUUID"`
@@ -274,15 +271,15 @@ func (vb *VB) LoadSnapshotBlockMap(snapshotID string) (*BlocksToObject, Snapshot
 			StateSeqNum          uint64 `json:"StateSeqNum"`
 		}
 		if err := json.Unmarshal(payload, &peek); err != nil {
-			return nil, ident, fmt.Errorf("%w: snapshot %s peek parse: %w", ErrIntegrity, snapshotID, err)
+			return nil, fmt.Errorf("%w: snapshot %s peek parse: %w", ErrIntegrity, snapshotID, err)
 		}
 		uuid, uuidErr := hex.DecodeString(peek.SourceVolumeUUID)
 		if uuidErr != nil || len(uuid) != 4 {
-			return nil, ident, fmt.Errorf("%w: snapshot %s SourceVolumeUUID invalid", ErrIntegrity, snapshotID)
+			return nil, fmt.Errorf("%w: snapshot %s SourceVolumeUUID invalid", ErrIntegrity, snapshotID)
 		}
 		nameHash, nhErr := hex.DecodeString(peek.SourceVolumeNameHash)
 		if nhErr != nil || len(nameHash) != 32 {
-			return nil, ident, fmt.Errorf("%w: snapshot %s SourceVolumeNameHash invalid", ErrIntegrity, snapshotID)
+			return nil, fmt.Errorf("%w: snapshot %s SourceVolumeNameHash invalid", ErrIntegrity, snapshotID)
 		}
 		var nonceUUID [4]byte
 		copy(nonceUUID[:], uuid)
@@ -291,15 +288,31 @@ func (vb *VB) LoadSnapshotBlockMap(snapshotID string) (*BlocksToObject, Snapshot
 		nonce := makeNonce(peek.StateSeqNum, nonceUUID, DomainSnapshotMeta)
 		aad := makeMetaAAD(aadNameHash, "snap:"+snapshotID, peek.StateSeqNum)
 		if err := verifyMeta(vb.aead, payload, tag, aad, nonce); err != nil {
-			return nil, ident, fmt.Errorf("%w: snapshot %s tag verify: %w", ErrIntegrity, snapshotID, err)
+			return nil, fmt.Errorf("%w: snapshot %s tag verify: %w", ErrIntegrity, snapshotID, err)
 		}
 		configData = payload
 	}
 
 	var snap SnapshotState
 	if err := json.Unmarshal(configData, &snap); err != nil {
-		return nil, ident, fmt.Errorf("failed to parse snapshot config %s: %w", snapshotID, err)
+		return nil, fmt.Errorf("failed to parse snapshot config %s: %w", snapshotID, err)
 	}
+	return &snap, nil
+}
+
+// LoadSnapshotBlockMap reads a snapshot's frozen block-to-object map from the
+// backend and returns it along with the source volume's encryption identity.
+// The returned BlocksToObject is intended to be used as a read-only base map
+// for clone volumes.
+func (vb *VB) LoadSnapshotBlockMap(snapshotID string) (*BlocksToObject, SnapshotIdentity, error) {
+	var ident SnapshotIdentity
+
+	// 1. Read and (for encrypted volumes) authenticate the snapshot config
+	snapPtr, err := vb.readSnapshotState(snapshotID)
+	if err != nil {
+		return nil, ident, err
+	}
+	snap := *snapPtr
 
 	ident.SourceVolumeName = snap.SourceVolumeName
 	if snap.SourceVolumeUUID != "" {
@@ -386,6 +399,158 @@ func (vb *VB) LoadSnapshotBlockMap(snapshotID string) (*BlocksToObject, Snapshot
 		"inheritedLayers", len(ident.InheritedLayers))
 
 	return baseMap, ident, nil
+}
+
+// CopySnapshotMeta duplicates the snapshot at srcSnapshotID under
+// dstSnapshotID, producing a second, independently addressable snapshot over
+// the same frozen block map. No block data is copied — both snapshots
+// reference the source volume's existing chunk files.
+//
+// It must be called on a VB open over the snapshot's own source volume. The
+// destination is sealed in that volume's nonce subspace (its VolumeUUID),
+// because SourceVolumeUUID/SourceVolumeNameHash are carried across verbatim so
+// a clone of the copy still decrypts source chunks under the source identity.
+// Only a handle on that volume owns nextStateSeqNum, the counter that keeps
+// the snapshot-meta nonce unique within the subspace, so copying from any
+// other volume is refused rather than risking AES-GCM nonce reuse.
+//
+// The checkpoint object is copied byte-for-byte: it is plaintext block-map
+// metadata with no nonce or AAD of its own, and the identity a reader needs to
+// decrypt the chunks it points at comes from the (authenticated) config.
+func (vb *VB) CopySnapshotMeta(srcSnapshotID, dstSnapshotID string) (*SnapshotState, error) {
+	if srcSnapshotID == "" || dstSnapshotID == "" {
+		return nil, fmt.Errorf("copy snapshot: source and destination snapshot IDs must both be set")
+	}
+	if srcSnapshotID == dstSnapshotID {
+		return nil, fmt.Errorf("copy snapshot: destination %q must differ from the source", dstSnapshotID)
+	}
+
+	// Latch chunk GC off for the same reason CreateSnapshot does: the copy is
+	// a new snapshot pinning this volume's chunks, and a sweep already in
+	// flight cannot see it via its cached ancestry answer.
+	if vb.GCEnabled && vb.gcLatchedOff.CompareAndSwap(false, true) {
+		vb.logger().Warn("chunk GC: disabled permanently, CopySnapshotMeta called on this volume", "volume", vb.VolumeName, "snapshotID", dstSnapshotID)
+	}
+
+	// Refuse to clobber a committed destination. config.json is the commit
+	// point (it is written last, below), so a lone checkpoint is a torn prior
+	// attempt this call overwrites rather than a snapshot anything can read.
+	if _, err := vb.Backend.ReadFrom(dstSnapshotID, types.FileTypeConfig, 0, 0, 0); err == nil {
+		return nil, fmt.Errorf("copy snapshot: destination %s already exists", dstSnapshotID)
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return nil, fmt.Errorf("copy snapshot: probe destination %s: %w", dstSnapshotID, err)
+	}
+
+	src, err := vb.readSnapshotState(srcSnapshotID)
+	if err != nil {
+		return nil, fmt.Errorf("copy snapshot: source %s: %w", srcSnapshotID, err)
+	}
+
+	// On an unencrypted volume nothing binds the blob to its key, so this is
+	// the only available check that the object read really is srcSnapshotID's
+	// state; it also catches an envelope parsed by a non-encrypted reader.
+	if src.SnapshotID != srcSnapshotID {
+		return nil, fmt.Errorf("copy snapshot: source %s config declares SnapshotID %q", srcSnapshotID, src.SnapshotID)
+	}
+
+	if vb.EncryptionEnabled {
+		if err := vb.checkSnapshotOwnership(srcSnapshotID, src); err != nil {
+			return nil, err
+		}
+	}
+
+	// Read the source checkpoint before anything is minted or written, so a
+	// missing or unreadable source fails with no durable side effects.
+	checkpoint, err := vb.Backend.ReadFrom(srcSnapshotID, types.FileTypeBlockCheckpoint, 0, 0, 0)
+	if err != nil {
+		return nil, fmt.Errorf("copy snapshot: read source checkpoint %s: %w", srcSnapshotID, err)
+	}
+
+	// Everything describing the frozen map (SeqNum, ObjectNum, block sizes,
+	// BlockCount, HasFlatSection) and the source's encryption identity is
+	// carried over unchanged — the copy freezes the same map, and BlockCount
+	// is cross-checked against the copied checkpoint on read. Only SnapshotID,
+	// CreatedAt and StateSeqNum are re-derived: the copy is a new object with
+	// its own creation time, and it must never re-seal under the source's
+	// StateSeqNum.
+	dst := &SnapshotState{
+		SnapshotID:           dstSnapshotID,
+		SourceVolumeName:     src.SourceVolumeName,
+		SeqNum:               src.SeqNum,
+		ObjectNum:            src.ObjectNum,
+		BlockSize:            src.BlockSize,
+		ObjBlockSize:         src.ObjBlockSize,
+		BlockCount:           src.BlockCount,
+		CreatedAt:            time.Now(),
+		SourceVolumeUUID:     src.SourceVolumeUUID,
+		SourceVolumeNameHash: src.SourceVolumeNameHash,
+		HasFlatSection:       src.HasFlatSection,
+	}
+
+	if vb.EncryptionEnabled {
+		dst.StateSeqNum = vb.nextStateSeqNum.Add(1)
+		// Persist the bumped counter before sealing under it, exactly as
+		// CreateSnapshot does: a crash between this Add and the next SaveState
+		// would reset nextStateSeqNum on restart and let a later seal re-issue
+		// dst.StateSeqNum, reusing this nonce under the same (key, VolumeUUID,
+		// domain=0x03) triple — catastrophic for AES-GCM.
+		if err := vb.SaveState(); err != nil {
+			return nil, fmt.Errorf("copy snapshot: StateSeqNum persist: %w", err)
+		}
+	}
+
+	dstJSON, err := json.Marshal(dst)
+	if err != nil {
+		return nil, fmt.Errorf("copy snapshot: marshal destination state: %w", err)
+	}
+
+	// The AAD's "snap:"||dstSnapshotID literal is what stops the copy being
+	// spliced back over the source (and vice versa) under the same key.
+	persisted := dstJSON
+	if vb.EncryptionEnabled {
+		nonce := makeNonce(dst.StateSeqNum, vb.VolumeUUID, DomainSnapshotMeta)
+		aad := makeMetaAAD(vb.volumeNameHash, "snap:"+dstSnapshotID, dst.StateSeqNum)
+		persisted = sealMeta(vb.aead, dstJSON, aad, nonce)
+	}
+
+	// Checkpoint first, config last — same order as CreateSnapshot. A failure
+	// between the two leaves an orphan checkpoint that no reader accepts as a
+	// snapshot (scanForOwnSnapshots skips a prefix with no config.json).
+	emptyHeaders := []byte{}
+	if err := vb.Backend.WriteTo(dstSnapshotID, types.FileTypeBlockCheckpoint, 0, &emptyHeaders, &checkpoint); err != nil {
+		return nil, fmt.Errorf("copy snapshot: write destination checkpoint %s: %w", dstSnapshotID, err)
+	}
+	if err := vb.Backend.WriteTo(dstSnapshotID, types.FileTypeConfig, 0, &emptyHeaders, &persisted); err != nil {
+		return nil, fmt.Errorf("copy snapshot: write destination config %s: %w", dstSnapshotID, err)
+	}
+
+	vb.logger().Info("CopySnapshotMeta: complete",
+		"srcSnapshotID", srcSnapshotID,
+		"dstSnapshotID", dstSnapshotID,
+		"sourceVolume", dst.SourceVolumeName,
+		"blocks", dst.BlockCount)
+
+	return dst, nil
+}
+
+// checkSnapshotOwnership verifies this VB is the volume the snapshot was taken
+// of, by comparing the persisted source identity against our own. The copy
+// seals in that volume's nonce subspace under its nextStateSeqNum counter, so
+// sealing from any other volume risks reusing a nonce the owner has issued.
+func (vb *VB) checkSnapshotOwnership(snapshotID string, snap *SnapshotState) error {
+	uuid, err := hex.DecodeString(snap.SourceVolumeUUID)
+	if err != nil || len(uuid) != 4 {
+		return fmt.Errorf("copy snapshot: source %s has invalid SourceVolumeUUID %q", snapshotID, snap.SourceVolumeUUID)
+	}
+	nameHash, err := hex.DecodeString(snap.SourceVolumeNameHash)
+	if err != nil || len(nameHash) != 32 {
+		return fmt.Errorf("copy snapshot: source %s has invalid SourceVolumeNameHash", snapshotID)
+	}
+	if !bytes.Equal(uuid, vb.VolumeUUID[:]) || !bytes.Equal(nameHash, vb.volumeNameHash[:]) {
+		return fmt.Errorf("copy snapshot: source %s belongs to volume %q, not %q — copy must run on the snapshot's own volume so StateSeqNum stays unique in its nonce subspace",
+			snapshotID, snap.SourceVolumeName, vb.VolumeName)
+	}
+	return nil
 }
 
 // OpenFromSnapshot loads the base block map from a snapshot and configures

--- a/viperblock/snapshot.go
+++ b/viperblock/snapshot.go
@@ -547,8 +547,8 @@ func (vb *VB) checkSnapshotOwnership(snapshotID string, snap *SnapshotState) err
 		return fmt.Errorf("copy snapshot: source %s has invalid SourceVolumeNameHash", snapshotID)
 	}
 	if !bytes.Equal(uuid, vb.VolumeUUID[:]) || !bytes.Equal(nameHash, vb.volumeNameHash[:]) {
-		return fmt.Errorf("copy snapshot: source %s belongs to volume %q, not %q — copy must run on the snapshot's own volume so StateSeqNum stays unique in its nonce subspace",
-			snapshotID, snap.SourceVolumeName, vb.VolumeName)
+		return fmt.Errorf("%w: copy snapshot: source %s belongs to volume %q, not %q — copy must run on the snapshot's own volume so StateSeqNum stays unique in its nonce subspace",
+			ErrSnapshotVolumeMismatch, snapshotID, snap.SourceVolumeName, vb.VolumeName)
 	}
 	return nil
 }

--- a/viperblock/snapshot_copy_test.go
+++ b/viperblock/snapshot_copy_test.go
@@ -143,6 +143,24 @@ func TestCopySnapshotMeta_RejectsForeignVolume(t *testing.T) {
 	assert.ErrorIs(t, readErr, os.ErrNotExist, "a refused copy must not leave a partial destination behind")
 }
 
+// TestCopySnapshotMeta_RejectsForeignVolumeUnencrypted pins the same refusal
+// without encryption. There is no nonce subspace to protect here, but naming a
+// volume the snapshot never came from is still a caller error, and gating the
+// check on encryption left it unenforced for every unencrypted volume.
+func TestCopySnapshotMeta_RejectsForeignVolumeUnencrypted(t *testing.T) {
+	env := newSnapshotEnv(t, "src-copy-plain", nil)
+	seedSnapshot(t, env, "snap-copy-plain-src", 1)
+
+	other := openEncryptedVBInDir(t, env.dir, "other-copy-plain", nil)
+
+	_, err := other.CopySnapshotMeta("snap-copy-plain-src", "snap-copy-plain-dst")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrSnapshotVolumeMismatch)
+
+	_, readErr := other.Backend.ReadFrom("snap-copy-plain-dst", types.FileTypeBlockCheckpoint, 0, 0, 0)
+	assert.ErrorIs(t, readErr, os.ErrNotExist, "a refused copy must not leave a partial destination behind")
+}
+
 // TestCopySnapshotMeta_RejectsExistingDestination gates against silently
 // replacing a snapshot that volumes may already be cloned from.
 func TestCopySnapshotMeta_RejectsExistingDestination(t *testing.T) {

--- a/viperblock/snapshot_copy_test.go
+++ b/viperblock/snapshot_copy_test.go
@@ -1,0 +1,251 @@
+// CopySnapshotMeta tests. A copy must be readable end to end on an encrypted
+// volume (clone reads decrypt source chunks through the copied checkpoint),
+// must seal under a freshly minted StateSeqNum that is durable before the
+// seal, and must refuse any input that would silently produce an unreadable
+// or nonce-unsafe destination.
+
+package viperblock
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mulgadc/viperblock/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// seedSnapshot writes blockCount random blocks to env.source, persists them to
+// chunks, and takes snapshotID. Returns the plaintext for later comparison.
+func seedSnapshot(t *testing.T, env *snapshotEnv, snapshotID string, blockCount uint64) ([]byte, *SnapshotState) {
+	t.Helper()
+	plaintext := make([]byte, uint64(env.source.BlockSize)*blockCount)
+	_, err := rand.Read(plaintext)
+	require.NoError(t, err)
+
+	require.NoError(t, env.source.Write(0, plaintext))
+	require.NoError(t, env.source.Flush())
+	require.NoError(t, env.source.WriteWALToChunk(true))
+
+	snap, err := env.source.CreateSnapshot(snapshotID)
+	require.NoError(t, err)
+	require.NotNil(t, snap)
+	return plaintext, snap
+}
+
+// TestCopySnapshotMeta_EncryptedRoundTrip is the decisive gate: a clone opened
+// from the COPY must decrypt the source volume's chunks and hand back the same
+// plaintext as a clone of the original. This is what the spinifex CopySnapshot
+// path was missing — the control plane wrote its own document under the new ID
+// and nothing landed on the backend, so the clone blew up at open.
+func TestCopySnapshotMeta_EncryptedRoundTrip(t *testing.T) {
+	env := newSnapshotEnv(t, "src-copy-rt", testKey(t, 0x42))
+	blockCount := uint64(4)
+	plaintext, src := seedSnapshot(t, env, "snap-copy-rt-src", blockCount)
+
+	dst, err := env.source.CopySnapshotMeta("snap-copy-rt-src", "snap-copy-rt-dst")
+	require.NoError(t, err)
+	require.NotNil(t, dst)
+
+	assert.Equal(t, "snap-copy-rt-dst", dst.SnapshotID)
+	assert.Equal(t, src.SourceVolumeName, dst.SourceVolumeName)
+	assert.Equal(t, src.SourceVolumeUUID, dst.SourceVolumeUUID,
+		"copy must carry the SOURCE volume identity, not a re-derived one, or clone chunk reads decrypt under the wrong nonce")
+	assert.Equal(t, src.SourceVolumeNameHash, dst.SourceVolumeNameHash)
+	assert.Equal(t, src.BlockCount, dst.BlockCount)
+
+	// Metadata must authenticate under the DESTINATION id — the AAD binds
+	// "snap:"||dstSnapshotID, so a config sealed for the source would fail here.
+	_, ident, err := env.source.LoadSnapshotBlockMap("snap-copy-rt-dst")
+	require.NoError(t, err, "copied snapshot metadata must verify under the destination id")
+	assert.Equal(t, env.source.VolumeUUID, ident.SourceVolumeUUID)
+
+	// End to end: a clone of the copy reads real plaintext, not zeros.
+	clone := env.openEncryptedClone(t, "clone-of-copy", "snap-copy-rt-dst")
+	require.NotEqual(t, env.source.VolumeUUID, clone.VolumeUUID,
+		"clone must have its own VolumeUUID — otherwise this test is meaningless")
+	for i := range blockCount {
+		got, err := clone.ReadAt(i*uint64(clone.BlockSize), uint64(clone.BlockSize))
+		require.NoError(t, err, "clone-of-copy read of block %d failed", i)
+		want := plaintext[i*uint64(env.source.BlockSize) : (i+1)*uint64(env.source.BlockSize)]
+		assert.True(t, bytes.Equal(want, got), "block %d plaintext mismatch through the copied snapshot", i)
+	}
+}
+
+// TestCopySnapshotMeta_MintsFreshStateSeqNum is the nonce-reuse guard. The
+// destination JSON differs from the source's (different SnapshotID) but is
+// sealed under the same key and the same VolumeUUID, so reusing the source's
+// StateSeqNum would put two different plaintexts under one AES-GCM nonce.
+func TestCopySnapshotMeta_MintsFreshStateSeqNum(t *testing.T) {
+	env := newSnapshotEnv(t, "src-copy-seq", testKey(t, 0x42))
+	_, src := seedSnapshot(t, env, "snap-copy-seq-src", 1)
+
+	dst, err := env.source.CopySnapshotMeta("snap-copy-seq-src", "snap-copy-seq-dst")
+	require.NoError(t, err)
+
+	require.NotZero(t, src.StateSeqNum)
+	assert.NotEqual(t, src.StateSeqNum, dst.StateSeqNum,
+		"copy must mint a fresh StateSeqNum: the same nonce over different plaintext under one key is catastrophic for AES-GCM")
+	assert.Greater(t, dst.StateSeqNum, src.StateSeqNum,
+		"StateSeqNum must advance monotonically, never be reissued")
+
+	// A second copy must advance again rather than reuse the first copy's value.
+	second, err := env.source.CopySnapshotMeta("snap-copy-seq-src", "snap-copy-seq-dst2")
+	require.NoError(t, err)
+	assert.Greater(t, second.StateSeqNum, dst.StateSeqNum)
+}
+
+// TestCopySnapshotMeta_PersistsStateSeqNumBeforeSealing gates the crash-safety
+// half of the nonce guard: the bumped counter must be durable on disk before
+// the seal, or a restart resets it and a later seal re-issues the same value.
+func TestCopySnapshotMeta_PersistsStateSeqNumBeforeSealing(t *testing.T) {
+	env := newSnapshotEnv(t, "src-copy-durable", testKey(t, 0x42))
+	seedSnapshot(t, env, "snap-copy-durable-src", 1)
+
+	dst, err := env.source.CopySnapshotMeta("snap-copy-durable-src", "snap-copy-durable-dst")
+	require.NoError(t, err)
+
+	configPath := filepath.Join(env.dir, types.GetFilePath(types.FileTypeConfig, 0, "src-copy-durable"))
+	persisted, err := env.source.LoadStateRequest(configPath)
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, persisted.StateSeqNum, dst.StateSeqNum,
+		"the copy's StateSeqNum must already be covered by the durable VBState, or a crash lets it be re-issued and the nonce reused")
+}
+
+// TestCopySnapshotMeta_RejectsForeignVolume gates the ownership check. The
+// metadata tag does NOT catch this: the reader reconstructs nonce + AAD from
+// the payload's own SourceVolumeUUID, so any volume sharing the master key
+// verifies the source config fine. Only the explicit check stops a copy being
+// sealed from a volume whose nextStateSeqNum counter does not govern the
+// source's nonce subspace.
+func TestCopySnapshotMeta_RejectsForeignVolume(t *testing.T) {
+	env := newSnapshotEnv(t, "src-copy-foreign", testKey(t, 0x42))
+	seedSnapshot(t, env, "snap-copy-foreign-src", 1)
+
+	other := openEncryptedVBInDir(t, env.dir, "other-copy-foreign", env.key)
+	require.NotEqual(t, env.source.VolumeUUID, other.VolumeUUID)
+
+	// Sanity: the foreign volume CAN authenticate the source config, which is
+	// exactly why the tag alone is not a sufficient guard here.
+	_, _, err := other.LoadSnapshotBlockMap("snap-copy-foreign-src")
+	require.NoError(t, err, "same master key verifies the blob — the ownership check is the only thing standing between this and nonce reuse")
+
+	_, err = other.CopySnapshotMeta("snap-copy-foreign-src", "snap-copy-foreign-dst")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "copy must run on the snapshot's own volume")
+
+	_, readErr := other.Backend.ReadFrom("snap-copy-foreign-dst", types.FileTypeBlockCheckpoint, 0, 0, 0)
+	assert.ErrorIs(t, readErr, os.ErrNotExist, "a refused copy must not leave a partial destination behind")
+}
+
+// TestCopySnapshotMeta_RejectsExistingDestination gates against silently
+// replacing a snapshot that volumes may already be cloned from.
+func TestCopySnapshotMeta_RejectsExistingDestination(t *testing.T) {
+	env := newSnapshotEnv(t, "src-copy-exists", testKey(t, 0x42))
+	seedSnapshot(t, env, "snap-copy-exists-a", 1)
+	seedSnapshot(t, env, "snap-copy-exists-b", 1)
+
+	_, err := env.source.CopySnapshotMeta("snap-copy-exists-a", "snap-copy-exists-b")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "destination snap-copy-exists-b already exists")
+
+	// The pre-existing destination is untouched and still readable.
+	_, _, err = env.source.LoadSnapshotBlockMap("snap-copy-exists-b")
+	require.NoError(t, err)
+}
+
+// TestCopySnapshotMeta_RejectsMissingSource gates the "describes fine, blows
+// up on attach" failure mode: a copy of a source that is not on the backend
+// must fail loudly rather than mint an empty destination.
+func TestCopySnapshotMeta_RejectsMissingSource(t *testing.T) {
+	env := newSnapshotEnv(t, "src-copy-missing", testKey(t, 0x42))
+
+	_, err := env.source.CopySnapshotMeta("snap-copy-missing-src", "snap-copy-missing-dst")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, os.ErrNotExist)
+
+	_, readErr := env.source.Backend.ReadFrom("snap-copy-missing-dst", types.FileTypeConfig, 0, 0, 0)
+	assert.ErrorIs(t, readErr, os.ErrNotExist, "a failed copy must not leave a destination config behind")
+}
+
+// TestCopySnapshotMeta_RejectsIDMismatch gates the only sanity check available
+// on an unencrypted volume, where nothing binds the config bytes to the key:
+// the blob read from srcSnapshotID/ must declare that same SnapshotID.
+func TestCopySnapshotMeta_RejectsIDMismatch(t *testing.T) {
+	env := newSnapshotEnv(t, "src-copy-mismatch", nil)
+	seedSnapshot(t, env, "snap-copy-mismatch-src", 1)
+
+	tampered, err := json.Marshal(&SnapshotState{SnapshotID: "snap-somewhere-else", SourceVolumeName: "src-copy-mismatch"})
+	require.NoError(t, err)
+	headers := []byte{}
+	require.NoError(t, env.source.Backend.WriteTo("snap-copy-mismatch-src", types.FileTypeConfig, 0, &headers, &tampered))
+
+	_, err = env.source.CopySnapshotMeta("snap-copy-mismatch-src", "snap-copy-mismatch-dst")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "declares SnapshotID")
+}
+
+// TestCopySnapshotMeta_RejectsSameID guards the degenerate case that would
+// otherwise read and rewrite one prefix under a new StateSeqNum.
+func TestCopySnapshotMeta_RejectsSameID(t *testing.T) {
+	env := newSnapshotEnv(t, "src-copy-same", testKey(t, 0x42))
+	seedSnapshot(t, env, "snap-copy-same-src", 1)
+
+	_, err := env.source.CopySnapshotMeta("snap-copy-same-src", "snap-copy-same-src")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must differ from the source")
+
+	_, err = env.source.CopySnapshotMeta("", "snap-copy-same-dst")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must both be set")
+}
+
+// TestCopySnapshotMeta_CheckpointCopiedVerbatim pins the decision that the
+// checkpoint needs no re-encryption: it is plaintext block-map metadata with
+// no nonce or AAD of its own, and the chunk identity a reader needs comes from
+// the authenticated config, so the bytes are copied unchanged.
+func TestCopySnapshotMeta_CheckpointCopiedVerbatim(t *testing.T) {
+	env := newSnapshotEnv(t, "src-copy-ckpt", testKey(t, 0x42))
+	seedSnapshot(t, env, "snap-copy-ckpt-src", 3)
+
+	_, err := env.source.CopySnapshotMeta("snap-copy-ckpt-src", "snap-copy-ckpt-dst")
+	require.NoError(t, err)
+
+	srcCkpt, err := env.source.Backend.ReadFrom("snap-copy-ckpt-src", types.FileTypeBlockCheckpoint, 0, 0, 0)
+	require.NoError(t, err)
+	dstCkpt, err := env.source.Backend.ReadFrom("snap-copy-ckpt-dst", types.FileTypeBlockCheckpoint, 0, 0, 0)
+	require.NoError(t, err)
+	assert.True(t, bytes.Equal(srcCkpt, dstCkpt), "checkpoint must be copied byte-for-byte")
+
+	// Both prefixes resolve to the same frozen map.
+	srcMap, _, err := env.source.LoadSnapshotBlockMap("snap-copy-ckpt-src")
+	require.NoError(t, err)
+	dstMap, _, err := env.source.LoadSnapshotBlockMap("snap-copy-ckpt-dst")
+	require.NoError(t, err)
+	assert.Equal(t, srcMap.lookup.len(), dstMap.lookup.len())
+}
+
+// TestCopySnapshotMeta_Unencrypted covers the plaintext path end to end so the
+// encrypted-only branches are not the sole exercised code.
+func TestCopySnapshotMeta_Unencrypted(t *testing.T) {
+	env := newSnapshotEnv(t, "src-copy-plain", nil)
+	blockCount := uint64(2)
+	plaintext, src := seedSnapshot(t, env, "snap-copy-plain-src", blockCount)
+
+	dst, err := env.source.CopySnapshotMeta("snap-copy-plain-src", "snap-copy-plain-dst")
+	require.NoError(t, err)
+	assert.Zero(t, src.StateSeqNum, "unencrypted snapshots allocate no StateSeqNum")
+	assert.Zero(t, dst.StateSeqNum)
+
+	clone := env.openEncryptedClone(t, "clone-of-plain-copy", "snap-copy-plain-dst")
+	for i := range blockCount {
+		got, err := clone.ReadAt(i*uint64(clone.BlockSize), uint64(clone.BlockSize))
+		require.NoError(t, err)
+		want := plaintext[i*uint64(env.source.BlockSize) : (i+1)*uint64(env.source.BlockSize)]
+		assert.True(t, bytes.Equal(want, got), "block %d mismatch through the copied snapshot", i)
+	}
+}

--- a/viperblock/snapshot_copy_test.go
+++ b/viperblock/snapshot_copy_test.go
@@ -136,6 +136,7 @@ func TestCopySnapshotMeta_RejectsForeignVolume(t *testing.T) {
 
 	_, err = other.CopySnapshotMeta("snap-copy-foreign-src", "snap-copy-foreign-dst")
 	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrSnapshotVolumeMismatch, "callers classify this as a caller error, so it must be matchable without string matching")
 	assert.Contains(t, err.Error(), "copy must run on the snapshot's own volume")
 
 	_, readErr := other.Backend.ReadFrom("snap-copy-foreign-dst", types.FileTypeBlockCheckpoint, 0, 0, 0)

--- a/viperblock/state_read_only_test.go
+++ b/viperblock/state_read_only_test.go
@@ -8,7 +8,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/mulgadc/predastore/pkg/masterkey"
+	"github.com/mulgadc/bluebottle/pkg/masterkey"
 	"github.com/mulgadc/viperblock/viperblock/backends/file"
 	"github.com/stretchr/testify/require"
 )

--- a/viperblock/state_read_only_test.go
+++ b/viperblock/state_read_only_test.go
@@ -1,0 +1,82 @@
+// What separates reading a volume's state from opening the volume. LoadState
+// claims a SeqNum window and durably persists it, which is correct for a
+// writer and wrong for a describe: it makes a read cost a PutObject and puts
+// that write on a node that does not own the volume.
+package viperblock
+
+import (
+	"context"
+	"testing"
+
+	"github.com/mulgadc/predastore/pkg/masterkey"
+	"github.com/mulgadc/viperblock/viperblock/backends/file"
+	"github.com/stretchr/testify/require"
+)
+
+// readerOnSharedStore builds a state reader against the shared store. It takes
+// no cleanup because there is nothing to stop — NewStateReader starts no
+// background goroutines.
+func readerOnSharedStore(t *testing.T, store, localDir, volume string, key *masterkey.Key) *VB {
+	t.Helper()
+	vb, err := NewStateReader(&VB{
+		VolumeName:        volume,
+		VolumeSize:        sharedStoreVolumeSize,
+		BaseDir:           localDir,
+		MasterKey:         key,
+		EncryptionEnabled: true,
+	}, "file", file.FileConfig{BaseDir: store, VolumeName: volume})
+	require.NoError(t, err)
+	require.NoError(t, vb.InitBackendForRead(context.Background()))
+	return vb
+}
+
+// persistedHighWater reads the durable SeqNum ceiling without disturbing it,
+// which is only possible because ReadState does not disturb it.
+func persistedHighWater(t *testing.T, store, volume string, key *masterkey.Key) uint64 {
+	t.Helper()
+	state, err := readerOnSharedStore(t, store, t.TempDir(), volume, key).ReadStateCtx(context.Background())
+	require.NoError(t, err)
+	return state.SeqNumHighWater
+}
+
+// TestReadState_ClaimsNoSeqNumWindow is the whole point of the read-only path.
+// A reader issues no SeqNum, so it needs no reservation, and burning one on
+// every describe costs a durable write to answer a question about capacity.
+func TestReadState_ClaimsNoSeqNumWindow(t *testing.T) {
+	store := t.TempDir()
+	key := testKey(t, 0x53)
+	const volume = "vol-readonly00001"
+
+	seedSharedVolume(t, store, t.TempDir(), volume, key)
+
+	// A real open first, so there is a claimed window for a reader to leave
+	// alone rather than a pristine zero.
+	opener := openOnSharedStore(t, store, t.TempDir(), volume, key)
+	require.NoError(t, opener.LoadState())
+
+	before := persistedHighWater(t, store, volume, key)
+	require.NotZero(t, before, "the seeded volume was never opened for writing")
+
+	for range 3 {
+		state, err := readerOnSharedStore(t, store, t.TempDir(), volume, key).ReadStateCtx(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, uint64(sharedStoreVolumeSize), state.VolumeSize)
+	}
+
+	require.Equal(t, before, persistedHighWater(t, store, volume, key),
+		"reading state advanced the durable SeqNum high-water, so a describe writes")
+}
+
+// TestReadState_StillRejectsTheWrongKey keeps the cheap path honest. It has to
+// run the same envelope verification a full open does, or it is not reading
+// the volume's state, it is reading whatever the store handed back.
+func TestReadState_StillRejectsTheWrongKey(t *testing.T) {
+	store := t.TempDir()
+	key := testKey(t, 0x54)
+	const volume = "vol-readonly00002"
+
+	seedSharedVolume(t, store, t.TempDir(), volume, key)
+
+	_, err := readerOnSharedStore(t, store, t.TempDir(), volume, testKey(t, 0x55)).ReadStateCtx(context.Background())
+	require.ErrorIs(t, err, ErrEncryptionMismatch)
+}

--- a/viperblock/viperblock.go
+++ b/viperblock/viperblock.go
@@ -459,11 +459,12 @@ type VB struct {
 	gcFloor      atomic.Uint64
 	gcFloorReady atomic.Bool
 
-	// streamNextBlock is the block a purely sequential reader would ask for
-	// next. Readahead fires only on a request that starts exactly there, so a
-	// random reader never pays for it. Deliberately racy: a wrong guess costs
-	// a wider fetch, never a wrong answer.
-	streamNextBlock atomic.Uint64
+	// readAhead decides which reads are widened past what they asked for.
+	readAhead readAheadTracker
+
+	// readsInFlight counts reads currently being served, which is the guest's
+	// queue depth as seen from here.
+	readsInFlight atomic.Int64
 
 	// gcSnapshotSafe/gcSnapshotChecked cache ensureGCSnapshotSafe's result:
 	// whether any snapshot already references this volume. Cached for the
@@ -1314,7 +1315,7 @@ func newVB(config *VB, btype string, backendConfig any) (vb *VB, err error) {
 		return nil, fmt.Errorf("failed to create checkpoint directory: %w", err)
 	}
 
-	vb.streamNextBlock.Store(noStreamPosition)
+	vb.readAhead.nextBlock = noStreamPosition
 
 	return vb, nil
 }
@@ -4804,17 +4805,70 @@ const noStreamPosition = ^uint64(0)
 // too, so the widest possible fetch is one whole chunk.
 const readAheadBlocks = 256
 
-// extendRunForReadahead grows a run forward through the same chunk, returning
-// the trailing blocks that could be fetched in the same round trip and their
-// SeqNums. It stops at the first block that is unmapped, lands in a different
-// chunk, or is not contiguous within this one — a discontinuity means another
-// round trip, which is what readahead exists to avoid.
-func (vb *VB) extendRunForReadahead(cb ConsecutiveBlock) (extra int, seqNums []uint64) {
+// streamRequest is the guest request a backend fetch is serving, carried down
+// to where the coalesced runs are known.
+type streamRequest struct {
+	block         uint64
+	blockRequests uint64
+}
+
+// readAheadTracker follows where a reader has got to, so that a request
+// starting exactly where the last one ended can be recognised as continuing a
+// stream. One VB serves one NBD connection, so there is one position to keep.
+type readAheadTracker struct {
+	mu sync.Mutex
+
+	// nextBlock is where a purely sequential reader would go next.
+	nextBlock uint64
+}
+
+// begin records a request for blockRequests blocks from block and reports
+// whether it continues a stream and so may be widened. A limit of zero records
+// the position and widens nothing.
+func (t *readAheadTracker) begin(block, blockRequests uint64, limit int) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	continues := block == t.nextBlock
+	t.nextBlock = block + blockRequests
+
+	return limit > 0 && continues
+}
+
+// planReadAhead records a request against the stream and returns the trailing
+// blocks its final run may carry with it, along with their SeqNums.
+func (vb *VB) planReadAhead(block, blockRequests uint64, runs []ConsecutiveBlock) (extra int, seqNums []uint64) {
 	// Never prefetch more than the cache can hold: blocks fetched only to be
 	// evicted before the request that wanted them are read, decrypted and
 	// thrown away. Volumes opened with a small cache get a small readahead.
 	limit := min(readAheadBlocks, vb.Cache.Config.Size)
 
+	// Readahead exists to fill the gap a reader leaves while it waits. A guest
+	// with several requests outstanding is already covering that gap itself,
+	// and prefetching under it only duplicates traffic it has in flight.
+	if vb.readsInFlight.Load() > 1 {
+		limit = 0
+	}
+
+	// Served entirely from cache. The position still has to advance, or the
+	// next request looks like the start of a new stream.
+	if len(runs) == 0 {
+		limit = 0
+	}
+
+	if !vb.readAhead.begin(block, blockRequests, limit) {
+		return 0, nil
+	}
+
+	return vb.extendRunForReadahead(runs[len(runs)-1], limit)
+}
+
+// extendRunForReadahead grows a run forward through the same chunk, returning
+// the trailing blocks that could be fetched in the same round trip and their
+// SeqNums. It stops at the first block that is unmapped, lands in a different
+// chunk, or is not contiguous within this one — a discontinuity means another
+// round trip, which is what readahead exists to avoid.
+func (vb *VB) extendRunForReadahead(cb ConsecutiveBlock, limit int) (extra int, seqNums []uint64) {
 	stride := vb.blockStride()
 	nextBlock := cb.StartBlock + uint64(cb.NumBlocks)
 	nextOffset := cb.ObjectOffset + uint32(cb.NumBlocks)*stride
@@ -5839,12 +5893,9 @@ func (vb *VB) read(ctx context.Context, block uint64, blockLen uint64) (data []b
 		i = j
 	}
 
-	// Readahead applies to the final run only, and only when this request
-	// continues where the last one stopped. There is no point widening a fetch
-	// on a volume whose cache is disabled: the extra blocks would be read and
-	// then dropped.
-	readAhead := vb.Cache.Config.Size > 0 && vb.streamNextBlock.Load() == block
-	vb.streamNextBlock.Store(block + blockRequests)
+	// Readahead applies to the final run only, since that is the one a
+	// continuing stream reads off the end of.
+	readAheadExtra, readAheadSeqNums := vb.planReadAhead(block, blockRequests, consecutiveBlocksToRead)
 
 	// Next, read our consecutive blocks from the backend
 	for idx, cb := range consecutiveBlocksToRead {
@@ -5854,8 +5905,8 @@ func (vb *VB) read(ctx context.Context, block uint64, blockLen uint64) (data []b
 		end := start + uint64(cb.NumBlocks)*uint64(vb.BlockSize)
 
 		extra, extraSeqNums := 0, []uint64(nil)
-		if readAhead && idx == len(consecutiveBlocksToRead)-1 {
-			extra, extraSeqNums = vb.extendRunForReadahead(cb)
+		if idx == len(consecutiveBlocksToRead)-1 {
+			extra, extraSeqNums = readAheadExtra, readAheadSeqNums
 		}
 
 		if err := vb.readRun(ctx, cb, extra, extraSeqNums, data[start:end]); err != nil {
@@ -5911,7 +5962,9 @@ func (vb *VB) ReadAtCtx(ctx context.Context, offset uint64, length uint64) ([]by
 	blockCount := lastBlock - firstBlock + 1
 
 	// Read entire range of needed blocks
+	vb.readsInFlight.Add(1)
 	fullData, err := vb.read(ctx, firstBlock, blockCount*blockSize)
+	vb.readsInFlight.Add(-1)
 
 	if err != nil && !errors.Is(err, ErrZeroBlock) {
 		return nil, err
@@ -6219,11 +6272,7 @@ func (vb *VB) readBlockStore(ctx context.Context, block uint64, blockLen uint64)
 	data = make([]byte, blockLen)
 	blockRequests := blockLen / uint64(vb.BlockSize)
 
-	// Readahead fires only where this request continues the previous one, and
-	// only where the extra blocks have somewhere to live. Recorded before any
-	// early return so a failed read still advances the stream position.
-	readAhead := vb.Cache.Config.Size > 0 && vb.streamNextBlock.Load() == block
-	vb.streamNextBlock.Store(block + blockRequests)
+	stream := &streamRequest{block: block, blockRequests: blockRequests}
 
 	var consecutiveBlocks ConsecutiveBlocks
 	var baseConsecutiveBlocks ConsecutiveBlocks
@@ -6344,10 +6393,15 @@ func (vb *VB) readBlockStore(ctx context.Context, block uint64, blockLen uint64)
 
 	// Fetch consecutive blocks from our own backend
 	if len(consecutiveBlocks) > 0 {
-		err = vb.fetchConsecutiveBlocksFromBackend(ctx, consecutiveBlocks, data, readAhead)
+		err = vb.fetchConsecutiveBlocksFromBackend(ctx, consecutiveBlocks, data, stream)
 		if err != nil {
 			return nil, err
 		}
+	} else {
+		// Served without touching the backend. The stream position still has to
+		// advance, or the cached stretch looks like the end of the stream and
+		// the request after it starts over.
+		vb.planReadAhead(stream.block, stream.blockRequests, nil)
 	}
 
 	// Fetch blocks from the source volume's backend (snapshot fallback)
@@ -6376,10 +6430,11 @@ func (vb *VB) readBlockStore(ctx context.Context, block uint64, blockLen uint64)
 
 // fetchConsecutiveBlocksFromBackend fetches blocks from backend storage
 // Used by both legacy and BlockStore read paths.
-// readAhead widens the final run past what was asked for; see readRun. Only
-// the own-volume fetch sets it — a snapshot base or ancestor layer is read
-// through the same helper but is not where a guest's stream lives.
-func (vb *VB) fetchConsecutiveBlocksFromBackend(ctx context.Context, consecutiveBlocks ConsecutiveBlocks, data []byte, readAhead bool) error {
+// stream, when set, names the guest request being served so the final run can
+// be widened; see planReadAhead. Only the own-volume fetch passes it — a
+// snapshot base or ancestor layer comes through here too, but is not where a
+// guest's stream lives.
+func (vb *VB) fetchConsecutiveBlocksFromBackend(ctx context.Context, consecutiveBlocks ConsecutiveBlocks, data []byte, stream *streamRequest) error {
 	var consecutiveBlocksToRead ConsecutiveBlocks
 	for i := 0; i < len(consecutiveBlocks); {
 		// Extend the run while blocks stay contiguous within one chunk, then
@@ -6414,6 +6469,11 @@ func (vb *VB) fetchConsecutiveBlocksFromBackend(ctx context.Context, consecutive
 		i = j
 	}
 
+	readAheadExtra, readAheadSeqNums := 0, []uint64(nil)
+	if stream != nil {
+		readAheadExtra, readAheadSeqNums = vb.planReadAhead(stream.block, stream.blockRequests, consecutiveBlocksToRead)
+	}
+
 	for idx, cb := range consecutiveBlocksToRead {
 		vb.logger().DebugContext(ctx, "[READ] READING CONSECUTIVE BLOCK:", "startBlock", cb.StartBlock, "numBlocks", cb.NumBlocks)
 
@@ -6421,8 +6481,8 @@ func (vb *VB) fetchConsecutiveBlocksFromBackend(ctx context.Context, consecutive
 		end := start + uint64(cb.NumBlocks)*uint64(vb.BlockSize)
 
 		extra, extraSeqNums := 0, []uint64(nil)
-		if readAhead && idx == len(consecutiveBlocksToRead)-1 {
-			extra, extraSeqNums = vb.extendRunForReadahead(cb)
+		if idx == len(consecutiveBlocksToRead)-1 {
+			extra, extraSeqNums = readAheadExtra, readAheadSeqNums
 		}
 
 		if err := vb.readRun(ctx, cb, extra, extraSeqNums, data[start:end]); err != nil {

--- a/viperblock/viperblock.go
+++ b/viperblock/viperblock.go
@@ -3912,6 +3912,12 @@ func (vb *VB) numberedCheckpointHighWater(ctx context.Context) (highWater uint64
 		return 0, false, err
 	}
 
+	return vb.checkpointHighWater(data)
+}
+
+// checkpointHighWater returns the highest chunk ObjectID a serialised block
+// checkpoint references. ok is false when it references none.
+func (vb *VB) checkpointHighWater(data []byte) (highWater uint64, ok bool, err error) {
 	haveObject := false
 	walkErr := walkBlockCheckpoint(data, vb.Version, vb.BlockToObjectWAL.WALMagic, func(block BlockLookup) {
 		if !haveObject || block.ObjectID > highWater {
@@ -3925,11 +3931,31 @@ func (vb *VB) numberedCheckpointHighWater(ctx context.Context) (highWater uint64
 	return highWater, haveObject, nil
 }
 
+// primeGCFloor caches the GC floor from a numbered checkpoint the caller has
+// already fetched, sparing ensureGCFloor a second read of the same object.
+// Only ever called with bytes read from the backend: the local copy is not
+// guaranteed to match it, and a floor below the backend checkpoint's would
+// let GC delete a chunk that checkpoint depends on.
+func (vb *VB) primeGCFloor(data []byte) {
+	high, ok, err := vb.checkpointHighWater(data)
+	if err != nil {
+		// Leave it unprimed rather than cache a bad floor; ensureGCFloor
+		// re-reads and reports the failure itself.
+		return
+	}
+	floor := uint64(0)
+	if ok {
+		floor = high + 1
+	}
+	vb.gcFloor.Store(floor)
+	vb.gcFloorReady.Store(true)
+}
+
 // ensureGCFloor lazily computes and caches the GC floor: one past the
 // highest chunk ObjectID referenced by the current numbered checkpoint, so
 // GC never deletes an object that checkpoint depends on if the live
-// checkpoint becomes unreadable. Cached for the VB lifetime — numbered
-// checkpoints are only rewritten at Close/RecoverLocalWALs.
+// checkpoint becomes unreadable. Cached for the VB lifetime, and may already
+// have been primed by LoadBlockStateCtx from the same object.
 func (vb *VB) ensureGCFloor(ctx context.Context) uint64 {
 	if vb.gcFloorReady.Load() {
 		return vb.gcFloor.Load()
@@ -4310,17 +4336,22 @@ func (vb *VB) LoadBlockStateCtx(ctx context.Context) (err error) {
 	// Step 1. Validate the local persistent disk contains the state
 	filename := fmt.Sprintf("%s/%s", vb.BaseDir, types.GetFilePath(types.FileTypeBlockCheckpoint, vb.BlockToObjectWAL.WallNum.Load(), vb.GetVolume()))
 
+	wallNum := vb.BlockToObjectWAL.WallNum.Load()
 	_, err = os.Stat(filename)
 	if err != nil {
 		vb.logger().InfoContext(ctx, "No state found in local file, using backend state", "error", err)
 
 		// Open the latest checkpoint from the backend
-		checkpoint, err = vb.Backend.ReadCtx(ctx, types.FileTypeBlockCheckpoint, vb.BlockToObjectWAL.WallNum.Load(), 0, 0)
+		checkpoint, err = vb.Backend.ReadCtx(ctx, types.FileTypeBlockCheckpoint, wallNum, 0, 0)
 
 		if err != nil {
 			// If no file found, volume is empty, return nil
 			return nil
 		}
+
+		// This is the same object, at the same WallNum, that the GC floor is
+		// derived from. Cache it now rather than fetch it again on the sweep.
+		vb.primeGCFloor(checkpoint)
 	} else {
 		checkpoint, err = os.ReadFile(filename)
 		if err != nil {

--- a/viperblock/viperblock.go
+++ b/viperblock/viperblock.go
@@ -964,6 +964,12 @@ var ErrStateNotFound = errors.New("viperblock: state not found")
 // retry with backoff; the state may become available shortly.
 var ErrStateBackendUnavailable = errors.New("viperblock: state backend unavailable")
 
+// ErrSnapshotVolumeMismatch is returned when an operation that must run on a
+// snapshot's own source volume is attempted from a different volume. It is a
+// caller error — the request named the wrong volume — so callers should
+// classify it as invalid input rather than as a fault in this volume.
+var ErrSnapshotVolumeMismatch = errors.New("viperblock: snapshot belongs to another volume")
+
 // ErrEncryptionMismatch is returned when the runtime master key and the
 // persisted VBState disagree on whether the volume is encrypted, when the
 // KeyFingerprint on disk does not match the loaded key, or when an encrypted

--- a/viperblock/viperblock.go
+++ b/viperblock/viperblock.go
@@ -1100,7 +1100,7 @@ func (vb *VB) SetCacheSystemMemory(percent int) error {
 	return vb.SetCacheSize(size, percent)
 }
 
-func New(config *VB, btype string, backendConfig any) (vb *VB, err error) {
+func newVB(config *VB, btype string, backendConfig any) (vb *VB, err error) {
 	var backend types.Backend
 
 	if config == nil {
@@ -1306,6 +1306,23 @@ func New(config *VB, btype string, backendConfig any) (vb *VB, err error) {
 	// Create the checkpoint directory if it doesn't exist
 	if err := os.MkdirAll(filepath.Join(vb.BaseDir, vb.GetVolume(), "checkpoints"), 0750); err != nil {
 		return nil, fmt.Errorf("failed to create checkpoint directory: %w", err)
+	}
+
+	return vb, nil
+}
+
+// NewStateReader builds a VB that can read and verify this volume's persisted
+// state and nothing else. It starts no background goroutines and records no
+// volume-open event, because unlike New it does not make the caller a
+// potential writer of the volume. Use it with ReadState.
+func NewStateReader(config *VB, btype string, backendConfig any) (*VB, error) {
+	return newVB(config, btype, backendConfig)
+}
+
+func New(config *VB, btype string, backendConfig any) (*VB, error) {
+	vb, err := newVB(config, btype, backendConfig)
+	if err != nil {
+		return nil, err
 	}
 
 	// Start background WAL syncer for periodic fsync (if interval > 0)
@@ -5091,14 +5108,16 @@ func (vb *VB) LoadState() error {
 	return vb.LoadStateCtx(context.Background())
 }
 
-// LoadStateCtx is LoadState with a caller-supplied context threaded through
-// the backend state fetch.
-func (vb *VB) LoadStateCtx(ctx context.Context) error {
+// selectPersistedState fetches both copies of the volume's persisted state,
+// picks the authoritative one and validates the encryption invariants against
+// it. It mutates nothing on the VB, so it is also the whole of a read-only
+// state load.
+func (vb *VB) selectPersistedState(ctx context.Context) (VBState, error) {
 	// Step 1. Query the state locally
 	localPath := fmt.Sprintf("%s/%s", vb.BaseDir, types.GetFilePath(types.FileTypeConfig, 0, vb.GetVolume()))
 	state, localErr := vb.LoadStateRequestCtx(ctx, localPath)
 	if errors.Is(localErr, ErrIntegrity) || errors.Is(localErr, ErrEncryptionMismatch) {
-		return fmt.Errorf("LoadState: local %s: %w", localPath, localErr)
+		return VBState{}, fmt.Errorf("LoadState: local %s: %w", localPath, localErr)
 	}
 	if localErr != nil {
 		vb.logger().InfoContext(ctx, "No state found in local file, using backend state", "error", localErr)
@@ -5108,7 +5127,7 @@ func (vb *VB) LoadStateCtx(ctx context.Context) error {
 	stateBackend, backendErr := vb.LoadStateRequestCtx(ctx, "")
 
 	if errors.Is(backendErr, ErrIntegrity) || errors.Is(backendErr, ErrEncryptionMismatch) {
-		return fmt.Errorf("LoadState: backend: %w", backendErr)
+		return VBState{}, fmt.Errorf("LoadState: backend: %w", backendErr)
 	}
 	if backendErr != nil {
 		vb.logger().WarnContext(ctx, "Failed to load state from backend", "error", backendErr)
@@ -5123,7 +5142,7 @@ func (vb *VB) LoadStateCtx(ctx context.Context) error {
 			vb.logger().DebugContext(ctx, "LoadState: no state in local or backend",
 				"volume", vb.GetVolume())
 		}
-		return classified
+		return VBState{}, classified
 	}
 
 	// Step 3. Compare the two states and select the authoritative copy.
@@ -5144,15 +5163,15 @@ func (vb *VB) LoadStateCtx(ctx context.Context) error {
 	// that log the error and continue cannot operate on partially-loaded
 	// state derived from the rejected blob.
 	if vb.EncryptionEnabled != state.EncryptionEnabled {
-		return fmt.Errorf("%w: runtime EncryptionEnabled=%v, persisted=%v (volume %s)",
+		return VBState{}, fmt.Errorf("%w: runtime EncryptionEnabled=%v, persisted=%v (volume %s)",
 			ErrEncryptionMismatch, vb.EncryptionEnabled, state.EncryptionEnabled, vb.VolumeName)
 	}
 	if vb.EncryptionEnabled {
 		if vb.MasterKey == nil {
-			return fmt.Errorf("%w: volume %s requires master key", ErrEncryptionMismatch, vb.VolumeName)
+			return VBState{}, fmt.Errorf("%w: volume %s requires master key", ErrEncryptionMismatch, vb.VolumeName)
 		}
 		if state.KeyFingerprint != vb.MasterKey.Fingerprint {
-			return fmt.Errorf("%w: volume %s sealed under key %s, supplied key is %s",
+			return VBState{}, fmt.Errorf("%w: volume %s sealed under key %s, supplied key is %s",
 				ErrEncryptionMismatch, vb.VolumeName, state.KeyFingerprint, vb.MasterKey.Fingerprint)
 		}
 	}
@@ -5169,6 +5188,44 @@ func (vb *VB) LoadStateCtx(ctx context.Context) error {
 	} else if configSizeBytes > 0 && configSizeBytes < state.VolumeSize {
 		vb.logger().Warn("LoadState: VolumeConfig.SizeGiB < VBState.VolumeSize (shrink not supported, keeping current size)",
 			"configSize", configSizeBytes, "stateSize", state.VolumeSize)
+	}
+
+	return state, nil
+}
+
+// ReadState fetches and verifies the volume's persisted state without opening
+// the volume. Same envelope verification and same local-vs-backend selection
+// as LoadState, but no VB field is set and no SeqNum window is claimed, so a
+// reader writes nothing.
+func (vb *VB) ReadState() (VBState, error) {
+	return vb.ReadStateCtx(context.Background())
+}
+
+// ReadStateCtx is ReadState with a caller-supplied context threaded through
+// the backend state fetch.
+func (vb *VB) ReadStateCtx(ctx context.Context) (VBState, error) {
+	return vb.selectPersistedState(ctx)
+}
+
+// InitBackendForRead prepares the backend for a read-only state fetch. Where
+// the backend supports it this skips the reachability probe a read-write open
+// pays for: the state read that follows fails the same way on an unusable
+// backend, so the probe would be a round trip spent to learn nothing.
+func (vb *VB) InitBackendForRead(ctx context.Context) error {
+	if ro, ok := vb.Backend.(interface {
+		InitReadOnlyCtx(context.Context) error
+	}); ok {
+		return ro.InitReadOnlyCtx(ctx)
+	}
+	return vb.Backend.InitCtx(ctx)
+}
+
+// LoadStateCtx is LoadState with a caller-supplied context threaded through
+// the backend state fetch.
+func (vb *VB) LoadStateCtx(ctx context.Context) error {
+	state, err := vb.selectPersistedState(ctx)
+	if err != nil {
+		return err
 	}
 
 	vb.VolumeName = state.VolumeName

--- a/viperblock/viperblock.go
+++ b/viperblock/viperblock.go
@@ -459,6 +459,12 @@ type VB struct {
 	gcFloor      atomic.Uint64
 	gcFloorReady atomic.Bool
 
+	// streamNextBlock is the block a purely sequential reader would ask for
+	// next. Readahead fires only on a request that starts exactly there, so a
+	// random reader never pays for it. Deliberately racy: a wrong guess costs
+	// a wider fetch, never a wrong answer.
+	streamNextBlock atomic.Uint64
+
 	// gcSnapshotSafe/gcSnapshotChecked cache ensureGCSnapshotSafe's result:
 	// whether any snapshot already references this volume. Cached for the
 	// process lifetime once checked; an error leaves gcSnapshotChecked false
@@ -1307,6 +1313,8 @@ func newVB(config *VB, btype string, backendConfig any) (vb *VB, err error) {
 	if err := os.MkdirAll(filepath.Join(vb.BaseDir, vb.GetVolume(), "checkpoints"), 0750); err != nil {
 		return nil, fmt.Errorf("failed to create checkpoint directory: %w", err)
 	}
+
+	vb.streamNextBlock.Store(noStreamPosition)
 
 	return vb, nil
 }
@@ -4786,6 +4794,108 @@ func (vb *VB) RecoverLocalWALs() (err error) {
 	return nil
 }
 
+// noStreamPosition marks "no read has happened yet", so the first read of a
+// volume is not mistaken for the continuation of a stream.
+const noStreamPosition = ^uint64(0)
+
+// readAheadBlocks caps how far a sequential fetch is widened past what was
+// asked for: 256 blocks is 1 MiB at the default block size, which turns a
+// 64 KiB stream into one round trip per sixteen requests. The chunk bounds it
+// too, so the widest possible fetch is one whole chunk.
+const readAheadBlocks = 256
+
+// extendRunForReadahead grows a run forward through the same chunk, returning
+// the trailing blocks that could be fetched in the same round trip and their
+// SeqNums. It stops at the first block that is unmapped, lands in a different
+// chunk, or is not contiguous within this one — a discontinuity means another
+// round trip, which is what readahead exists to avoid.
+func (vb *VB) extendRunForReadahead(cb ConsecutiveBlock) (extra int, seqNums []uint64) {
+	// Never prefetch more than the cache can hold: blocks fetched only to be
+	// evicted before the request that wanted them are read, decrypted and
+	// thrown away. Volumes opened with a small cache get a small readahead.
+	limit := min(readAheadBlocks, vb.Cache.Config.Size)
+
+	stride := vb.blockStride()
+	nextBlock := cb.StartBlock + uint64(cb.NumBlocks)
+	nextOffset := cb.ObjectOffset + uint32(cb.NumBlocks)*stride
+
+	for extra < limit {
+		objectID, objectOffset, seqNum, err := vb.LookupBlockToObject(nextBlock)
+		if err != nil || objectID != cb.ObjectID || objectOffset != nextOffset {
+			break
+		}
+		seqNums = append(seqNums, seqNum)
+		extra++
+		nextBlock++
+		nextOffset += stride
+	}
+	return extra, seqNums
+}
+
+// readRun fetches one coalesced run into dst, optionally widened by extra
+// trailing blocks which are cached rather than returned. dst must be exactly
+// cb.NumBlocks blocks long.
+func (vb *VB) readRun(ctx context.Context, cb ConsecutiveBlock, extra int, extraSeqNums []uint64, dst []byte) error {
+	fetchBlocks := int(cb.NumBlocks) + extra
+	length := utils.SafeIntToUint32(fetchBlocks) * vb.blockStride()
+
+	objectID := cb.ObjectID
+	if err := vb.checkChunkMagic(vb.VolumeName, objectID, func(off, l uint32) ([]byte, error) {
+		return vb.Backend.ReadCtx(ctx, types.FileTypeChunk, objectID, off, l)
+	}); err != nil {
+		return err
+	}
+
+	blockData, err := vb.Backend.ReadCtx(ctx, types.FileTypeChunk, cb.ObjectID, cb.ObjectOffset, length)
+	if err != nil {
+		return err
+	}
+
+	// Without readahead the plaintext lands straight in the caller's buffer;
+	// with it, the widened run needs somewhere to put the blocks the caller
+	// did not ask for.
+	plain := dst
+	if extra > 0 {
+		plain = make([]byte, fetchBlocks*int(vb.BlockSize))
+	}
+
+	if vb.EncryptionEnabled {
+		wide := cb
+		wide.NumBlocks = utils.SafeIntToUint16(fetchBlocks)
+		if extra > 0 {
+			wide.SeqNums = append(slices.Clone(cb.SeqNums), extraSeqNums...)
+		}
+		if err := vb.openChunkRun(blockData, wide, vb.VolumeUUID, vb.volumeNameHash, plain); err != nil {
+			return err
+		}
+	} else {
+		// openChunkRun length-checks the encrypted path; the cleartext path
+		// must not be weaker. A short body here would leave the tail of dst
+		// zero-filled and then get cached as valid.
+		if len(blockData) != int(length) {
+			return fmt.Errorf("%w: chunk %d offset %d run %d: got %d bytes, expected %d",
+				types.ErrShortRead, cb.ObjectID, cb.ObjectOffset, fetchBlocks, len(blockData), length)
+		}
+		copy(plain, blockData)
+	}
+
+	if extra == 0 {
+		return nil
+	}
+
+	blockSize := int(vb.BlockSize)
+	copy(dst, plain[:int(cb.NumBlocks)*blockSize])
+
+	// Keyed by the SeqNum the block map held when the run was planned, so a
+	// block rewritten since this fetch simply misses rather than serving stale
+	// plaintext.
+	for k := range extra {
+		block := int(cb.NumBlocks) + k
+		vb.Cache.put(cb.StartBlock+utils.SafeIntToUint64(block), extraSeqNums[k], plain[block*blockSize:(block+1)*blockSize])
+	}
+	return nil
+}
+
 // checkChunkMagic preflights the first 4 bytes of a chunk file before the
 // body decrypt path runs, so a pre-encryption volume opened under
 // EncryptionEnabled=true fails with a dedicated, actionable
@@ -5729,50 +5839,27 @@ func (vb *VB) read(ctx context.Context, block uint64, blockLen uint64) (data []b
 		i = j
 	}
 
-	// Per-block on-disk stride: encrypted chunks add a 16-byte GCM tag after
-	// each ciphertext block; unencrypted chunks stay at BlockSize.
-	stride := vb.BlockSize
-	if vb.EncryptionEnabled {
-		stride += 16
-	}
+	// Readahead applies to the final run only, and only when this request
+	// continues where the last one stopped. There is no point widening a fetch
+	// on a volume whose cache is disabled: the extra blocks would be read and
+	// then dropped.
+	readAhead := vb.Cache.Config.Size > 0 && vb.streamNextBlock.Load() == block
+	vb.streamNextBlock.Store(block + blockRequests)
 
 	// Next, read our consecutive blocks from the backend
-	for _, cb := range consecutiveBlocksToRead {
+	for idx, cb := range consecutiveBlocksToRead {
 		vb.logger().Debug("[READ] READING CONSECUTIVE BLOCK:", "startBlock", cb.StartBlock, "numBlocks", cb.NumBlocks, "offsetStart", cb.OffsetStart, "offsetEnd", cb.OffsetEnd, "objectID", cb.ObjectID, "objectOffset", cb.ObjectOffset)
-
-		consecutiveBlockOffset := uint32(cb.NumBlocks) * stride
 
 		start := cb.BlockPosition * uint64(vb.BlockSize)
 		end := start + uint64(cb.NumBlocks)*uint64(vb.BlockSize)
 
-		objectID := cb.ObjectID
-		if err := vb.checkChunkMagic(vb.VolumeName, objectID, func(off, length uint32) ([]byte, error) {
-			return vb.Backend.ReadCtx(ctx, types.FileTypeChunk, objectID, off, length)
-		}); err != nil {
-			return nil, err
+		extra, extraSeqNums := 0, []uint64(nil)
+		if readAhead && idx == len(consecutiveBlocksToRead)-1 {
+			extra, extraSeqNums = vb.extendRunForReadahead(cb)
 		}
 
-		blockData, err := vb.Backend.ReadCtx(ctx, types.FileTypeChunk, cb.ObjectID, cb.ObjectOffset, consecutiveBlockOffset)
-		if err != nil {
+		if err := vb.readRun(ctx, cb, extra, extraSeqNums, data[start:end]); err != nil {
 			return nil, err
-		}
-
-		vb.logger().DebugContext(ctx, "[READ] COPYING BLOCK DATA:", "start", start, "end", end)
-		vb.logger().DebugContext(ctx, "[READ] DATA:", "data len", len(data))
-
-		if vb.EncryptionEnabled {
-			if err := vb.openChunkRun(blockData, cb, vb.VolumeUUID, vb.volumeNameHash, data[start:end]); err != nil {
-				return nil, err
-			}
-		} else {
-			// openChunkRun length-checks the encrypted path; the cleartext
-			// path must not be weaker. A short body here would leave the tail
-			// of data[start:end] zero-filled and then get cached as valid.
-			if len(blockData) != int(consecutiveBlockOffset) {
-				return nil, fmt.Errorf("%w: chunk %d offset %d run %d: got %d bytes, expected %d",
-					types.ErrShortRead, cb.ObjectID, cb.ObjectOffset, cb.NumBlocks, len(blockData), consecutiveBlockOffset)
-			}
-			copy(data[start:end], blockData)
 		}
 	}
 
@@ -6132,6 +6219,12 @@ func (vb *VB) readBlockStore(ctx context.Context, block uint64, blockLen uint64)
 	data = make([]byte, blockLen)
 	blockRequests := blockLen / uint64(vb.BlockSize)
 
+	// Readahead fires only where this request continues the previous one, and
+	// only where the extra blocks have somewhere to live. Recorded before any
+	// early return so a failed read still advances the stream position.
+	readAhead := vb.Cache.Config.Size > 0 && vb.streamNextBlock.Load() == block
+	vb.streamNextBlock.Store(block + blockRequests)
+
 	var consecutiveBlocks ConsecutiveBlocks
 	var baseConsecutiveBlocks ConsecutiveBlocks
 	ancestorConsBlocks := make([]ConsecutiveBlocks, len(vb.ancestors))
@@ -6251,7 +6344,7 @@ func (vb *VB) readBlockStore(ctx context.Context, block uint64, blockLen uint64)
 
 	// Fetch consecutive blocks from our own backend
 	if len(consecutiveBlocks) > 0 {
-		err = vb.fetchConsecutiveBlocksFromBackend(ctx, consecutiveBlocks, data)
+		err = vb.fetchConsecutiveBlocksFromBackend(ctx, consecutiveBlocks, data, readAhead)
 		if err != nil {
 			return nil, err
 		}
@@ -6283,7 +6376,10 @@ func (vb *VB) readBlockStore(ctx context.Context, block uint64, blockLen uint64)
 
 // fetchConsecutiveBlocksFromBackend fetches blocks from backend storage
 // Used by both legacy and BlockStore read paths.
-func (vb *VB) fetchConsecutiveBlocksFromBackend(ctx context.Context, consecutiveBlocks ConsecutiveBlocks, data []byte) error {
+// readAhead widens the final run past what was asked for; see readRun. Only
+// the own-volume fetch sets it — a snapshot base or ancestor layer is read
+// through the same helper but is not where a guest's stream lives.
+func (vb *VB) fetchConsecutiveBlocksFromBackend(ctx context.Context, consecutiveBlocks ConsecutiveBlocks, data []byte, readAhead bool) error {
 	var consecutiveBlocksToRead ConsecutiveBlocks
 	for i := 0; i < len(consecutiveBlocks); {
 		// Extend the run while blocks stay contiguous within one chunk, then
@@ -6318,42 +6414,19 @@ func (vb *VB) fetchConsecutiveBlocksFromBackend(ctx context.Context, consecutive
 		i = j
 	}
 
-	stride := vb.BlockSize
-	if vb.EncryptionEnabled {
-		stride += 16
-	}
-
-	for _, cb := range consecutiveBlocksToRead {
+	for idx, cb := range consecutiveBlocksToRead {
 		vb.logger().DebugContext(ctx, "[READ] READING CONSECUTIVE BLOCK:", "startBlock", cb.StartBlock, "numBlocks", cb.NumBlocks)
 
-		consecutiveBlockOffset := uint32(cb.NumBlocks) * stride
 		start := cb.BlockPosition * uint64(vb.BlockSize)
 		end := start + uint64(cb.NumBlocks)*uint64(vb.BlockSize)
 
-		objectID := cb.ObjectID
-		if err := vb.checkChunkMagic(vb.VolumeName, objectID, func(off, length uint32) ([]byte, error) {
-			return vb.Backend.ReadCtx(ctx, types.FileTypeChunk, objectID, off, length)
-		}); err != nil {
-			return err
+		extra, extraSeqNums := 0, []uint64(nil)
+		if readAhead && idx == len(consecutiveBlocksToRead)-1 {
+			extra, extraSeqNums = vb.extendRunForReadahead(cb)
 		}
 
-		blockData, err := vb.Backend.ReadCtx(ctx, types.FileTypeChunk, cb.ObjectID, cb.ObjectOffset, consecutiveBlockOffset)
-		if err != nil {
+		if err := vb.readRun(ctx, cb, extra, extraSeqNums, data[start:end]); err != nil {
 			return err
-		}
-
-		if vb.EncryptionEnabled {
-			if err := vb.openChunkRun(blockData, cb, vb.VolumeUUID, vb.volumeNameHash, data[start:end]); err != nil {
-				return err
-			}
-		} else {
-			// See vb.read: the cleartext path needs the same length check the
-			// encrypted path gets from openChunkRun.
-			if len(blockData) != int(consecutiveBlockOffset) {
-				return fmt.Errorf("%w: chunk %d offset %d run %d: got %d bytes, expected %d",
-					types.ErrShortRead, cb.ObjectID, cb.ObjectOffset, cb.NumBlocks, len(blockData), consecutiveBlockOffset)
-			}
-			copy(data[start:end], blockData)
 		}
 	}
 

--- a/viperblock/volumelock.go
+++ b/viperblock/volumelock.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"syscall"
+	"time"
 )
 
 // ErrVolumeLocked is returned by AcquireVolumeLock when another opener
@@ -29,6 +30,32 @@ const volumeLockFileName = ".viperblock.lock"
 // Returns the open, locked file; caller releases it via ReleaseVolumeLock.
 // Non-blocking: a lock already held fails fast with ErrVolumeLocked.
 func AcquireVolumeLock(baseDir, volume string) (*os.File, error) {
+	return AcquireVolumeLockWait(baseDir, volume, 0)
+}
+
+// volumeLockPollInterval is how often AcquireVolumeLockWait retries. flock's
+// blocking mode cannot be cancelled once entered, so waiting is a poll.
+const volumeLockPollInterval = 20 * time.Millisecond
+
+// AcquireVolumeLockWait is AcquireVolumeLock with a bound on how long it will
+// wait for a lock another opener still holds. It exists for handover: the
+// previous holder releases only after its drain and close, so an arriving
+// opener that would succeed a moment later is otherwise refused outright.
+//
+// Exclusion is unchanged — only one caller ever holds the lock. wait <= 0 is
+// the non-blocking form. On expiry the error is still ErrVolumeLocked.
+func AcquireVolumeLockWait(baseDir, volume string, wait time.Duration) (*os.File, error) {
+	deadline := time.Now().Add(wait)
+	for {
+		f, err := tryAcquireVolumeLock(baseDir, volume)
+		if err == nil || !errors.Is(err, ErrVolumeLocked) || !time.Now().Before(deadline) {
+			return f, err
+		}
+		time.Sleep(volumeLockPollInterval)
+	}
+}
+
+func tryAcquireVolumeLock(baseDir, volume string) (*os.File, error) {
 	dir := filepath.Join(baseDir, volume)
 	if err := os.MkdirAll(dir, 0750); err != nil {
 		return nil, fmt.Errorf("AcquireVolumeLock: create volume dir %s: %w", dir, err)

--- a/viperblock/volumelock.go
+++ b/viperblock/volumelock.go
@@ -13,10 +13,20 @@ import (
 // already holds the volume's exclusive lock.
 var ErrVolumeLocked = errors.New("viperblock: volume is locked by another opener")
 
-// volumeLockFileName is a fixed sibling of config.json under the volume's
-// local directory. Its only purpose is to be flock'd; contents are never
-// read or written.
-const volumeLockFileName = ".viperblock.lock"
+// volumeLockFilePrefix names the per-volume lock file, which sits in the base
+// directory rather than inside the volume's own. Close removes the volume
+// directory and only then releases, so a lock file inside it would be
+// unlinked while still held: the next opener would create a fresh file at the
+// same path and flock a different inode, and both would believe they held the
+// volume exclusively. Contents are never read or written.
+const volumeLockFilePrefix = ".viperblock-"
+
+const volumeLockFileSuffix = ".lock"
+
+// volumeLockPath is where the lock file for one volume lives.
+func volumeLockPath(baseDir, volume string) string {
+	return filepath.Join(baseDir, volumeLockFilePrefix+volume+volumeLockFileSuffix)
+}
 
 // AcquireVolumeLock takes an exclusive, non-blocking flock on a per-volume
 // lock file, admitting only one caller through New..OpenWAL at a time. This
@@ -56,12 +66,11 @@ func AcquireVolumeLockWait(baseDir, volume string, wait time.Duration) (*os.File
 }
 
 func tryAcquireVolumeLock(baseDir, volume string) (*os.File, error) {
-	dir := filepath.Join(baseDir, volume)
-	if err := os.MkdirAll(dir, 0750); err != nil {
-		return nil, fmt.Errorf("AcquireVolumeLock: create volume dir %s: %w", dir, err)
+	if err := os.MkdirAll(baseDir, 0750); err != nil {
+		return nil, fmt.Errorf("AcquireVolumeLock: create base dir %s: %w", baseDir, err)
 	}
 
-	path := filepath.Join(dir, volumeLockFileName)
+	path := volumeLockPath(baseDir, volume)
 	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0600)
 	if err != nil {
 		return nil, fmt.Errorf("AcquireVolumeLock: open %s: %w", path, err)

--- a/viperblock/volumelock_test.go
+++ b/viperblock/volumelock_test.go
@@ -3,6 +3,7 @@ package viperblock
 import (
 	"errors"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -156,6 +157,27 @@ func TestAcquireVolumeLockWait_ExpiresWhileHeld(t *testing.T) {
 	require.Error(t, err, "a lock held for the whole wait must not be handed out")
 	assert.ErrorIs(t, err, ErrVolumeLocked)
 	assert.GreaterOrEqual(t, time.Since(start), 100*time.Millisecond, "must have waited the full bound before giving up")
+}
+
+// TestAcquireVolumeLock_SurvivesTheHolderRemovingItsVolumeDirectory pins the
+// ordering that makes the lock mean anything during handover. Close removes
+// the volume's local directory and only then releases, so if the lock file
+// lived inside that directory the holder would unlink it mid-close, an
+// arriving opener would create a fresh file at the same path, and both would
+// hold an exclusive lock on different inodes.
+func TestAcquireVolumeLock_SurvivesTheHolderRemovingItsVolumeDirectory(t *testing.T) {
+	dir := t.TempDir()
+
+	first, err := AcquireVolumeLock(dir, "vol-1")
+	require.NoError(t, err)
+	defer func() { _ = ReleaseVolumeLock(first) }()
+
+	// What RemoveLocalFiles does at the end of Close, while the lock is held.
+	require.NoError(t, os.RemoveAll(filepath.Join(dir, "vol-1")))
+
+	_, err = AcquireVolumeLock(dir, "vol-1")
+	require.Error(t, err, "a second opener was admitted while the first still held the volume")
+	assert.ErrorIs(t, err, ErrVolumeLocked)
 }
 
 // TestReleaseVolumeLock_NilIsNoOp lets every call site defer

--- a/viperblock/volumelock_test.go
+++ b/viperblock/volumelock_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -115,6 +116,46 @@ func TestAcquireVolumeLock_ConcurrentRace(t *testing.T) {
 	// ErrVolumeLocked, never anything else, and never silently double-opened.
 	assert.Equal(t, attempts, winners+busyErrs)
 	assert.Positive(t, winners, "at least one attempt must have won the lock")
+}
+
+// TestAcquireVolumeLockWait_AdmittedAfterHolderReleases models an NBD client
+// reconnecting while the previous connection's Close is still draining. The
+// arriving opener must be admitted once the drain finishes, not refused for
+// being a moment early.
+func TestAcquireVolumeLockWait_AdmittedAfterHolderReleases(t *testing.T) {
+	dir := t.TempDir()
+
+	first, err := AcquireVolumeLock(dir, "vol-1")
+	require.NoError(t, err)
+
+	const holdFor = 150 * time.Millisecond
+	go func() {
+		time.Sleep(holdFor)
+		_ = ReleaseVolumeLock(first)
+	}()
+
+	start := time.Now()
+	second, err := AcquireVolumeLockWait(dir, "vol-1", 5*time.Second)
+	require.NoError(t, err, "an opener must be admitted once the previous holder releases")
+	require.NoError(t, ReleaseVolumeLock(second))
+	assert.GreaterOrEqual(t, time.Since(start), holdFor, "must not have been admitted before the holder released")
+}
+
+// TestAcquireVolumeLockWait_ExpiresWhileHeld pins that waiting does not weaken
+// exclusion: a holder that never releases still keeps everyone else out, and
+// the waiter gives up with the same error the non-blocking form returns.
+func TestAcquireVolumeLockWait_ExpiresWhileHeld(t *testing.T) {
+	dir := t.TempDir()
+
+	first, err := AcquireVolumeLock(dir, "vol-1")
+	require.NoError(t, err)
+	defer func() { _ = ReleaseVolumeLock(first) }()
+
+	start := time.Now()
+	_, err = AcquireVolumeLockWait(dir, "vol-1", 100*time.Millisecond)
+	require.Error(t, err, "a lock held for the whole wait must not be handed out")
+	assert.ErrorIs(t, err, ErrVolumeLocked)
+	assert.GreaterOrEqual(t, time.Since(start), 100*time.Millisecond, "must have waited the full bound before giving up")
 }
 
 // TestReleaseVolumeLock_NilIsNoOp lets every call site defer


### PR DESCRIPTION
Sixteen commits behind the spinifex EBS provider decouple. Grouped by what they do.

## Snapshot copy and ownership

- `480992e` exports `CopySnapshotMeta`, which duplicates a snapshot under a new ID over the same frozen data rather than copying blocks.
- `50caa74` adds `ErrSnapshotVolumeMismatch`, so a caller can tell "that snapshot belongs to another volume" from a generic failure.
- `c687802` enforces snapshot ownership on unencrypted volumes too. The check was only running on the encrypted path, so an unencrypted volume could copy a foreign snapshot.

## Volume lock

- `fdcb2b0` makes an opener wait for the volume lock instead of refusing. A reconnecting NBD client was hard-refused while the previous connection was still draining, which looked like a dead volume.
- `c0bbd50` moves the lock file out of the volume's own directory. `Close` removes that directory and only then releases the lock, so a lock file inside it was unlinked while still held: the next opener created a fresh file at the same path and flocked a different inode, and both processes believed they held the volume exclusively. This one is worth reading on its own.

## Reading state without becoming a writer

- `adbde17` adds `NewStateReader`, which loads volume state without opening the volume. `viperblock.New` starts a chunk uploader, so every construction was a writer; a caller that only wanted to read state had no way to say so.
- `3b3f852` scopes the S3 reachability probe to the volume instead of the bucket.

## Performance

- `1ec1b6f` lets callers share one HTTP client across S3 backends, via `NewHTTPClient`. Each backend was building its own, so connection pools were never reused.
- `52c5de8` primes the GC floor from the checkpoint the state load already read, removing a second fetch.
- `87fbb30` reads ahead on sequential streams, with `84fe2d4` suppressing it when the guest has its own queue (read-ahead under a guest that already pipelines costs backend reads without reducing latency).

## Tests and hygiene

- `f3df493` counts the backend reads a sequential stream costs, which is what makes the read-ahead change measurable rather than asserted.
- `fa13a11` covers read-ahead running into a sparse region.
- `54e5820` asserts backend init logs neither S3 credential.
- `0198944` consumes masterkey from bluebottle in the tests this branch added.

## Compatibility

The exported API is additive. `NewHTTPClient`, `NewStateReader`, `CopySnapshotMeta` and `ErrSnapshotVolumeMismatch` are new; `New`'s signature changed only from named to unnamed returns (same types, source-compatible); no exported symbol was removed except the local `viperblock/telemetry` package, which moved to bluebottle's `otelsetup`.

Nothing downstream moves on merge: spinifex pins an explicit pseudo-version, so no spinifex build changes until that pin is bumped deliberately. When it is, the risk is behavioural rather than compile-level — read-ahead, the lock file location, the GC floor and the shared HTTP client all warrant a live smoke test rather than a green build.

## Supersedes

`feat/viperblock-ebs-provider-decouple` is fully contained in this branch and can be deleted once this merges. Four of its five commits are patch-equivalent to commits here; the fifth is present by content, with the rebase having folded the bluebottle import change into it. Its `volumelock.go` still has the in-directory lock file this branch fixes.

## Testing

`make preflight` passes: golangci-lint 0 issues, govulncheck clean, diff coverage 87.7%.