### PR TITLE
feat: report volume closes so concurrent engine holders are distinguishable from a handover

### DIFF
--- a/telemetry/metrics.go
+++ b/telemetry/metrics.go
@@ -31,8 +31,9 @@ var (
 
 	cacheLookups metric.Int64Counter
 
-	rmwConflicts metric.Int64Counter
-	volumeOpens  metric.Int64Counter
+	rmwConflicts  metric.Int64Counter
+	volumeOpens   metric.Int64Counter
+	volumeEngines metric.Int64UpDownCounter
 
 	// cacheHitOpts/cacheMissOpts are pre-built as slices, not bare options, so
 	// the per-block cache lookup path (inside the read hot loop) allocates
@@ -114,6 +115,13 @@ func instruments() {
 		if err != nil {
 			otel.Handle(err)
 		}
+
+		volumeEngines, err = m.Int64UpDownCounter("viperblock.volume.engines",
+			metric.WithDescription("Engines currently holding a volume: incremented on open, decremented on close. Summed across pids for one volume, a value above 1 is a dual-open happening now, without reconstructing intervals from open events."),
+			metric.WithUnit("{engine}"))
+		if err != nil {
+			otel.Handle(err)
+		}
 	})
 }
 
@@ -138,19 +146,46 @@ func RecordRMWConflict(ctx context.Context, volume string) {
 // identity: role ("nbdkit" for the data-path plugin, "daemon" for a
 // control-plane import, or "" when unset), executable name and pid.
 //
-// viperblock currently runs as BOTH an nbdkit plugin and a Go module imported
-// into the spinifex daemon, so a volume can be held by more than one engine
-// with no arbitration between them. mulga-t1sch removes the second engine; the
-// invariant it establishes is "one owner per volume". This metric is how that
-// invariant is observed: opens for a single volume carrying two different pids
-// or roles are a dual-open. It is both the evidence for the current bug class
-// and the permanent regression alarm for the plan's end state -- after
-// t1sch lands, any such series is a regression.
+// viperblock runs as both an nbdkit plugin and a Go module importable by a
+// control plane, so a volume can be held by more than one engine. The
+// invariant is one owner per volume, and this is how it is observed: opens
+// for one volume carrying two pids or roles are a dual-open.
 func RecordVolumeOpen(ctx context.Context, volume, role string) {
 	instruments()
-	if volumeOpens == nil {
+	attrs := volumeIdentityAttrs(volume, role)
+	if volumeOpens != nil {
+		volumeOpens.Add(ctx, 1, metric.WithAttributes(attrs...))
+	}
+	if volumeEngines != nil {
+		volumeEngines.Add(ctx, 1, metric.WithAttributes(attrs...))
+	}
+}
+
+// RecordVolumeClose releases the volume-open recorded by RecordVolumeOpen,
+// decrementing the engine count under identical attributes so the two cancel.
+//
+// Without it, opens for one volume are indistinguishable from two engines
+// holding it at once: nbdkit opening after the control plane released is a
+// normal handover and produces the same two events as a genuine dual-open.
+// The engine count is what separates them, and it only means anything if
+// every open is eventually matched.
+//
+// A process that dies never gets here, so its open stays outstanding. That is
+// deliberate: the volume lock and the control-plane lease are what reclaim a
+// dead holder, and an unmatched open is a signal worth keeping rather than
+// papering over.
+func RecordVolumeClose(ctx context.Context, volume, role string) {
+	instruments()
+	if volumeEngines == nil {
 		return
 	}
+	volumeEngines.Add(ctx, -1, metric.WithAttributes(volumeIdentityAttrs(volume, role)...))
+}
+
+// volumeIdentityAttrs builds the attributes identifying which engine holds a
+// volume. Shared by open and close so the two carry an identical attribute
+// set; any divergence would leave the engine count unable to cancel them out.
+func volumeIdentityAttrs(volume, role string) []attribute.KeyValue {
 	attrs := []attribute.KeyValue{
 		attribute.Int("pid", os.Getpid()),
 		attribute.String("process", filepath.Base(os.Args[0])),
@@ -161,7 +196,7 @@ func RecordVolumeOpen(ctx context.Context, volume, role string) {
 	if role != "" {
 		attrs = append(attrs, attribute.String("role", role))
 	}
-	volumeOpens.Add(ctx, 1, metric.WithAttributes(attrs...))
+	return attrs
 }
 
 // RecordBackendIO records one backend chunk-object read or write: op count,

--- a/telemetry/volume_engines_test.go
+++ b/telemetry/volume_engines_test.go
@@ -1,0 +1,114 @@
+package telemetry
+
+import (
+	"context"
+	"testing"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+// engineCount sums viperblock.volume.engines across every attribute set whose
+// volume matches, which is how a reader asks "how many engines hold this
+// volume right now" without caring which process each one is.
+func engineCount(t *testing.T, metrics map[string]any, volume string) int64 {
+	t.Helper()
+	sum, ok := metrics["viperblock.volume.engines"].(metricdata.Sum[int64])
+	if !ok {
+		t.Fatalf("viperblock.volume.engines missing or wrong type: %#v", metrics["viperblock.volume.engines"])
+	}
+	var held int64
+	for _, dp := range sum.DataPoints {
+		if v, found := dp.Attributes.Value(attribute.Key("volume")); found && v.AsString() == volume {
+			held += dp.Value
+		}
+	}
+	return held
+}
+
+func collect(t *testing.T, reader interface {
+	Collect(context.Context, *metricdata.ResourceMetrics) error
+}) map[string]any {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &rm); err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	return collectMetrics(t, rm)
+}
+
+// TestVolumeEnginesNetsToZero is the whole point of the close event: an open
+// followed by its close must leave nothing held. Without it, the open alone
+// looks identical to an engine that never let go.
+func TestVolumeEnginesNetsToZero(t *testing.T) {
+	reader := withManualReader(t)
+	ctx := context.Background()
+
+	RecordVolumeOpen(ctx, "vol-net", "nbdkit")
+	if held := engineCount(t, collect(t, reader), "vol-net"); held != 1 {
+		t.Fatalf("engines held after open = %d, want 1", held)
+	}
+
+	RecordVolumeClose(ctx, "vol-net", "nbdkit")
+	if held := engineCount(t, collect(t, reader), "vol-net"); held != 0 {
+		t.Errorf("engines held after close = %d, want 0", held)
+	}
+}
+
+// TestVolumeEnginesSeesConcurrentHolders is the condition being hunted: two
+// engines holding one volume at the same time. Both opens land before either
+// close, so a handover cannot produce this reading.
+func TestVolumeEnginesSeesConcurrentHolders(t *testing.T) {
+	reader := withManualReader(t)
+	ctx := context.Background()
+
+	RecordVolumeOpen(ctx, "vol-dual", "nbdkit")
+	RecordVolumeOpen(ctx, "vol-dual", "daemon")
+
+	if held := engineCount(t, collect(t, reader), "vol-dual"); held != 2 {
+		t.Fatalf("engines held = %d, want 2 — a dual-open must be readable directly", held)
+	}
+
+	RecordVolumeClose(ctx, "vol-dual", "daemon")
+	if held := engineCount(t, collect(t, reader), "vol-dual"); held != 1 {
+		t.Errorf("engines held after one release = %d, want 1", held)
+	}
+}
+
+// TestVolumeEnginesHandoverIsNotADualOpen pins the distinction the open
+// counter alone cannot make. The same two opens as above, with a close in
+// between, never reads above one.
+func TestVolumeEnginesHandoverIsNotADualOpen(t *testing.T) {
+	reader := withManualReader(t)
+	ctx := context.Background()
+
+	RecordVolumeOpen(ctx, "vol-handover", "daemon")
+	RecordVolumeClose(ctx, "vol-handover", "daemon")
+	RecordVolumeOpen(ctx, "vol-handover", "nbdkit")
+
+	metrics := collect(t, reader)
+	if held := engineCount(t, metrics, "vol-handover"); held != 1 {
+		t.Errorf("engines held after handover = %d, want 1", held)
+	}
+
+	opens, ok := metrics["viperblock.volume.opens"].(metricdata.Sum[int64])
+	if !ok {
+		t.Fatalf("viperblock.volume.opens missing: %#v", metrics["viperblock.volume.opens"])
+	}
+	var total int64
+	for _, dp := range opens.DataPoints {
+		if v, found := dp.Attributes.Value(attribute.Key("volume")); found && v.AsString() == "vol-handover" {
+			total += dp.Value
+		}
+	}
+	if total != 2 {
+		t.Errorf("opens = %d, want 2 — the two readings must disagree, or the engine count adds nothing", total)
+	}
+}
+
+// TestRecordVolumeCloseIsNoopWithoutRealProvider mirrors the open path: the
+// global meter stays a no-op until Init installs a provider, and a close on
+// shutdown must tolerate that rather than panic.
+func TestRecordVolumeCloseIsNoopWithoutRealProvider(t *testing.T) {
+	RecordVolumeClose(context.Background(), "vol-1", "nbdkit")
+}

--- a/viperblock/viperblock.go
+++ b/viperblock/viperblock.go
@@ -1377,6 +1377,22 @@ func (vb *VB) releaseEngine() {
 		"process", filepath.Base(os.Args[0]))
 }
 
+// Detach stops this engine's background goroutines and reports the volume
+// released, without Close's flush and state save. It is for the short-lived
+// engines a control plane opens for one operation and then abandons: those
+// stop the goroutines and never reach Close, so without this the engine count
+// only ever counts up and every volume eventually reads as permanently held.
+//
+// Unlike the hand-rolled stop pairs it replaces, this also stops the chunk GC
+// sweeper, which New starts and those callers left running on an engine they
+// had finished with.
+func (vb *VB) Detach() {
+	vb.StopChunkGC()
+	vb.StopChunkUploader()
+	vb.StopWALSyncer()
+	vb.releaseEngine()
+}
+
 // logger returns vb.log, falling back to slog.Default() for VB values
 // assembled without going through New() (e.g. spinifex's snapshotRunningVolume
 // path, which hand-builds a read-only VB sharing another instance's backend).

--- a/viperblock/viperblock.go
+++ b/viperblock/viperblock.go
@@ -489,6 +489,13 @@ type VB struct {
 	// reused" invariant GC's refcount/floor reasoning relies on). Checked
 	// by ensureGCSnapshotSafe.
 	gcLatchedOff atomic.Bool
+
+	// engineHeld is set by New once it records the volume open, and cleared by
+	// the close that reports the release. Only a VB that recorded an open may
+	// report a close, so a hand-built VB that never went through New cannot
+	// drive the engine count negative, and a second CloseCtx on an already
+	// closed VB cannot decrement twice.
+	engineHeld atomic.Bool
 }
 
 // CacheConfig holds configuration for the LRU cache.
@@ -1347,12 +1354,27 @@ func New(config *VB, btype string, backendConfig any) (*VB, error) {
 	// every construction is a potential WRITER of this volume, not a reader --
 	// which is why the open is worth recording with process identity. Opens
 	// for one volume carrying two pids/roles mean two engines hold it.
+	vb.engineHeld.Store(true)
 	telemetry.RecordVolumeOpen(context.Background(), vb.VolumeName, vb.Role)
 	vb.logger().Info("viperblock volume opened",
 		"volume", vb.VolumeName, "role", vb.Role, "pid", os.Getpid(),
 		"process", filepath.Base(os.Args[0]), "encrypted", vb.EncryptionEnabled)
 
 	return vb, nil
+}
+
+// releaseEngine reports that this VB no longer holds its volume, exactly once
+// and only if New recorded the open. Paired with the open event, this is what
+// makes two engines holding one volume at the same time distinguishable from
+// one engine handing the volume to another.
+func (vb *VB) releaseEngine() {
+	if !vb.engineHeld.CompareAndSwap(true, false) {
+		return
+	}
+	telemetry.RecordVolumeClose(context.Background(), vb.VolumeName, vb.Role)
+	vb.logger().Info("viperblock volume closed",
+		"volume", vb.VolumeName, "role", vb.Role, "pid", os.Getpid(),
+		"process", filepath.Base(os.Args[0]))
 }
 
 // logger returns vb.log, falling back to slog.Default() for VB values
@@ -5994,6 +6016,12 @@ func (vb *VB) Close() error {
 // cancellable, since it is what makes an aborted CloseCtx safe to recover from.
 func (vb *VB) CloseCtx(ctx context.Context) error {
 	vb.logger().Info("VB Close, flushing block state to disk")
+
+	// Deferred so a Close that fails still reports the release: the background
+	// goroutines are stopped either way, and callers release the volume lock
+	// regardless of the error. An engine still counted as holding a volume it
+	// has stopped writing to would read as a dual-open on the next opener.
+	defer vb.releaseEngine()
 
 	// Stop background goroutines before flushing
 	vb.StopChunkGC()

--- a/viperblock/volume_engine_release_test.go
+++ b/viperblock/volume_engine_release_test.go
@@ -1,0 +1,120 @@
+package viperblock
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/mulgadc/viperblock/viperblock/backends/file"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// captureHandler records the messages logged through it, so a test can assert
+// on the open/close events themselves rather than on the flag that gates them.
+type captureHandler struct {
+	mu   sync.Mutex
+	msgs []string
+}
+
+func (h *captureHandler) Enabled(context.Context, slog.Level) bool { return true }
+
+func (h *captureHandler) Handle(_ context.Context, r slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.msgs = append(h.msgs, r.Message)
+	return nil
+}
+
+func (h *captureHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h *captureHandler) WithGroup(string) slog.Handler      { return h }
+
+func (h *captureHandler) count(msg string) int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	n := 0
+	for _, m := range h.msgs {
+		if m == msg {
+			n++
+		}
+	}
+	return n
+}
+
+const (
+	volumeOpenedMsg = "viperblock volume opened"
+	volumeClosedMsg = "viperblock volume closed"
+)
+
+// newCapturedVB builds a VB whose events land in the returned handler.
+func newCapturedVB(t *testing.T) (*VB, *captureHandler) {
+	t.Helper()
+
+	tmpDir := t.TempDir()
+	testVol := fmt.Sprintf("test_engine_release_%d", time.Now().UnixNano())
+	capture := &captureHandler{}
+
+	vb, err := New(&VB{
+		VolumeName:          testVol,
+		VolumeSize:          volumeSize,
+		BaseDir:             fmt.Sprintf("%s/%s", tmpDir, "viperblock"),
+		WALSyncInterval:     5 * time.Millisecond,
+		ChunkUploadInterval: 10 * time.Millisecond,
+		Logger:              slog.New(capture),
+	}, FileBackend, file.FileConfig{
+		VolumeName: testVol,
+		VolumeSize: volumeSize,
+		BaseDir:    tmpDir,
+	})
+	require.NoError(t, err)
+	require.NoError(t, vb.Backend.Init())
+	require.NoError(t, vb.OpenWAL(&vb.WAL, fmt.Sprintf("%s/%s/wal/chunks/wal.%08d.bin",
+		vb.BaseDir, vb.GetVolume(), vb.WAL.WallNum.Load())))
+
+	t.Cleanup(func() {
+		vb.StopChunkUploader()
+		vb.StopWALSyncer()
+	})
+
+	return vb, capture
+}
+
+// TestCloseEmitsOneVolumeClosed is the wiring. CloseCtx has several exits, so
+// the release is deferred rather than sitting on the success path; and it must
+// fire once, not once per exit.
+func TestCloseEmitsOneVolumeClosed(t *testing.T) {
+	vb, capture := newCapturedVB(t)
+	require.Equal(t, 1, capture.count(volumeOpenedMsg), "New must record the open, or the close below has nothing to match")
+	require.Zero(t, capture.count(volumeClosedMsg))
+
+	require.NoError(t, vb.Close())
+	assert.Equal(t, 1, capture.count(volumeClosedMsg), "Close must report the volume released exactly once")
+}
+
+// TestSecondCloseEmitsNothing covers a VB closed twice — nbdkit's Unload runs
+// after Close on some shutdown paths. The engine count is a running total, so
+// a repeated release would push it below zero and read as fewer holders than
+// there are.
+func TestSecondCloseEmitsNothing(t *testing.T) {
+	vb, capture := newCapturedVB(t)
+	require.NoError(t, vb.Close())
+	require.Equal(t, 1, capture.count(volumeClosedMsg))
+
+	vb.releaseEngine()
+	assert.Equal(t, 1, capture.count(volumeClosedMsg), "a second release must not be reported")
+}
+
+// TestHandBuiltVBEmitsNoClose covers a VB assembled as a struct literal rather
+// than through New — the read-only shapes that share another instance's
+// backend. Those record no open, so releasing one would decrement a count it
+// never incremented.
+func TestHandBuiltVBEmitsNoClose(t *testing.T) {
+	capture := &captureHandler{}
+	vb := &VB{VolumeName: "vol-handbuilt", log: slog.New(capture)}
+
+	vb.releaseEngine()
+	assert.Zero(t, capture.count(volumeClosedMsg), "a VB that skipped New holds nothing to release")
+}

--- a/viperblock/volume_engine_release_test.go
+++ b/viperblock/volume_engine_release_test.go
@@ -107,6 +107,43 @@ func TestSecondCloseEmitsNothing(t *testing.T) {
 	assert.Equal(t, 1, capture.count(volumeClosedMsg), "a second release must not be reported")
 }
 
+// TestDetachEmitsOneVolumeClosed is the path that actually matters in the
+// control plane: an engine opened for one operation and abandoned. Most
+// callers stop the goroutines and never reach Close, so without a release here
+// the engine count only ever counts up.
+func TestDetachEmitsOneVolumeClosed(t *testing.T) {
+	vb, capture := newCapturedVB(t)
+	require.Equal(t, 1, capture.count(volumeOpenedMsg))
+
+	vb.Detach()
+	assert.Equal(t, 1, capture.count(volumeClosedMsg), "Detach must report the volume released")
+}
+
+// TestDetachStopsBackgroundGoroutines pins that Detach really is a teardown
+// and not just an event: an engine that keeps uploading chunks after being
+// reported as released is still a writer of the volume.
+func TestDetachStopsBackgroundGoroutines(t *testing.T) {
+	vb, _ := newCapturedVB(t)
+	require.NotNil(t, vb.chunkUploadStop, "the uploader must be running, or this passes vacuously")
+	require.NotNil(t, vb.walSyncStop, "the WAL syncer must be running, or this passes vacuously")
+
+	vb.Detach()
+	assert.Nil(t, vb.chunkUploadStop, "Detach must stop the chunk uploader")
+	assert.Nil(t, vb.walSyncStop, "Detach must stop the WAL syncer")
+}
+
+// TestDetachThenCloseEmitsOnce covers a caller that detaches and later closes
+// the same VB. Two releases for one open would read as fewer holders than
+// there are.
+func TestDetachThenCloseEmitsOnce(t *testing.T) {
+	vb, capture := newCapturedVB(t)
+	vb.Detach()
+	require.Equal(t, 1, capture.count(volumeClosedMsg))
+
+	require.NoError(t, vb.Close())
+	assert.Equal(t, 1, capture.count(volumeClosedMsg), "the close after a detach must not report a second release")
+}
+
 // TestHandBuiltVBEmitsNoClose covers a VB assembled as a struct literal rather
 // than through New — the read-only shapes that share another instance's
 // backend. Those record no open, so releasing one would decrement a count it


### PR DESCRIPTION
## Summary

`New()` recorded a volume open with process identity, and nothing recorded the release. So two opens for one volume could not be told apart from two *sequential* ones — nbdkit opening after the control plane let go is a normal handover and produces the same events as a genuine dual-open.

That gap blocks the last acceptance criterion of the single-owner-per-volume work: verifying live that no two processes hold engines for the same volume during AMI creation from a running instance. Without an interval there is nothing to overlap, so a clean run is weaker evidence than it looks.

## Changes

- `RecordVolumeClose` in `telemetry`, mirroring the open's attributes exactly so the two cancel.
- `viperblock.volume.engines`, an UpDownCounter incremented on open and decremented on close. Summed across pids for one volume, a value above 1 is a dual-open happening now — readable directly rather than reconstructed from open events.
- The release fires from **two** teardowns, not one:
  - `CloseCtx`, which `nbd` `Close`, `nbd` `Unload` and `Close` all reach. Deferred, so a close that fails still reports: the goroutines are stopped either way and callers release the volume lock regardless.
  - `Detach`, new, for an engine opened for a single operation and abandoned. It stops the goroutines and reports the release.
- Guarded by an atomic that `New` sets. A hand-built read-only VB that recorded no open cannot decrement; a second close, or a close after a detach, cannot decrement twice.

### Why Detach exists

An earlier revision of this PR reported the release from `CloseCtx` alone and described it as the universal chokepoint. That is wrong, and it matters. `CloseCtx` is the chokepoint for engines that own a mount. A control plane opening an engine for one operation stops the background goroutines and never closes — viperblockd does this in nine places (`provider_handlers.go` 501, 702, 982, 1166, 1290, 1315, 1606; `viperblockd.go` 358, 691, 976) against three that reach `CloseCtx`.

Reporting only from `CloseCtx` would leave those opens outstanding forever. The engine count would climb monotonically and read as a permanent dual-open on every volume — worse than no gauge, because it looks authoritative.

`Detach` also stops the chunk GC sweeper, which `New` starts and those callers left running on an engine they had finished with.

Callers move to `defer vb.Detach()` in a follow-up on the spinifex side, which needs this released and pinned first.

## Known limit

A process that dies never reaches either teardown, so its open stays outstanding. Deliberate: the volume lock and the control-plane lease are what reclaim a dead holder, and an unmatched open is itself a useful signal.

## Testing

`make preflight` passes. Each test falsified by breaking the guard it covers:

| Test | Falsified by | Went red |
| --- | --- | --- |
| `TestVolumeEnginesNetsToZero` | making the close a zero-delta add | yes |
| `TestVolumeEnginesSeesConcurrentHolders` | same | yes |
| `TestVolumeEnginesHandoverIsNotADualOpen` | same | yes |
| `TestCloseEmitsOneVolumeClosed` | removing the deferred release | yes |
| `TestSecondCloseEmitsNothing` | replacing the compare-and-swap with a plain store | yes |
| `TestHandBuiltVBEmitsNoClose` | same | yes |
| `TestDetachEmitsOneVolumeClosed` | dropping the release from Detach | yes |
| `TestDetachThenCloseEmitsOnce` | same | yes |
| `TestDetachStopsBackgroundGoroutines` | making Detach report without stopping anything | yes |

Note: GitHub reports no status checks on this branch — viperblock CI did not pick the PR up.