### PR TITLE
chore: bump Go toolchain to 1.26.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mulgadc/viperblock
 
-go 1.26.5
+go 1.26.6
 
 replace libguestfs.org/nbdkit => ./nbd/libguestfs.org/nbdkit
 

--- a/nbd/go.mod
+++ b/nbd/go.mod
@@ -1,6 +1,6 @@
 module main
 
-go 1.26.5
+go 1.26.6
 
 replace libguestfs.org/nbdkit => ./libguestfs.org/nbdkit
 


### PR DESCRIPTION
## Summary

Bumps the pinned Go toolchain from 1.26.5 to 1.26.6 across viperblock. Four Go
stdlib advisories (GO-2026-6088, GO-2026-6089, GO-2026-6090, GO-2026-6091)
were published on 2026-08-13 and are fixed in go1.26.6. predastore CI was
already failing govulncheck because of them, and the team decided to move the
whole monorepo to 1.26.6 in one pass. This is a mechanical version bump, no
logic changes.

Files changed:
- `go.mod` (root module) — `go 1.26.5` -> `go 1.26.6`
- `nbd/go.mod` — `go 1.26.5` -> `go 1.26.6`. This is a separate nested Go
  module (module `main`, its own go.sum) used to build the nbdkit plugin, so
  it needed its own bump and its own build/govulncheck verification rather
  than inheriting the root module's pin.

`.github/workflows/viperblock.yml` uses `go-version-file: "go.mod"` in all
four jobs, so CI's toolchain follows the go.mod change automatically and
needed no edit. No Dockerfiles, shell scripts, or other hardcoded
`1.26.5` toolchain pins exist in the repo — the only two occurrences were the
two go.mod files above.

Reference: mulga-0q99f

## Verification

- `GOWORK=off go build ./...` succeeds in the repo root with go1.26.6.
- The real nbd plugin build path (`go build -buildmode=c-shared
  nbd/viperblock.go`, i.e. what `make go_build_nbd` runs) succeeds with
  go1.26.6. Note: `cd nbd && go build ./...` as a standalone module fails
  both before and after this change, with an unrelated pre-existing
  internal-package import error (`nbd/viperblock.go` blank-imports
  `github.com/mulgadc/viperblock/internal/fipsboot`, which module `main`
  cannot import under Go's internal-package visibility rule). This is not
  caused by the toolchain bump and is out of scope for this mechanical
  change.
- `GOWORK=off make preflight` passed (lint, govulncheck, test-cover, diff
  coverage) at the root.
- govulncheck before/after, called vulnerabilities only:
  - Root module: 7 before (go1.26.5, forced) -> 0 after (go1.26.6). The 7
    included GO-2026-6088/6089/6090/6091 plus GO-2026-6218, GO-2026-5972,
    GO-2026-5026, all fixed in go1.26.6.
  - `nbd/` module (checked via `govulncheck -mode=binary` against the built
    plugin `.so`, since the module can't be loaded standalone as above):
    7 before -> 0 after, same vulnerability set.

## Test plan

- [x] `GOWORK=off go build ./...` at repo root
- [x] Real nbd plugin build (`go build -buildmode=c-shared nbd/viperblock.go`)
- [x] `GOWORK=off make preflight`
- [x] `GOWORK=off go tool govulncheck ./...` (root) — 0 called vulnerabilities
- [x] `govulncheck -mode=binary` on nbd plugin artifact — 0 called vulnerabilities