### PR TITLE
fix: stop retrying permanent backend errors

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -29,6 +29,10 @@ var ErrShortRead = errors.New("viperblock: backend returned a short read")
 // operation instead of taking the process down.
 var ErrBackendConfig = errors.New("viperblock: backend config type mismatch")
 
+// ErrBackendNonRetryable marks a deterministic backend failure that another
+// attempt cannot fix, such as a rejected request or a missing DNS name.
+var ErrBackendNonRetryable = errors.New("viperblock: non-retryable backend error")
+
 type Backend interface {
 	Init() error
 	InitCtx(ctx context.Context) error

--- a/viperblock/backends/s3/s3.go
+++ b/viperblock/backends/s3/s3.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
 	"net/http"
 	"os"
 	"regexp"
@@ -17,6 +18,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsmiddleware "github.com/aws/aws-sdk-go-v2/aws/middleware"
+	awsretry "github.com/aws/aws-sdk-go-v2/aws/retry"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/smithy-go"
@@ -74,6 +76,50 @@ func wrapNotFound(err error) error {
 		case "NoSuchKey", "NoSuchBucket", "NotFound", "NoSuchVersion":
 			return fmt.Errorf("%w: %w", os.ErrNotExist, err)
 		}
+	}
+	return err
+}
+
+// isNonRetryableBackendError identifies failures that cannot recover without
+// changing the request or DNS configuration. Throttling remains retryable.
+func isNonRetryableBackendError(err error) bool {
+	var statusErr interface{ HTTPStatusCode() int }
+	if errors.As(err, &statusErr) {
+		status := statusErr.HTTPStatusCode()
+		return status >= http.StatusBadRequest && status < http.StatusInternalServerError && status != http.StatusTooManyRequests
+	}
+
+	var dnsErr *net.DNSError
+	return errors.As(err, &dnsErr) && dnsErr.IsNotFound
+}
+
+// newRetryer preserves the SDK retry policy while overriding deterministic
+// client and DNS failures before the default connection checks see them.
+func newRetryer() aws.Retryer {
+	return awsretry.NewStandard(func(options *awsretry.StandardOptions) {
+		classifier := awsretry.IsErrorRetryableFunc(func(err error) aws.Ternary {
+			var statusErr interface{ HTTPStatusCode() int }
+			if errors.As(err, &statusErr) && statusErr.HTTPStatusCode() == http.StatusTooManyRequests {
+				return aws.TrueTernary
+			}
+			if isNonRetryableBackendError(err) {
+				return aws.FalseTernary
+			}
+			return aws.UnknownTernary
+		})
+		options.Retryables = append([]awsretry.IsErrorRetryable{classifier}, options.Retryables...)
+	})
+}
+
+// classifyReadErr exposes deterministic failures to Viperblock's outer retry
+// loops while preserving the established object-not-found contract.
+func classifyReadErr(err error) error {
+	err = wrapNotFound(err)
+	if err == nil || errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	if isNonRetryableBackendError(err) {
+		return fmt.Errorf("%w: %w", types.ErrBackendNonRetryable, err)
 	}
 	return err
 }
@@ -352,6 +398,7 @@ func (backend *Backend) InitReadOnlyCtx(ctx context.Context) error {
 		Region:                       backend.config.Region,
 		HTTPClient:                   client,
 		Credentials:                  credentials.NewStaticCredentialsProvider(backend.config.AccessKey, backend.config.SecretKey, ""),
+		Retryer:                      newRetryer(),
 		// Registers the pool-pressure observer after the SDK's own deserialize
 		// middleware, so RawResponse is already populated when it runs.
 		APIOptions: []func(*middleware.Stack) error{
@@ -405,11 +452,10 @@ func (backend *Backend) ReadCtx(ctx context.Context, fileType types.FileType, ob
 		backend.log.DebugContext(ctx, "[S3 READ] Reading entire file", "key", filename)
 	}
 
-	// TODO: Add retry from S3 timeout/500/etc
 	textResult, err := backend.config.s3Client.GetObject(ctx, requestObject)
 
 	if err != nil {
-		return nil, wrapNotFound(err)
+		return nil, classifyReadErr(err)
 	}
 	defer textResult.Body.Close()
 
@@ -524,7 +570,7 @@ func (backend *Backend) ReadFromCtx(ctx context.Context, volumeName string, file
 
 	textResult, err := backend.config.s3Client.GetObject(ctx, requestObject)
 	if err != nil {
-		return nil, wrapNotFound(err)
+		return nil, classifyReadErr(err)
 	}
 	defer textResult.Body.Close()
 

--- a/viperblock/backends/s3/s3_test.go
+++ b/viperblock/backends/s3/s3_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"sync/atomic"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -77,6 +78,25 @@ func TestNormalizeEndpoint(t *testing.T) {
 // TestWrapNotFound pins the AWS-error → os.ErrNotExist mapping that callers
 // (e.g. viperblock.LoadState) rely on to tell "object missing" apart from
 // "backend unreachable". Required by the medium-term fix.
+func TestRetryerClassifiesHTTPStatus(t *testing.T) {
+	cases := []struct {
+		status    int
+		retryable bool
+	}{
+		{status: http.StatusBadRequest, retryable: false},
+		{status: http.StatusForbidden, retryable: false},
+		{status: http.StatusTooManyRequests, retryable: true},
+		{status: http.StatusInternalServerError, retryable: true},
+	}
+
+	retryer := newRetryer()
+	for _, tc := range cases {
+		t.Run(strconv.Itoa(tc.status), func(t *testing.T) {
+			assert.Equal(t, tc.retryable, retryer.IsErrorRetryable(newResponseError(tc.status)))
+		})
+	}
+}
+
 func TestWrapNotFound(t *testing.T) {
 	cases := []struct {
 		name         string
@@ -398,8 +418,27 @@ func newTestBackend(t *testing.T, rt http.RoundTripper) *Backend {
 		Region:       "us-east-1",
 		HTTPClient:   &http.Client{Transport: rt},
 		Credentials:  credentials.NewStaticCredentialsProvider("ak", "sk", ""),
+		Retryer:      newRetryer(),
 	})
 	return backend
+}
+
+func TestReadCtx_BadRequestIsNotRetried(t *testing.T) {
+	var requests atomic.Int32
+	backend := newTestBackend(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requests.Add(1)
+		return &http.Response{
+			StatusCode: http.StatusBadRequest,
+			Header:     http.Header{},
+			Body:       io.NopCloser(bytes.NewReader(nil)),
+			Request:    req,
+		}, nil
+	}))
+
+	_, err := backend.ReadCtx(context.Background(), types.FileTypeConfig, 0, 0, 0)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, types.ErrBackendNonRetryable)
+	assert.Equal(t, int32(1), requests.Load())
 }
 
 // TestReadCtx_FullObjectShortBodyIsRefused pins that a full-object GET

--- a/viperblock/block_state_error_test.go
+++ b/viperblock/block_state_error_test.go
@@ -1,0 +1,60 @@
+package viperblock
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/mulgadc/viperblock/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type checkpointReadErrorBackend struct {
+	types.Backend
+
+	err error
+}
+
+var _ types.Backend = (*checkpointReadErrorBackend)(nil)
+
+func (b *checkpointReadErrorBackend) ReadCtx(ctx context.Context, fileType types.FileType, objectID uint64, offset, length uint32) ([]byte, error) {
+	if fileType == types.FileTypeBlockCheckpoint {
+		return nil, b.err
+	}
+	return b.Backend.ReadCtx(ctx, fileType, objectID, offset, length)
+}
+
+func TestLoadBlockStateCtx_ClassifiesBackendReadErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		readErr error
+		wantErr error
+	}{
+		{
+			name:    "missing checkpoint means empty volume",
+			readErr: fmt.Errorf("checkpoint: %w", os.ErrNotExist),
+		},
+		{
+			name:    "backend rejection fails closed",
+			readErr: fmt.Errorf("checkpoint: %w", types.ErrBackendNonRetryable),
+			wantErr: types.ErrBackendNonRetryable,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vb := newFileBackedVB(t, "vol-checkpoint-error", nil)
+			vb.Backend = &checkpointReadErrorBackend{Backend: vb.Backend, err: tt.readErr}
+
+			err := vb.LoadBlockStateCtx(context.Background())
+			if tt.wantErr == nil {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.ErrorIs(t, err, tt.wantErr)
+		})
+	}
+}

--- a/viperblock/state_retry_test.go
+++ b/viperblock/state_retry_test.go
@@ -135,6 +135,20 @@ func TestLoadStateRequestCtx_ExhaustsRetriesOnPersistentTruncation(t *testing.T)
 	assert.Equal(t, stateReadMaxAttempts, flaky.callCount())
 }
 
+func TestLoadStateRequestCtx_NoRetryOnNonRetryableBackendError(t *testing.T) {
+	vb := newFileBackedVB(t, "vol-retry-rejected", nil)
+	flaky := &flakyConfigBackend{Backend: vb.Backend}
+	flaky.mutate = func(call int, data []byte, err error) ([]byte, error) {
+		return nil, fmt.Errorf("bad request: %w", types.ErrBackendNonRetryable)
+	}
+	vb.Backend = flaky
+
+	_, err := vb.LoadStateRequestCtx(context.Background(), "")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, types.ErrBackendNonRetryable)
+	assert.Equal(t, 1, flaky.callCount())
+}
+
 // TestLoadStateRequestCtx_NoRetryOnEncryptionMismatch pins that a wrong-key
 // open makes exactly one attempt: the key is wrong on every retry too, so
 // retrying only burns the recovery window for a deterministic failure.

--- a/viperblock/v_utils/v_utils.go
+++ b/viperblock/v_utils/v_utils.go
@@ -2,6 +2,7 @@ package v_utils
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -153,16 +154,11 @@ func ImportDiskImage(s3Config *s3.S3Config, vbConfig *viperblock.VB, filename st
 		return fmt.Errorf("failed to initialize backend: %w", err)
 	}
 
-	//var walNum uint64
-
-	// First, fetch the state from the remote backend
-	_ = vb.LoadState()
-	// err = vb.LoadState()
-
-	// if err != nil {
-	// 	// Soft error, since volume may be new
-	// 	//return fmt.Errorf("failed to load state: %v", err)
-	// }
+	// A missing state object is expected for a new import. Every other error
+	// means an existing volume could not be inspected and must fail closed.
+	if err := vb.LoadState(); err != nil && !errors.Is(err, viperblock.ErrStateNotFound) {
+		return fmt.Errorf("failed to load state: %w", err)
+	}
 
 	err = vb.LoadBlockState()
 

--- a/viperblock/v_utils/v_utils_test.go
+++ b/viperblock/v_utils/v_utils_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
@@ -14,6 +15,7 @@ import (
 
 	"github.com/mulgadc/bluebottle/pkg/masterkey"
 	"github.com/mulgadc/viperblock/internal/predastoretest"
+	backendtypes "github.com/mulgadc/viperblock/types"
 	"github.com/mulgadc/viperblock/viperblock"
 	"github.com/mulgadc/viperblock/viperblock/backends/s3"
 	"github.com/stretchr/testify/assert"
@@ -66,6 +68,42 @@ func TestImportDiskImage(t *testing.T) {
 	assert.NotEmpty(t, vbConfig.VolumeConfig.AMIMetadata.RootDeviceType)
 	assert.NotEmpty(t, vbConfig.VolumeConfig.AMIMetadata.Virtualization)
 	assert.NotEmpty(t, vbConfig.VolumeConfig.AMIMetadata.ImageOwnerAlias)
+}
+
+func TestImportDiskImage_ExistingStateReadErrorFailsClosed(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("list-type") == "2" {
+			w.Header().Set("Content-Type", "application/xml")
+			_, _ = fmt.Fprint(w, `<?xml version="1.0" encoding="UTF-8"?><ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>bucket</Name><KeyCount>0</KeyCount><MaxKeys>1</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>`)
+			return
+		}
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	t.Cleanup(srv.Close)
+
+	imagePath := filepath.Join(t.TempDir(), "disk.raw")
+	require.NoError(t, os.WriteFile(imagePath, bytes.Repeat([]byte{0xAB}, int(viperblock.DefaultBlockSize)), 0o600))
+
+	volumeName := "vol-import-rejected"
+	vbConfig := &viperblock.VB{
+		VolumeName: volumeName,
+		VolumeSize: uint64(viperblock.DefaultBlockSize),
+		BaseDir:    t.TempDir(),
+	}
+	s3Config := &s3.S3Config{
+		VolumeName: volumeName,
+		VolumeSize: uint64(viperblock.DefaultBlockSize),
+		Region:     "us-east-1",
+		Bucket:     "bucket",
+		AccessKey:  "access-key",
+		SecretKey:  "secret-key",
+		Host:       srv.URL,
+	}
+
+	err := ImportDiskImage(s3Config, vbConfig, imagePath, nil)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "failed to load state")
+	assert.ErrorIs(t, err, backendtypes.ErrBackendNonRetryable)
 }
 
 // TestProgressReporterThrottlesToPercent drives the reporter over a simulated

--- a/viperblock/viperblock.go
+++ b/viperblock/viperblock.go
@@ -973,9 +973,8 @@ var ErrNoSpace = types.ErrNoSpace
 // volume).
 var ErrStateNotFound = errors.New("viperblock: state not found")
 
-// ErrStateBackendUnavailable is returned by LoadState when the backend Read
-// failed with a non-not-found error (timeout, network, 5xx). Callers should
-// retry with backoff; the state may become available shortly.
+// ErrStateBackendUnavailable is returned when a state read fails with a
+// transient backend error. Callers should retry with backoff.
 var ErrStateBackendUnavailable = errors.New("viperblock: state backend unavailable")
 
 // ErrSnapshotVolumeMismatch is returned when an operation that must run on a
@@ -1030,10 +1029,12 @@ var ErrWALHeaderShort = errors.New("viperblock: WAL file too short to contain a 
 // volume has no persisted state (genuine "new volume"), anything else means
 // the backend is transiently unreachable.
 //
-// Backends signal "object missing" by wrapping os.ErrNotExist (file backend
-// returns os.PathError directly; s3 backend's wrapNotFound translates
-// NoSuchKey/NoSuchBucket/etc.). Any other error is treated as transient.
+// Backends signal missing objects with os.ErrNotExist and deterministic
+// failures with types.ErrBackendNonRetryable. Other errors are transient.
 func classifyStateLoad(localErr, backendErr error) error {
+	if errors.Is(backendErr, types.ErrBackendNonRetryable) {
+		return backendErr
+	}
 	if backendErr != nil && !errors.Is(backendErr, os.ErrNotExist) {
 		return fmt.Errorf("%w: %w", ErrStateBackendUnavailable, backendErr)
 	}
@@ -5693,9 +5694,8 @@ func (vb *VB) loadStateAttemptCtx(ctx context.Context, filename string) (state V
 	} else {
 		jsonData, err = vb.Backend.ReadCtx(ctx, types.FileTypeConfig, 0, 0, 0)
 		if err != nil {
-			// Object-not-found is genuinely missing state, not a transient
-			// backend hiccup — retrying it only burns the recovery window.
-			return state, !errors.Is(err, os.ErrNotExist), err
+			retryable = !errors.Is(err, os.ErrNotExist) && !errors.Is(err, types.ErrBackendNonRetryable)
+			return state, retryable, err
 		}
 	}
 

--- a/viperblock/viperblock.go
+++ b/viperblock/viperblock.go
@@ -4400,10 +4400,11 @@ func (vb *VB) LoadBlockStateCtx(ctx context.Context) (err error) {
 
 		// Open the latest checkpoint from the backend
 		checkpoint, err = vb.Backend.ReadCtx(ctx, types.FileTypeBlockCheckpoint, wallNum, 0, 0)
-
 		if err != nil {
-			// If no file found, volume is empty, return nil
-			return nil
+			if errors.Is(err, os.ErrNotExist) {
+				return nil
+			}
+			return fmt.Errorf("read block checkpoint %d: %w", wallNum, err)
 		}
 
 		// This is the same object, at the same WallNum, that the GC floor is

--- a/viperblock/viperblock_test.go
+++ b/viperblock/viperblock_test.go
@@ -2604,6 +2604,14 @@ func TestClassifyStateLoad(t *testing.T) {
 	}
 }
 
+func TestClassifyStateLoad_NonRetryableBackendErrorPassesThrough(t *testing.T) {
+	rejected := fmt.Errorf("bad request: %w", types.ErrBackendNonRetryable)
+	got := classifyStateLoad(fmt.Errorf("local: %w", os.ErrNotExist), rejected)
+
+	assert.ErrorIs(t, got, types.ErrBackendNonRetryable)
+	assert.NotErrorIs(t, got, ErrStateBackendUnavailable)
+}
+
 // The sweep runs against a directory shared with other processes, so what it
 // declines to touch matters as much as what it reclaims: only a directory that
 // matches the prefix AND is far older than any live run may go.


### PR DESCRIPTION
## Summary

- classify HTTP 4xx responses other than 429 and permanent DNS lookup failures as non-retryable
- stop deterministic failures at both the AWS SDK and Viperblock state-read retry layers
- preserve retries for throttling, 5xx responses, and other transient failures
- add request-count and error-classification regression coverage