### PR TITLE
refactor: use bluebottle/pkg/safecast for the numeric conversions

### DIFF
--- a/cmd/sfs/sfs.go
+++ b/cmd/sfs/sfs.go
@@ -12,12 +12,12 @@ import (
 
 	"github.com/mulgadc/viperblock/simplefs"
 	"github.com/mulgadc/viperblock/types"
-	"github.com/mulgadc/viperblock/utils"
 	"github.com/mulgadc/viperblock/viperblock"
 	"github.com/mulgadc/viperblock/viperblock/backends/file"
 	"github.com/mulgadc/viperblock/viperblock/backends/s3"
 
 	_ "github.com/mulgadc/bluebottle/pkg/fipsboot"
+	"github.com/mulgadc/bluebottle/pkg/safecast"
 )
 
 func main() {
@@ -215,7 +215,7 @@ func main() {
 		}
 
 		// Create a file
-		blocks, err := sfs.CreateFile(path, utils.SafeInt64ToUint64(info.Size()))
+		blocks, err := sfs.CreateFile(path, safecast.Int64ToUint64(info.Size()))
 		if err != nil {
 			slog.Error("Could not create file", "error", err)
 			return err
@@ -334,21 +334,21 @@ func main() {
 				os.Exit(1)
 			}
 
-			data, err := vb.Backend.Read(types.FileTypeChunk, objectID, objectOffset, utils.SafeUint64ToUint32(sfs.Blocksize))
+			data, err := vb.Backend.Read(types.FileTypeChunk, objectID, objectOffset, safecast.Uint64ToUint32(sfs.Blocksize))
 			if err != nil {
 				slog.Error("Could not read block", "error", err)
 				os.Exit(1)
 			}
 
 			// Position in the buffer where this block should go
-			pos := i * utils.SafeUint64ToInt(sfs.Blocksize)
+			pos := i * safecast.Uint64ToInt(sfs.Blocksize)
 			if pos >= len(fileBuffer) {
 				break // Don't write past the buffer
 			}
 
 			// How much we can copy from this block
-			bytesToCopy := utils.SafeUint64ToInt(sfs.Blocksize)
-			if (pos + utils.SafeUint64ToInt(sfs.Blocksize)) > len(fileBuffer) {
+			bytesToCopy := safecast.Uint64ToInt(sfs.Blocksize)
+			if (pos + safecast.Uint64ToInt(sfs.Blocksize)) > len(fileBuffer) {
 				bytesToCopy = len(fileBuffer) - pos
 			}
 

--- a/cmd/vblock/main.go
+++ b/cmd/vblock/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/mulgadc/viperblock/viperblock/v_utils"
 
 	_ "github.com/mulgadc/bluebottle/pkg/fipsboot"
+	"github.com/mulgadc/bluebottle/pkg/safecast"
 )
 
 func main() {
@@ -115,7 +116,7 @@ func main() {
 
 	s3Config := s3.S3Config{
 		VolumeName: volID,
-		VolumeSize: utils.SafeIntToUint64(*size),
+		VolumeSize: safecast.IntToUint64(*size),
 		Bucket:     *bucket,
 		Region:     *region,
 		AccessKey:  *access_key,
@@ -131,7 +132,7 @@ func main() {
 
 	vbConfig := viperblock.VB{
 		VolumeName: volID,
-		VolumeSize: utils.SafeIntToUint64(*size),
+		VolumeSize: safecast.IntToUint64(*size),
 		BaseDir:    *base_dir,
 		Cache: viperblock.Cache{
 			Config: viperblock.CacheConfig{

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.107.2
 	github.com/aws/smithy-go v1.27.8
 	github.com/hashicorp/golang-lru/v2 v2.0.7
-	github.com/mulgadc/bluebottle v1.18.1-0.20260827043632-fca81ec29266
+	github.com/mulgadc/bluebottle v1.18.1-0.20260827045410-e7d5cf022748
 	github.com/mulgadc/predastore v1.18.0
 	github.com/stretchr/testify v1.12.1
 	github.com/tidwall/btree v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -166,8 +166,8 @@ github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJ
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
-github.com/mulgadc/bluebottle v1.18.1-0.20260827043632-fca81ec29266 h1:F8lFWRvjjvXGWTNGdiQOZX7VJ9FCy6uJXFMuYn6KnAg=
-github.com/mulgadc/bluebottle v1.18.1-0.20260827043632-fca81ec29266/go.mod h1:mvvV4d2w+kGLXxO1ymptNlxqUlNJKB2oAhk6PkpVLj8=
+github.com/mulgadc/bluebottle v1.18.1-0.20260827045410-e7d5cf022748 h1:kvoYwPtGXrX7GTN1aRL9KteP0bteaYNzrSMFQ+A7AmU=
+github.com/mulgadc/bluebottle v1.18.1-0.20260827045410-e7d5cf022748/go.mod h1:mvvV4d2w+kGLXxO1ymptNlxqUlNJKB2oAhk6PkpVLj8=
 github.com/mulgadc/predastore v1.18.0 h1:RW1Qw1SM2iYxqi6HaHLv5Qb1h1vhZSO3x6pOhPAb9mw=
 github.com/mulgadc/predastore v1.18.0/go.mod h1:+VBT3ofH/YmdTg0ug9EQwHDb8bQbHaMvWUyh5cIpBeo=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=

--- a/simplefs/simplefs.go
+++ b/simplefs/simplefs.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"sync"
 
-	"github.com/mulgadc/viperblock/utils"
+	"github.com/mulgadc/bluebottle/pkg/safecast"
 	"github.com/mulgadc/viperblock/viperblock"
 )
 
@@ -87,11 +87,11 @@ func (sfs *SimpleFS) AllocateBlocks(size uint64) (blocks []uint64, err error) {
 
 	// First, error if there are not enough free blocks
 	//fmt.Println("Allocating blocks", len(sfs.Volume.Free), size)
-	if len(sfs.Volume.Free) < utils.SafeUint64ToInt(size) {
+	if len(sfs.Volume.Free) < safecast.Uint64ToInt(size) {
 		return nil, fmt.Errorf("not enough free blocks")
 	}
 
-	for i := 0; i < utils.SafeUint64ToInt(size); i++ {
+	for i := 0; i < safecast.Uint64ToInt(size); i++ {
 		blocks[i] = sfs.Volume.Free[i]
 		sfs.Volume.Used[sfs.Volume.Free[i]] = true
 		sfs.Volume.Free[i] = 0

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -2,7 +2,6 @@ package utils
 
 import (
 	"fmt"
-	"math"
 )
 
 // HumanBytes formats a byte count using IEC binary suffixes (KiB, MiB, ...).
@@ -20,77 +19,4 @@ func HumanBytes(b uint64) string {
 		exp++
 	}
 	return fmt.Sprintf("%.1f %ciB", float64(b)/float64(div), "KMGTPEZY"[exp])
-}
-
-// SafeInt64ToUint64 converts int64 to uint64, returning 0 if negative.
-func SafeInt64ToUint64(v int64) uint64 {
-	if v < 0 {
-		return 0
-	}
-	return uint64(v)
-}
-
-// SafeIntToUint64 converts int to uint64, returning 0 if negative.
-func SafeIntToUint64(v int) uint64 {
-	if v < 0 {
-		return 0
-	}
-	return uint64(v)
-}
-
-// SafeUint64ToInt64 converts uint64 to int64, capping at math.MaxInt64.
-func SafeUint64ToInt64(v uint64) int64 {
-	if v > math.MaxInt64 {
-		return math.MaxInt64
-	}
-	return int64(v)
-}
-
-// SafeUint64ToUint32 converts uint64 to uint32, capping at math.MaxUint32.
-func SafeUint64ToUint32(v uint64) uint32 {
-	if v > math.MaxUint32 {
-		return math.MaxUint32
-	}
-	return uint32(v)
-}
-
-// SafeUint64ToInt converts uint64 to int, capping at math.MaxInt.
-func SafeUint64ToInt(v uint64) int {
-	if v > math.MaxInt {
-		return math.MaxInt
-	}
-	return int(v)
-}
-
-// SafeInt64ToUint32 converts int64 to uint32, returning 0 if negative and capping at math.MaxUint32.
-func SafeInt64ToUint32(v int64) uint32 {
-	if v < 0 {
-		return 0
-	}
-	if v > math.MaxUint32 {
-		return math.MaxUint32
-	}
-	return uint32(v)
-}
-
-// SafeIntToUint32 converts int to uint32, returning 0 if negative.
-func SafeIntToUint32(v int) uint32 {
-	if v < 0 {
-		return 0
-	}
-	if v > math.MaxUint32 {
-		return math.MaxUint32
-	}
-	return uint32(v)
-}
-
-// SafeIntToUint16 converts int to uint16, returning 0 if negative and capping at math.MaxUint16.
-func SafeIntToUint16(v int) uint16 {
-	if v < 0 {
-		return 0
-	}
-	if v > math.MaxUint16 {
-		return math.MaxUint16
-	}
-	return uint16(v)
 }

--- a/viperblock/arena.go
+++ b/viperblock/arena.go
@@ -4,7 +4,7 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/mulgadc/viperblock/utils"
+	"github.com/mulgadc/bluebottle/pkg/safecast"
 )
 
 // Arena is a bump-pointer memory allocator for write data.
@@ -91,7 +91,7 @@ func (a *Arena) AllocCopy(data []byte) []byte {
 
 // AllocN allocates n consecutive blocks from the arena.
 func (a *Arena) AllocN(n int) []byte {
-	size := utils.SafeIntToUint32(n) * a.blockSize
+	size := safecast.IntToUint32(n) * a.blockSize
 
 	a.mu.Lock()
 	defer a.mu.Unlock()

--- a/viperblock/backends/file/file.go
+++ b/viperblock/backends/file/file.go
@@ -11,9 +11,9 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/mulgadc/bluebottle/pkg/safecast"
 	"github.com/mulgadc/viperblock/telemetry"
 	"github.com/mulgadc/viperblock/types"
-	"github.com/mulgadc/viperblock/utils"
 )
 
 // 2. Define config structs.
@@ -188,7 +188,7 @@ func (backend *Backend) Read(fileType types.FileType, objectId uint64, offset ui
 		if err != nil {
 			return nil, err
 		}
-		length = utils.SafeInt64ToUint32(stat.Size())
+		length = safecast.Int64ToUint32(stat.Size())
 	}
 
 	// Read the specified block for the length
@@ -278,7 +278,7 @@ func (backend *Backend) ReadFrom(volumeName string, fileType types.FileType, obj
 		if err != nil {
 			return nil, err
 		}
-		length = utils.SafeInt64ToUint32(stat.Size())
+		length = safecast.Int64ToUint32(stat.Size())
 	}
 
 	data = make([]byte, length)

--- a/viperblock/snapshot.go
+++ b/viperblock/snapshot.go
@@ -12,8 +12,8 @@ import (
 	"os"
 	"time"
 
+	"github.com/mulgadc/bluebottle/pkg/safecast"
 	"github.com/mulgadc/viperblock/types"
-	"github.com/mulgadc/viperblock/utils"
 )
 
 // SnapshotState holds metadata for a frozen snapshot stored on the backend.
@@ -379,7 +379,7 @@ func (vb *VB) LoadSnapshotBlockMap(snapshotID string) (*BlocksToObject, Snapshot
 	}
 
 	// 6. Validate block count against metadata
-	if snap.BlockCount > 0 && utils.SafeIntToUint64(baseMap.lookup.len()) != snap.BlockCount {
+	if snap.BlockCount > 0 && safecast.IntToUint64(baseMap.lookup.len()) != snap.BlockCount {
 		return nil, ident, fmt.Errorf("snapshot block count mismatch: metadata says %d, checkpoint has %d", snap.BlockCount, baseMap.lookup.len())
 	}
 

--- a/viperblock/v_utils/v_utils.go
+++ b/viperblock/v_utils/v_utils.go
@@ -8,8 +8,8 @@ import (
 	"os"
 	"time"
 
+	"github.com/mulgadc/bluebottle/pkg/safecast"
 	"github.com/mulgadc/viperblock/types"
-	"github.com/mulgadc/viperblock/utils"
 	"github.com/mulgadc/viperblock/viperblock"
 	"github.com/mulgadc/viperblock/viperblock/backends/s3"
 )
@@ -41,7 +41,7 @@ func (p *progressReporter) report(current uint64) {
 	if p.progress == nil || p.total == 0 {
 		return
 	}
-	pct := utils.SafeUint64ToInt(current * 100 / p.total)
+	pct := safecast.Uint64ToInt(current * 100 / p.total)
 	if pct > p.lastPct {
 		p.lastPct = pct
 		p.progress(current, p.total)
@@ -89,7 +89,7 @@ func ImportDiskImage(s3Config *s3.S3Config, vbConfig *viperblock.VB, filename st
 	}
 
 	if vbConfig.VolumeConfig.VolumeMetadata.SizeGiB == 0 {
-		vbConfig.VolumeConfig.VolumeMetadata.SizeGiB = utils.SafeInt64ToUint64(fileInfo.Size()) / 1024 / 1024 / 1024
+		vbConfig.VolumeConfig.VolumeMetadata.SizeGiB = safecast.Int64ToUint64(fileInfo.Size()) / 1024 / 1024 / 1024
 	}
 
 	if vbConfig.VolumeConfig.VolumeMetadata.State == "" {
@@ -137,7 +137,7 @@ func ImportDiskImage(s3Config *s3.S3Config, vbConfig *viperblock.VB, filename st
 
 		if vbConfig.VolumeConfig.AMIMetadata.VolumeSizeGiB == 0 {
 			// Convert from bytes to GiB
-			vbConfig.VolumeConfig.AMIMetadata.VolumeSizeGiB = utils.SafeInt64ToUint64(fileInfo.Size()) / 1024 / 1024 / 1024
+			vbConfig.VolumeConfig.AMIMetadata.VolumeSizeGiB = safecast.Int64ToUint64(fileInfo.Size()) / 1024 / 1024 / 1024
 		}
 	}
 
@@ -208,7 +208,7 @@ func ImportDiskImage(s3Config *s3.S3Config, vbConfig *viperblock.VB, filename st
 
 	// Progress is measured in bytes so callers render a unit that matches the
 	// download bar; the reporter throttles rendering to percentage steps.
-	reporter := newProgressReporter(progress, utils.SafeInt64ToUint64(totalBytes))
+	reporter := newProgressReporter(progress, safecast.Int64ToUint64(totalBytes))
 	var current uint64
 
 	buf := make([]byte, vb.BlockSize)
@@ -222,7 +222,7 @@ func ImportDiskImage(s3Config *s3.S3Config, vbConfig *viperblock.VB, filename st
 		if bytes.Equal(buf[:n], nullBlock) {
 			//fmt.Printf("Null block found at %d, skipping\n", block)
 			block++
-			current += utils.SafeIntToUint64(n)
+			current += safecast.IntToUint64(n)
 			reporter.report(current)
 			continue
 		}
@@ -243,7 +243,7 @@ func ImportDiskImage(s3Config *s3.S3Config, vbConfig *viperblock.VB, filename st
 		//fmt.Println("Write", "block", hex.EncodeToString(buf[:n]))
 
 		block++
-		current += utils.SafeIntToUint64(n)
+		current += safecast.IntToUint64(n)
 		reporter.report(current)
 
 		// Flush every 4MB

--- a/viperblock/viperblock.go
+++ b/viperblock/viperblock.go
@@ -30,9 +30,9 @@ import (
 	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/mulgadc/bluebottle/pkg/masterkey"
 	"github.com/mulgadc/bluebottle/pkg/otelsetup"
+	"github.com/mulgadc/bluebottle/pkg/safecast"
 	"github.com/mulgadc/viperblock/telemetry"
 	"github.com/mulgadc/viperblock/types"
-	"github.com/mulgadc/viperblock/utils"
 	"github.com/mulgadc/viperblock/viperblock/backends/file"
 	"github.com/mulgadc/viperblock/viperblock/backends/s3"
 )
@@ -658,7 +658,7 @@ func (bl BlockLookup) seqNumAt(i int) uint64 {
 // position i within this entry's run, given the chunk's per-block byte
 // stride (BlockSize, or BlockSize+16 on encrypted volumes).
 func (bl BlockLookup) offsetAt(i int, stride uint32) uint32 {
-	return bl.ObjectOffset + utils.SafeIntToUint32(i)*stride
+	return bl.ObjectOffset + safecast.IntToUint32(i)*stride
 }
 
 // sliceSeqNums returns the SeqNums for block positions [from, to) within
@@ -724,7 +724,7 @@ func (b *BlocksToObject) resolveBlockLookup(block uint64) (BlockLookup, int, boo
 	if !ok {
 		return BlockLookup{}, 0, false
 	}
-	return bl, utils.SafeUint64ToInt(block - bl.StartBlock), true
+	return bl, safecast.Uint64ToInt(block - bl.StartBlock), true
 }
 
 // insertCoalescedLocked inserts newEntry into BlockLookup, fracturing any
@@ -755,10 +755,10 @@ func (b *BlocksToObject) insertCoalescedLocked(newEntry BlockLookup, stride uint
 
 		// Surviving head: [exStart, newStart)
 		if exStart < newStart {
-			headLen := utils.SafeUint64ToInt(newStart - exStart)
+			headLen := safecast.Uint64ToInt(newStart - exStart)
 			head := BlockLookup{
 				StartBlock:   exStart,
-				NumBlocks:    utils.SafeIntToUint16(headLen),
+				NumBlocks:    safecast.IntToUint16(headLen),
 				ObjectID:     existing.ObjectID,
 				ObjectOffset: existing.ObjectOffset,
 				SeqNum:       existing.seqNumAt(0),
@@ -773,11 +773,11 @@ func (b *BlocksToObject) insertCoalescedLocked(newEntry BlockLookup, stride uint
 		// Surviving tail: [newEnd, exEnd)
 		if exEnd > newEnd {
 			tailStart := newEnd
-			tailOffset := utils.SafeUint64ToInt(tailStart - exStart)
-			tailLen := utils.SafeUint64ToInt(exEnd - tailStart)
+			tailOffset := safecast.Uint64ToInt(tailStart - exStart)
+			tailLen := safecast.Uint64ToInt(exEnd - tailStart)
 			tail := BlockLookup{
 				StartBlock:   tailStart,
-				NumBlocks:    utils.SafeIntToUint16(tailLen),
+				NumBlocks:    safecast.IntToUint16(tailLen),
 				ObjectID:     existing.ObjectID,
 				ObjectOffset: existing.offsetAt(tailOffset, stride),
 				SeqNum:       existing.seqNumAt(tailOffset),
@@ -839,7 +839,7 @@ func coalesceBlockLookup(flat map[uint64]BlockLookup, stride uint32) map[uint64]
 
 		merged := BlockLookup{
 			StartBlock:   first.StartBlock,
-			NumBlocks:    utils.SafeIntToUint16(len(seqNums)),
+			NumBlocks:    safecast.IntToUint16(len(seqNums)),
 			ObjectID:     first.ObjectID,
 			ObjectOffset: first.ObjectOffset,
 			SeqNum:       first.SeqNum,
@@ -1069,9 +1069,9 @@ func calculateCacheSize(blockSize uint32, percent int) int {
 	}
 
 	systemMemory := getSystemMemory()
-	cacheMemory := (systemMemory * utils.SafeIntToUint64(percent)) / 100
+	cacheMemory := (systemMemory * safecast.IntToUint64(percent)) / 100
 
-	return utils.SafeUint64ToInt(cacheMemory / uint64(blockSize))
+	return safecast.Uint64ToInt(cacheMemory / uint64(blockSize))
 }
 
 // SetCacheSize sets the size of the LRU cache in number of blocks.
@@ -2761,7 +2761,7 @@ func (vb *VB) ReadWAL() (err error) {
 		var n int
 		n, err = currentWAL.Read(block.Data)
 
-		if n != utils.SafeUint64ToInt(block.Len) {
+		if n != safecast.Uint64ToInt(block.Len) {
 			return fmt.Errorf("incomplete read: got %d bytes, expected %d", n, block.Len)
 		}
 
@@ -3659,9 +3659,9 @@ func (vb *VB) createChunkFile(ctx context.Context, currentWALNum uint64, chunkBu
 
 		newBlock := BlockLookup{
 			StartBlock:   first.Block,
-			NumBlocks:    utils.SafeIntToUint16(numBlocks),
+			NumBlocks:    safecast.IntToUint16(numBlocks),
 			ObjectID:     chunkIndex,
-			ObjectOffset: utils.SafeIntToUint32(headerLen + (runStart * stride)),
+			ObjectOffset: safecast.IntToUint32(headerLen + (runStart * stride)),
 			SeqNum:       first.SeqNum,
 			SeqNums:      seqNums,
 		}
@@ -4948,7 +4948,7 @@ func (vb *VB) extendRunForReadahead(cb ConsecutiveBlock, limit int) (extra int, 
 // cb.NumBlocks blocks long.
 func (vb *VB) readRun(ctx context.Context, cb ConsecutiveBlock, extra int, extraSeqNums []uint64, dst []byte) error {
 	fetchBlocks := int(cb.NumBlocks) + extra
-	length := utils.SafeIntToUint32(fetchBlocks) * vb.blockStride()
+	length := safecast.IntToUint32(fetchBlocks) * vb.blockStride()
 
 	objectID := cb.ObjectID
 	if err := vb.checkChunkMagic(vb.VolumeName, objectID, func(off, l uint32) ([]byte, error) {
@@ -4972,7 +4972,7 @@ func (vb *VB) readRun(ctx context.Context, cb ConsecutiveBlock, extra int, extra
 
 	if vb.EncryptionEnabled {
 		wide := cb
-		wide.NumBlocks = utils.SafeIntToUint16(fetchBlocks)
+		wide.NumBlocks = safecast.IntToUint16(fetchBlocks)
 		if extra > 0 {
 			wide.SeqNums = append(slices.Clone(cb.SeqNums), extraSeqNums...)
 		}
@@ -5002,7 +5002,7 @@ func (vb *VB) readRun(ctx context.Context, cb ConsecutiveBlock, extra int, extra
 	// plaintext.
 	for k := range extra {
 		block := int(cb.NumBlocks) + k
-		vb.Cache.put(cb.StartBlock+utils.SafeIntToUint64(block), extraSeqNums[k], plain[block*blockSize:(block+1)*blockSize])
+		vb.Cache.put(cb.StartBlock+safecast.IntToUint64(block), extraSeqNums[k], plain[block*blockSize:(block+1)*blockSize])
 	}
 	return nil
 }
@@ -5954,7 +5954,7 @@ func (vb *VB) read(ctx context.Context, block uint64, blockLen uint64) (data []b
 		consecutiveBlocksToRead = append(consecutiveBlocksToRead, ConsecutiveBlock{
 			BlockPosition: consecutiveBlocks[i].BlockPosition,
 			StartBlock:    consecutiveBlocks[i].StartBlock,
-			NumBlocks:     utils.SafeIntToUint16(numBlocks),
+			NumBlocks:     safecast.IntToUint16(numBlocks),
 			OffsetStart:   consecutiveBlocks[i].OffsetStart,
 			OffsetEnd:     consecutiveBlocks[i].OffsetEnd,
 			ObjectID:      consecutiveBlocks[i].ObjectID,
@@ -6265,7 +6265,7 @@ func (vb *VB) WALHeader() []byte {
 	copy(header[:len(vb.WAL.WALMagic)], vb.WAL.WALMagic[:])
 	binary.BigEndian.PutUint16(header[4:6], vb.Version)
 	binary.BigEndian.PutUint32(header[6:10], vb.BlockSize)
-	binary.BigEndian.PutUint64(header[10:18], utils.SafeInt64ToUint64(time.Now().Unix()))
+	binary.BigEndian.PutUint64(header[10:18], safecast.Int64ToUint64(time.Now().Unix()))
 	return header
 }
 
@@ -6281,7 +6281,7 @@ func (vb *VB) BlockToObjectWALHeader() []byte {
 	vb.logger().Debug("Writing BlockToObjectWALHeader", "header", header, "size", vb.BlockToObjectWALHeaderSize())
 	copy(header[:len(vb.BlockToObjectWAL.WALMagic)], vb.BlockToObjectWAL.WALMagic[:])
 	binary.BigEndian.PutUint16(header[4:6], vb.Version)
-	binary.BigEndian.PutUint64(header[6:14], utils.SafeInt64ToUint64(time.Now().Unix()))
+	binary.BigEndian.PutUint64(header[6:14], safecast.Int64ToUint64(time.Now().Unix()))
 	return header
 }
 
@@ -6536,7 +6536,7 @@ func (vb *VB) fetchConsecutiveBlocksFromBackend(ctx context.Context, consecutive
 		consecutiveBlocksToRead = append(consecutiveBlocksToRead, ConsecutiveBlock{
 			BlockPosition: consecutiveBlocks[i].BlockPosition,
 			StartBlock:    consecutiveBlocks[i].StartBlock,
-			NumBlocks:     utils.SafeIntToUint16(numBlocks),
+			NumBlocks:     safecast.IntToUint16(numBlocks),
 			OffsetStart:   consecutiveBlocks[i].OffsetStart,
 			OffsetEnd:     consecutiveBlocks[i].OffsetEnd,
 			ObjectID:      consecutiveBlocks[i].ObjectID,
@@ -6602,7 +6602,7 @@ func (vb *VB) fetchBaseBlocksFromBackend(ctx context.Context, sourceVolume strin
 		consecutiveBlocksToRead = append(consecutiveBlocksToRead, ConsecutiveBlock{
 			BlockPosition: consecutiveBlocks[i].BlockPosition,
 			StartBlock:    consecutiveBlocks[i].StartBlock,
-			NumBlocks:     utils.SafeIntToUint16(numBlocks),
+			NumBlocks:     safecast.IntToUint16(numBlocks),
 			OffsetStart:   consecutiveBlocks[i].OffsetStart,
 			OffsetEnd:     consecutiveBlocks[i].OffsetEnd,
 			ObjectID:      consecutiveBlocks[i].ObjectID,


### PR DESCRIPTION
Consumer half of workstream 3 of the bluebottle shared utility consolidation. Depends on mulgadc/bluebottle#12.

`utils/utils.go` held eight clamping wrappers; spinifex held five, with four in common and neither set a superset of the other. They now live in bluebottle as one set of nine.

## Changes

- Every call site moves from `utils.SafeX` to `safecast.X`. The `Safe` prefix is dropped because it stammers under a package named `safecast`.
- The `Safe*` functions are removed from `utils/utils.go`. The package stays for `HumanBytes`.

Rename only — bodies and clamping semantics are unchanged. Old and new names share no prefix, so there is no partial-match hazard in the rewrite.

## Testing

`make preflight` passes.

## Before merge

`go.mod` needs a bump to a bluebottle pseudo-version containing `pkg/safecast`. Local builds resolve bluebottle from the sibling checkout via `go.work` and so look green without it; CI will not.