### PR TITLE
fix: correct the stale-drain SeqNum comparison and bound backpressure by a deadline

### DIFF
--- a/viperblock/backpressure_cancel_test.go
+++ b/viperblock/backpressure_cancel_test.go
@@ -1,0 +1,94 @@
+package viperblock
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCancelledWriteDoesNotRecordADrainStall pins that a caller giving up on
+// its own write is not recorded as the backend failing. awaitBackpressure
+// drives the drain on the caller's context, so a cancellation surfaces as a
+// drain error -- but the backend never said anything was wrong, and the stall
+// deadline it would be recorded against is shared by every writer on the
+// volume.
+func TestCancelledWriteDoesNotRecordADrainStall(t *testing.T) {
+	vb, backend := newEnospcTestVB(t)
+	blockSize := uint64(vb.BlockSize)
+
+	// Force the backpressure gate to engage on the next write.
+	vb.MaxPendingBytes = blockSize
+	require.NoError(t, vb.WriteAt(0, make([]byte, blockSize)))
+
+	// The backend now neither succeeds nor fails: it waits for the caller's
+	// context, which is what a slow-but-healthy backend looks like from here.
+	backend.blockUntilCancelled.Store(true)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+
+	done := make(chan error, 1)
+	go func() { done <- vb.WriteAtCtx(ctx, blockSize, make([]byte, blockSize)) }()
+
+	var err error
+	select {
+	case err = <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("WriteAtCtx did not return after its context was cancelled")
+	}
+
+	require.ErrorIs(t, err, context.Canceled,
+		"a cancelled write must surface the cancellation, not a backend drain failure")
+
+	stalled, lastErr := vb.drainStall.elapsed()
+	assert.Zero(t, stalled, "a cancelled caller must not start the volume's shared stall deadline")
+	assert.NoError(t, lastErr, "a cancelled caller must not be recorded as the backend's last failure")
+}
+
+// TestCancelledWriteDoesNotStallLaterWriters pins the consequence of the above:
+// because drainStall is volume-scoped, one abandoned request recording itself
+// there would abort every later writer against a backend that is working.
+func TestCancelledWriteDoesNotStallLaterWriters(t *testing.T) {
+	vb, backend := newEnospcTestVB(t)
+	blockSize := uint64(vb.BlockSize)
+
+	vb.MaxPendingBytes = blockSize
+	// Short enough that any deadline the cancelled write below started has
+	// certainly expired by the time the surviving write checks it.
+	vb.BackpressureStallTimeout = time.Millisecond
+	require.NoError(t, vb.WriteAt(0, make([]byte, blockSize)))
+
+	backend.blockUntilCancelled.Store(true)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+
+	abandoned := make(chan error, 1)
+	go func() { abandoned <- vb.WriteAtCtx(ctx, blockSize, make([]byte, blockSize)) }()
+
+	select {
+	case err := <-abandoned:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(30 * time.Second):
+		t.Fatal("WriteAtCtx did not return after its context was cancelled")
+	}
+
+	// The backend was never unhealthy, so the next writer must be able to drain.
+	backend.blockUntilCancelled.Store(false)
+	time.Sleep(10 * time.Millisecond)
+
+	err := runBlockingWriteWithHangTimeout(t, vb, 2*blockSize, make([]byte, blockSize), 30*time.Second)
+	assert.NoError(t, err,
+		"a write against a healthy backend must not inherit a stall deadline started by a cancelled caller")
+
+	require.NoError(t, vb.DrainToBackendCtx(context.Background()))
+}

--- a/viperblock/backpressure_stall_test.go
+++ b/viperblock/backpressure_stall_test.go
@@ -1,0 +1,124 @@
+package viperblock
+
+import (
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mulgadc/viperblock/types"
+)
+
+// The first failure of a run starts the clock rather than reporting elapsed
+// time, so one failure can never trip a deadline on its own.
+func TestDrainStallFirstFailureReportsZero(t *testing.T) {
+	var s drainStall
+	assert.Zero(t, s.fail(errors.New("boom")), "the first failure starts the run, it does not measure it")
+
+	time.Sleep(20 * time.Millisecond)
+	elapsed, lastErr := s.elapsed()
+	assert.Positive(t, elapsed, "a run in progress must report how long it has lasted")
+	assert.EqualError(t, lastErr, "boom", "the run must carry its last cause for the error the writer returns")
+}
+
+// A drain that succeeds means the backend is answering, so the run ends and a
+// later failure starts a fresh deadline rather than inheriting the old one.
+func TestDrainStallSuccessEndsTheRun(t *testing.T) {
+	var s drainStall
+	s.fail(errors.New("first"))
+	time.Sleep(30 * time.Millisecond)
+	require.Positive(t, mustElapsed(t, &s))
+
+	s.clear()
+	elapsed, lastErr := s.elapsed()
+	assert.Zero(t, elapsed, "a successful drain must end the run")
+	assert.NoError(t, lastErr)
+
+	assert.Zero(t, s.fail(errors.New("second")), "a failure after a success starts a new run, not a continuation")
+}
+
+// The bound is on the volume, so it holds however many writers are blocked.
+// A per-writer counter divides the real tolerance by the number of writers,
+// which is what made the old bound unreachable under concurrent load.
+func TestDrainStallDeadlineIsSharedAcrossWriters(t *testing.T) {
+	var s drainStall
+	const writers = 16
+
+	s.fail(errors.New("backend gone"))
+	time.Sleep(30 * time.Millisecond)
+
+	var wg sync.WaitGroup
+	seen := make([]time.Duration, writers)
+	for i := range writers {
+		wg.Go(func() {
+			// Every writer charges its own failure, exactly as concurrent
+			// callers of awaitBackpressure do.
+			s.fail(errors.New("backend gone"))
+			seen[i], _ = s.elapsed()
+		})
+	}
+	wg.Wait()
+
+	for i, d := range seen {
+		assert.Positive(t, d, "writer %d must observe the run that started before it, not a fresh one", i)
+	}
+}
+
+func mustElapsed(t *testing.T, s *drainStall) time.Duration {
+	t.Helper()
+	d, _ := s.elapsed()
+	return d
+}
+
+// The old bound was a local in awaitBackpressure, so with N writers blocked the
+// effective tolerance was N times the intended one and, because only one writer
+// at a time wins the drain CAS, in practice it was never reached at all. This
+// is the case a single-writer test cannot see.
+func TestAwaitBackpressureDeadlineHoldsWithConcurrentWriters(t *testing.T) {
+	vb, backend := newEnospcTestVB(t)
+	blockSize := uint64(vb.BlockSize)
+
+	vb.MaxPendingBytes = blockSize
+	vb.BackpressureStallTimeout = 500 * time.Millisecond
+	require.NoError(t, vb.WriteAt(0, make([]byte, blockSize)))
+
+	// Every checkpoint write fails from here on, and pendingBytes is pinned
+	// back above the low-watermark so no writer can escape by the gate
+	// releasing rather than by the deadline.
+	backend.genericFail.Store(true)
+	backend.afterWrite = func(fileType types.FileType, _ error) {
+		if fileType == types.FileTypeBlockCheckpointLive {
+			vb.pendingBytes.Store(int64(vb.maxPendingBytes()) * 4)
+		}
+	}
+
+	const writers = 8
+	errs := make([]error, writers)
+	var wg sync.WaitGroup
+	start := time.Now()
+	for i := range writers {
+		wg.Go(func() {
+			errs[i] = vb.WriteAt(uint64(i+1)*blockSize, make([]byte, blockSize))
+		})
+	}
+
+	done := make(chan struct{})
+	go func() { wg.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("writers did not return: the bound is still per-writer, so concurrency defeats it")
+	}
+	elapsed := time.Since(start)
+
+	for i, err := range errs {
+		require.Error(t, err, "writer %d must be bounded by the volume's deadline", i)
+		assert.Contains(t, err.Error(), "has not drained for",
+			"writer %d must fail on the stall deadline, not some other error", i)
+	}
+	assert.Less(t, elapsed, 15*time.Second,
+		"the deadline is on the volume, so %d writers must not take %d times as long to reach it", writers, writers)
+}

--- a/viperblock/chunk_drain_bench_test.go
+++ b/viperblock/chunk_drain_bench_test.go
@@ -1,0 +1,172 @@
+package viperblock
+
+import (
+	"crypto/rand"
+	"fmt"
+	"testing"
+
+	"github.com/mulgadc/viperblock/types"
+	"github.com/mulgadc/viperblock/viperblock/backends/file"
+	"github.com/stretchr/testify/require"
+)
+
+// chunkBlocks is one 4 MiB chunk at the 4 KiB block size: the unit
+// createChunkFile classifies in one pass.
+const chunkBlocks = 1024
+
+// setupDrainBenchVB is setupBenchVB with a volume large enough that successive
+// iterations can each drain a region no earlier one touched.
+func setupDrainBenchVB(b *testing.B, size uint64) *VB {
+	b.Helper()
+
+	tmpDir := b.TempDir()
+	testVol := fmt.Sprintf("bench_drain_%d", b.N)
+
+	vbconfig := VB{
+		VolumeName:      testVol,
+		VolumeSize:      size,
+		BaseDir:         fmt.Sprintf("%s/viperblock", tmpDir),
+		WALSyncInterval: -1,
+		Cache:           Cache{Config: CacheConfig{Size: 0}},
+	}
+
+	vb, err := New(&vbconfig, "file", file.FileConfig{
+		VolumeName: testVol,
+		VolumeSize: size,
+		BaseDir:    tmpDir,
+	})
+	require.NoError(b, err)
+	require.NoError(b, vb.Backend.Init())
+
+	require.NoError(b, vb.OpenWAL(&vb.WAL,
+		fmt.Sprintf("%s/%s", vb.WAL.BaseDir, types.GetFilePath(types.FileTypeWALChunk, 0, vb.GetVolume()))))
+	require.NoError(b, vb.OpenWAL(&vb.BlockToObjectWAL,
+		fmt.Sprintf("%s/%s", vb.BlockToObjectWAL.BaseDir, types.GetFilePath(types.FileTypeWALBlock, vb.BlockToObjectWAL.WallNum.Load(), vb.GetVolume()))))
+
+	b.Cleanup(func() { _ = vb.RemoveLocalFiles() })
+
+	return vb
+}
+
+// mappedVB returns a VB whose block map covers blocks [0, blocks) in extents of
+// extentLen blocks: what a volume of that size looks like once written at that
+// average extent length.
+func mappedVB(blocks, extentLen uint64) *VB {
+	vb := &VB{}
+	for start := uint64(0); start < blocks; start += extentLen {
+		vb.BlocksToObject.lookup.set(BlockLookup{
+			StartBlock: start,
+			NumBlocks:  uint16(extentLen),
+			SeqNum:     start,
+		})
+	}
+	return vb
+}
+
+// BenchmarkRunClassify isolates the block-map work createChunkFile does for one
+// 4 MiB chunk landing entirely on already-mapped blocks, across volume size and
+// fragmentation. Everything else in a drain -- encrypt, backend write, WAL --
+// is excluded, because that I/O is what hides this cost end to end.
+func BenchmarkRunClassify(b *testing.B) {
+	sizes := []struct {
+		name   string
+		blocks uint64
+	}{
+		{"8GiB", 8 << 30 / 4096},
+		{"250GiB", 250 << 30 / 4096},
+	}
+	// 32 KiB and 512 KiB average extents: how fragmented the map is decides how
+	// many entries the ordered walk covers, where the per-block path pays one
+	// tree descent regardless.
+	extentLens := []uint64{8, 128}
+
+	for _, size := range sizes {
+		for _, extentLen := range extentLens {
+			vb := mappedVB(size.blocks, extentLen)
+			name := fmt.Sprintf("%s/extent%dblk", size.name, extentLen)
+
+			// A chunk-sized run mid-volume, every candidate newer than what is
+			// mapped, so neither implementation can exit early.
+			base := size.blocks / 2
+			run := make([]Block, chunkBlocks)
+			for i := range run {
+				run[i] = Block{Block: base + uint64(i), SeqNum: 1 << 40}
+			}
+
+			b.Run(name+"/perBlockLookup", func(b *testing.B) {
+				for range b.N {
+					for _, candidate := range run {
+						if !vb.supersedesLocked(candidate) {
+							b.Fatal("candidate must supersede")
+						}
+					}
+				}
+			})
+
+			b.Run(name+"/orderedMerge", func(b *testing.B) {
+				var (
+					overlaps []BlockLookup
+					verdict  []bool
+				)
+				for range b.N {
+					overlaps = vb.BlocksToObject.lookup.collectOverlaps(overlaps[:0], run[0].Block, run[len(run)-1].Block+1)
+					verdict = classifyRun(overlaps, run, verdict[:0])
+					if len(verdict) != len(run) {
+						b.Fatal("short verdict")
+					}
+				}
+			})
+		}
+	}
+}
+
+// BenchmarkChunkDrain_FreshSequential drains one chunk per iteration into a
+// region no earlier iteration touched, against a block map that keeps growing.
+// This is what a guest filling a new volume does, and the case the whole-run
+// no-overlap check exists for: every candidate is new, so a per-block
+// classifier pays 1,024 tree descents to reach the verdict one range query
+// gives.
+func BenchmarkChunkDrain_FreshSequential(b *testing.B) {
+	vb := setupDrainBenchVB(b, uint64(b.N+1)*chunkBlocks*4096)
+
+	data := make([]byte, 4096)
+	_, err := rand.Read(data)
+	require.NoError(b, err)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		base := uint64(i) * chunkBlocks
+		for j := range chunkBlocks {
+			require.NoError(b, vb.WriteAt((base+uint64(j))*4096, data))
+		}
+		require.NoError(b, vb.Flush())
+		b.StartTimer()
+
+		require.NoError(b, vb.WriteWALToChunk(true))
+	}
+}
+
+// BenchmarkChunkDrain_FullOverwrite drains the same region every iteration, so
+// the map always covers it and the per-block classifier always runs. It is the
+// control for FreshSequential: the no-overlap check must not cost anything
+// measurable on the path it cannot take.
+func BenchmarkChunkDrain_FullOverwrite(b *testing.B) {
+	vb := setupDrainBenchVB(b, chunkBlocks*4096*2)
+
+	data := make([]byte, 4096)
+	_, err := rand.Read(data)
+	require.NoError(b, err)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		for j := range chunkBlocks {
+			require.NoError(b, vb.WriteAt(uint64(j)*4096, data))
+		}
+		require.NoError(b, vb.Flush())
+		b.StartTimer()
+
+		require.NoError(b, vb.WriteWALToChunk(true))
+	}
+}

--- a/viperblock/chunk_fastpath_test.go
+++ b/viperblock/chunk_fastpath_test.go
@@ -1,0 +1,104 @@
+package viperblock
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// drainChunk buffers blocks [base, base+count) filled with fill, then drains
+// them to a chunk, returning how many runs each classification path took.
+func drainChunk(t *testing.T, vb *VB, base uint64, count int, fill byte) (fast, classified uint64) {
+	t.Helper()
+
+	blockSize := uint64(vb.BlockSize)
+	data := bytes.Repeat([]byte{fill}, int(blockSize))
+	for i := range count {
+		require.NoError(t, vb.WriteAt((base+uint64(i))*blockSize, data))
+	}
+	require.NoError(t, vb.Flush())
+
+	beforeFast := vb.chunkRunsFastPath.Load()
+	beforeClassified := vb.chunkRunsClassified.Load()
+	require.NoError(t, vb.WriteWALToChunk(true))
+
+	return vb.chunkRunsFastPath.Load() - beforeFast,
+		vb.chunkRunsClassified.Load() - beforeClassified
+}
+
+// assertBlocks reads count blocks back from base and fails unless every byte is
+// fill, so a run installed by either path is checked against the same standard.
+func assertBlocks(t *testing.T, vb *VB, base uint64, count int, fill byte) {
+	t.Helper()
+
+	blockSize := uint64(vb.BlockSize)
+	want := bytes.Repeat([]byte{fill}, int(blockSize))
+	for i := range count {
+		got, err := vb.ReadAt((base+uint64(i))*blockSize, uint64(blockSize))
+		require.NoError(t, err, "block %d", base+uint64(i))
+		assert.Equal(t, want, got, "block %d", base+uint64(i))
+	}
+}
+
+// TestChunkDrainTakesTheFastPathOnlyWhenNothingOverlaps pins which branch each
+// shape of drain takes. A run the block map does not cover is all-new by
+// construction, so one range query settles it; a run it does cover must fall
+// back to the per-block classifier, because a coalesced extent's SeqNum belongs
+// to its first block and a replayed run straddles opposite verdicts.
+func TestChunkDrainTakesTheFastPathOnlyWhenNothingOverlaps(t *testing.T) {
+	vb, _ := newEnospcTestVB(t)
+
+	// Fresh volume: nothing is mapped, so the whole run is accepted at once.
+	fast, classified := drainChunk(t, vb, 0, 64, 0xA1)
+	assert.Equal(t, uint64(1), fast, "a run against an empty block map must take the fast path")
+	assert.Zero(t, classified, "no run should have been classified block by block")
+	assertBlocks(t, vb, 0, 64, 0xA1)
+
+	// A disjoint region is still all-new, even though the map is not empty.
+	fast, classified = drainChunk(t, vb, 512, 64, 0xB2)
+	assert.Equal(t, uint64(1), fast, "a run into a region the map does not cover must take the fast path")
+	assert.Zero(t, classified)
+	assertBlocks(t, vb, 512, 64, 0xB2)
+
+	// Rewriting mapped blocks must not: the verdict is per block there.
+	fast, classified = drainChunk(t, vb, 0, 64, 0xC3)
+	assert.Zero(t, fast, "a run overlapping the map must not be accepted whole")
+	assert.Equal(t, uint64(1), classified)
+	assertBlocks(t, vb, 0, 64, 0xC3)
+	assertBlocks(t, vb, 512, 64, 0xB2)
+
+	// Partial overlap is the case the range query must not wave through: only
+	// the tail of this run is new.
+	fast, classified = drainChunk(t, vb, 32, 64, 0xD4)
+	assert.Zero(t, fast, "a run overlapping the map at one end only must not be accepted whole")
+	assert.Equal(t, uint64(1), classified)
+	assertBlocks(t, vb, 0, 32, 0xC3)
+	assertBlocks(t, vb, 32, 64, 0xD4)
+
+	// The map must survive a reopen: the fast path writes the same extents.
+	require.NoError(t, vb.SaveState())
+	require.NoError(t, vb.Close())
+}
+
+// TestChunkDrainFastPathSurvivesAColdReopen pins that extents the fast path
+// installed are checkpointed and reloaded like any other, so the shortcut
+// cannot leave the map correct only in memory.
+func TestChunkDrainFastPathSurvivesAColdReopen(t *testing.T) {
+	vb, _ := newEnospcTestVB(t)
+
+	fast, _ := drainChunk(t, vb, 0, 128, 0x7E)
+	require.Equal(t, uint64(1), fast)
+
+	require.NoError(t, vb.DrainToBackendCtx(context.Background()))
+	require.NoError(t, vb.SaveState())
+
+	vb.BlocksToObject.mu.Lock()
+	vb.BlocksToObject.lookup.clear()
+	vb.BlocksToObject.mu.Unlock()
+
+	require.NoError(t, vb.LoadBlockStateCtx(context.Background()))
+	assertBlocks(t, vb, 0, 128, 0x7E)
+}

--- a/viperblock/classify_run_test.go
+++ b/viperblock/classify_run_test.go
@@ -1,0 +1,138 @@
+package viperblock
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// consecutiveRun builds the candidate shape createChunkFile classifies: blocks
+// [start, start+len(seqNums)) carrying the given sequence numbers.
+func consecutiveRun(start uint64, seqNums ...uint64) []Block {
+	run := make([]Block, len(seqNums))
+	for i, seq := range seqNums {
+		run[i] = Block{Block: start + uint64(i), SeqNum: seq}
+	}
+	return run
+}
+
+// TestClassifyRun pins the verdict for each shape a run can present against the
+// extents covering it. The comparison is strictly greater and strictly per
+// block: a coalesced extent's own SeqNum belongs to its first block only.
+func TestClassifyRun(t *testing.T) {
+	// [10, 14) at seqs 100..103, then a gap, then [20, 22) at seqs 50, 51.
+	mapped := []BlockLookup{
+		{StartBlock: 10, NumBlocks: 4, SeqNums: []uint64{100, 101, 102, 103}},
+		{StartBlock: 20, NumBlocks: 2, SeqNums: []uint64{50, 51}},
+	}
+
+	cases := []struct {
+		name     string
+		overlaps []BlockLookup
+		run      []Block
+		want     []bool
+	}{
+		{
+			name:     "nothing mapped",
+			overlaps: nil,
+			run:      consecutiveRun(0, 1, 2, 3),
+			want:     []bool{true, true, true},
+		},
+		{
+			name:     "every candidate newer",
+			overlaps: mapped[:1],
+			run:      consecutiveRun(10, 200, 201, 202, 203),
+			want:     []bool{true, true, true, true},
+		},
+		{
+			name:     "every candidate older",
+			overlaps: mapped[:1],
+			run:      consecutiveRun(10, 1, 2, 3, 4),
+			want:     []bool{false, false, false, false},
+		},
+		{
+			name:     "equal is not newer",
+			overlaps: mapped[:1],
+			run:      consecutiveRun(10, 100, 101, 102, 103),
+			want:     []bool{false, false, false, false},
+		},
+		{
+			// The reason the verdict cannot be taken once for a whole run: the
+			// extent's own SeqNum is 100, but its blocks carry 100..103.
+			name:     "mixed within one coalesced extent",
+			overlaps: mapped[:1],
+			run:      consecutiveRun(10, 101, 101, 104, 1),
+			want:     []bool{true, false, true, false},
+		},
+		{
+			name:     "starts before the first extent",
+			overlaps: mapped[:1],
+			run:      consecutiveRun(8, 1, 1, 1, 1),
+			want:     []bool{true, true, false, false},
+		},
+		{
+			name:     "runs off the end of the last extent",
+			overlaps: mapped[:1],
+			run:      consecutiveRun(12, 1, 1, 1, 1),
+			want:     []bool{false, false, true, true},
+		},
+		{
+			name:     "crosses the gap between two extents",
+			overlaps: mapped,
+			run:      consecutiveRun(13, 1, 1, 1, 1, 1, 1, 1, 1, 1),
+			want:     []bool{false, true, true, true, true, true, true, false, false},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, classifyRun(tc.overlaps, tc.run, nil))
+		})
+	}
+}
+
+// TestClassifyRunMatchesPerBlockLookup is the differential guard on the ordered
+// merge: against a randomly fragmented index it must give the identical verdict
+// to supersedesLocked, which reaches it with one tree descent per block.
+func TestClassifyRunMatchesPerBlockLookup(t *testing.T) {
+	rng := rand.New(rand.NewSource(20260904))
+	vb := &VB{}
+
+	// A fragmented map: extents of random length with random gaps between
+	// them, and per-block sequence numbers that rise and fall within each.
+	for block := uint64(0); block < 4096; {
+		block += uint64(rng.Intn(4)) // gap, sometimes zero
+		n := 1 + rng.Intn(12)
+		seqNums := make([]uint64, n)
+		for i := range seqNums {
+			seqNums[i] = uint64(rng.Intn(2000))
+		}
+		vb.BlocksToObject.lookup.set(BlockLookup{
+			StartBlock: block,
+			NumBlocks:  uint16(n),
+			SeqNums:    seqNums,
+		})
+		block += uint64(n)
+	}
+	require.NotZero(t, vb.BlocksToObject.lookup.len())
+
+	for range 500 {
+		start := uint64(rng.Intn(4096))
+		run := make([]Block, 1+rng.Intn(64))
+		for i := range run {
+			run[i] = Block{Block: start + uint64(i), SeqNum: uint64(rng.Intn(2000))}
+		}
+
+		overlaps := vb.BlocksToObject.lookup.collectOverlaps(nil, run[0].Block, run[len(run)-1].Block+1)
+		got := classifyRun(overlaps, run, nil)
+
+		want := make([]bool, len(run))
+		for i, candidate := range run {
+			want[i] = vb.supersedesLocked(candidate)
+		}
+
+		require.Equal(t, want, got, "run starting at block %d", start)
+	}
+}

--- a/viperblock/coalesced_seqnum_test.go
+++ b/viperblock/coalesced_seqnum_test.go
@@ -1,0 +1,129 @@
+package viperblock
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// These tests pin the staleness decision createChunkFile makes when the block
+// it is about to repoint is already covered by a COALESCED extent.
+//
+// An extent's own SeqNum belongs to its first block; every other block in the
+// run carries its own value in SeqNums. Comparing a new chunk's SeqNum against
+// the extent's therefore compares against the wrong block, and gets it wrong in
+// both directions: newer data dropped where the extent happens to start newer,
+// superseded data installed where it happens to start older.
+//
+// Each case is read back after a cold reopen, because that is where it bites.
+// The verdict is what goes into the checkpoint, so a fresh process — a restart
+// after a failed seal, which is the only path that replays a WAL over an
+// existing map — serves the wrong bytes with nothing to indicate it.
+
+// chunkOf builds the chunk body and matched-block list for a run of
+// consecutive blocks starting at start, each filled with fill and carrying the
+// SeqNum at the same index.
+func chunkOf(vb *VB, start uint64, fill byte, seqNums []uint64) ([]byte, []Block) {
+	bs := int(vb.BlockSize)
+	buf := bytes.Repeat([]byte{fill}, bs*len(seqNums))
+	blocks := make([]Block, len(seqNums))
+	for i, seq := range seqNums {
+		blocks[i] = Block{Block: start + uint64(i), SeqNum: seq, Len: uint64(bs)}
+	}
+	return buf, blocks
+}
+
+// checkpointAndReopen publishes the map and boots a fresh VB over the same
+// backend, so what follows reads only what was made durable.
+func checkpointAndReopen(t *testing.T, vb *VB, root, volumeName string) *VB {
+	t.Helper()
+	require.NoError(t, vb.SaveState())
+	require.NoError(t, vb.SaveLiveCheckpoint())
+	return reopenGCTestVB(t, root, volumeName, true)
+}
+
+// requireBlockFill fails unless the whole block reads back as fill.
+func requireBlockFill(t *testing.T, vb *VB, block uint64, fill byte, msg string) {
+	t.Helper()
+	bs := uint64(vb.BlockSize)
+	got, err := vb.ReadAt(block*bs, bs)
+	require.NoError(t, err)
+	require.Equalf(t, bytes.Repeat([]byte{fill}, int(bs)), got,
+		"%s (block %d first byte got=%#x want=%#x)", msg, block, got[0], fill)
+}
+
+// TestCoalescedExtent_NewerWriteToAMiddleBlockIsNotDropped is the data-loss
+// direction. Block 2 is superseded by a strictly newer chunk, but the extent
+// covering it starts at block 0 whose SeqNum is higher, so the run reads as
+// stale and the newer bytes never land.
+func TestCoalescedExtent_NewerWriteToAMiddleBlockIsNotDropped(t *testing.T) {
+	root := t.TempDir()
+	const vol = "vol-coalesced-newer-middle"
+	vb := newGCTestVB(t, root, vol, true)
+	ctx := context.Background()
+
+	// One chunk covering blocks 0-3 as a single coalesced extent. Block 0 was
+	// rewritten last, so the extent's SeqNum (100) is far above block 2's (11).
+	buf, blocks := chunkOf(vb, 0, 0x11, []uint64{100, 10, 11, 12})
+	require.NoError(t, vb.createChunkFile(ctx, 0, &buf, &blocks))
+
+	// A later write to block 2 alone: SeqNum 50 supersedes block 2's 11.
+	newer, newerBlocks := chunkOf(vb, 2, 0x22, []uint64{50})
+	require.NoError(t, vb.createChunkFile(ctx, 0, &newer, &newerBlocks))
+
+	reopened := checkpointAndReopen(t, vb, root, vol)
+	requireBlockFill(t, reopened, 2, 0x22,
+		"block 2's newer chunk was rejected against block 0's SeqNum, so an acknowledged write was dropped")
+}
+
+// TestCoalescedExtent_OlderWriteToAMiddleBlockIsRejected is the same mistake in
+// the other direction: an older chunk accepted because the extent it overwrites
+// starts at a lower SeqNum than the block it actually replaces.
+func TestCoalescedExtent_OlderWriteToAMiddleBlockIsRejected(t *testing.T) {
+	root := t.TempDir()
+	const vol = "vol-coalesced-older-middle"
+	vb := newGCTestVB(t, root, vol, true)
+	ctx := context.Background()
+
+	// Block 0 is the oldest in the run; block 2 is the newest.
+	buf, blocks := chunkOf(vb, 0, 0x33, []uint64{10, 40, 90, 41})
+	require.NoError(t, vb.createChunkFile(ctx, 0, &buf, &blocks))
+
+	// A stale drain for block 2 at SeqNum 50: older than block 2's 90, newer
+	// than the extent's 10.
+	stale, staleBlocks := chunkOf(vb, 2, 0x44, []uint64{50})
+	require.NoError(t, vb.createChunkFile(ctx, 0, &stale, &staleBlocks))
+
+	reopened := checkpointAndReopen(t, vb, root, vol)
+	requireBlockFill(t, reopened, 2, 0x33,
+		"a stale chunk was accepted against block 0's SeqNum, so block 2 reverted to superseded bytes")
+}
+
+// TestCoalescedExtent_MixedRunKeepsOnlyItsNewerBlocks covers the granularity
+// half. A replayed run spans blocks that are newer and blocks that are stale,
+// and one verdict for the whole run either drops the newer blocks or installs
+// the stale ones. A WAL replayed over an existing map produces exactly this.
+func TestCoalescedExtent_MixedRunKeepsOnlyItsNewerBlocks(t *testing.T) {
+	root := t.TempDir()
+	const vol = "vol-coalesced-mixed-run"
+	vb := newGCTestVB(t, root, vol, true)
+	ctx := context.Background()
+
+	// Blocks 0-3, with block 0 much newer than the rest.
+	buf, blocks := chunkOf(vb, 0, 0x55, []uint64{900, 10, 11, 12})
+	require.NoError(t, vb.createChunkFile(ctx, 0, &buf, &blocks))
+
+	// A replay covering the same four blocks. Only blocks 1-3 are newer;
+	// block 0's 800 is stale against the 900 already mapped.
+	replay, replayBlocks := chunkOf(vb, 0, 0x66, []uint64{800, 810, 811, 812})
+	require.NoError(t, vb.createChunkFile(ctx, 0, &replay, &replayBlocks))
+
+	reopened := checkpointAndReopen(t, vb, root, vol)
+	requireBlockFill(t, reopened, 0, 0x55, "block 0 took the replay's older bytes")
+	for block := uint64(1); block <= 3; block++ {
+		requireBlockFill(t, reopened, block, 0x66,
+			"the run was rejected wholesale on block 0's verdict, so a superseded block survived")
+	}
+}

--- a/viperblock/enospc_test.go
+++ b/viperblock/enospc_test.go
@@ -586,14 +586,15 @@ func TestWriteAtRecoveryProbeDoesNotHangAgainstUnresponsiveBackend(t *testing.T)
 
 // TestAwaitBackpressureBoundsConsecutiveNonNoSpaceFailures pins that a
 // backend persistently rejecting the checkpoint write with a non-ErrNoSpace
-// error does not keep awaitBackpressure spinning indefinitely:
-// maxDrainFailures bounds it after 10 consecutive failed drains.
+// error does not keep awaitBackpressure spinning indefinitely: the volume's
+// stall deadline bounds it.
 func TestAwaitBackpressureBoundsConsecutiveNonNoSpaceFailures(t *testing.T) {
 	vb, backend := newEnospcTestVB(t)
 	blockSize := uint64(vb.BlockSize)
 
 	// Force the backpressure gate to engage on the very next write.
 	vb.MaxPendingBytes = blockSize
+	vb.BackpressureStallTimeout = 500 * time.Millisecond
 	require.NoError(t, vb.WriteAt(0, make([]byte, blockSize)))
 
 	// Every checkpoint write fails from here on. Pin pendingBytes back
@@ -608,23 +609,22 @@ func TestAwaitBackpressureBoundsConsecutiveNonNoSpaceFailures(t *testing.T) {
 	}
 
 	start := time.Now()
-	// newEnospcTestVB shrinks SaveLiveCheckpointCtx's retry backoff, so the 10
-	// bounded rounds cost microseconds rather than ~3s each. The timeout is a
-	// hang detector with generous headroom, not an expected duration.
+	// The timeout is a hang detector with generous headroom over the 500ms
+	// stall deadline set above, not an expected duration.
 	err := runBlockingWriteWithHangTimeout(t, vb, blockSize, make([]byte, blockSize), 30*time.Second)
 	elapsed := time.Since(start)
 
 	require.Error(t, err, "a backend that never recovers must eventually surface an error instead of hanging")
 	assert.NotErrorIs(t, err, ErrNoSpace, "a generic, non-out-of-space drain failure must not be misreported as ErrNoSpace")
-	assert.Contains(t, err.Error(), "consecutive drains failed", "error must be the maxDrainFailures-bounded error, not some other failure")
+	assert.Contains(t, err.Error(), "has not drained for", "error must be the stall-deadline error, not some other failure")
 	assert.False(t, vb.backendFull.Load(), "a generic drain failure must not latch backendFull -- that latch is reserved for real out-of-space errors")
 	assert.Less(t, elapsed, 30*time.Second, "must return once the bound trips, not hang until the test's own safety-net timeout")
 }
 
 // TestAwaitBackpressureFailureCounterResetsAfterInterleavedSuccess pins that
-// a single successful drain resets the consecutive-failure counter, so
-// failures separated by a success (1 + 9, both under the cap of 10) don't
-// accumulate and trip maxDrainFailures.
+// a single successful drain ends the current run of failures, so failures
+// separated by a success don't accumulate toward the stall deadline and a
+// backend that is merely slow still completes the write.
 func TestAwaitBackpressureFailureCounterResetsAfterInterleavedSuccess(t *testing.T) {
 	vb, backend := newEnospcTestVB(t)
 	blockSize := uint64(vb.BlockSize)
@@ -679,7 +679,7 @@ func TestAwaitBackpressureFailureCounterResetsAfterInterleavedSuccess(t *testing
 	err := runBlockingWriteWithHangTimeout(t, vb, blockSize, make([]byte, blockSize), 90*time.Second)
 	elapsed := time.Since(start)
 
-	assert.NoError(t, err, "an interleaved success must reset the consecutive-failure counter so 9 more failures (well under the cap of 10) do not trip it")
+	assert.NoError(t, err, "an interleaved success must end the run of failures so the ones after it start a fresh deadline")
 	assert.False(t, vb.backendFull.Load())
 	assert.Less(t, elapsed, 90*time.Second, "must complete once the script settles, not hang")
 }

--- a/viperblock/viperblock.go
+++ b/viperblock/viperblock.go
@@ -77,6 +77,16 @@ const DefaultMaxPendingBytes uint64 = 256 * 1024 * 1024
 // still well above the 4MB chunk size so drains stay chunk-sized.
 const nearFullPendingDivisor uint64 = 8
 
+// DefaultBackpressureStallTimeout bounds how long a volume tolerates a backend
+// that will not drain before it fails the blocked write. A duration, not an
+// attempt count: ten fast failures and ten slow ones mean different things.
+//
+// The value sits between multipath's common 30s and VMware's 140s all-paths-down
+// declaration, and inside the 5 minutes EBS takes to raise volume status. It is
+// far longer than any internal retry chain, so reaching it means the backend is
+// genuinely gone rather than slow.
+const DefaultBackpressureStallTimeout time.Duration = 150 * time.Second
+
 // The backpressure budget is a bound on unflushed bytes, so it is meaningless
 // above what the WAL device can actually hold. The budget is clamped to
 // walFreeFraction of the free space, sampled at most once per
@@ -230,6 +240,17 @@ type VB struct {
 	// active drain each at a time; other callers fail fast or poll instead of
 	// launching redundant drains. drainMu below is the real exclusion guarantee.
 	drainInFlight atomic.Bool
+
+	// BackpressureStallTimeout bounds how long this volume waits on a backend
+	// that will not drain. 0 uses DefaultBackpressureStallTimeout. Per-volume
+	// because a read-only root is terminal where a read-only data mount is not.
+	BackpressureStallTimeout time.Duration
+
+	// drainStall is how long the backend has been failing to drain, held on the
+	// volume rather than in each blocked writer. Only one writer at a time wins
+	// the drainInFlight CAS, so a per-writer count divides the real tolerance by
+	// the number of writers and never bounds anything.
+	drainStall drainStall
 
 	// Last sampled free space on the WAL device, and when it was taken, so
 	// maxPendingBytes can clamp without a statfs per call.
@@ -2004,15 +2025,20 @@ func (vb *VB) awaitBackpressure(ctx context.Context) error {
 	// adds latency after the drain that unblocked the writer has finished.
 	const maxBackoff = 50 * time.Millisecond
 
-	// Bound consecutive non-ErrNoSpace drain failures so a persistently
-	// failing drain doesn't spin here forever; a single success resets the
-	// count so transient backend slowness doesn't trip it.
-	const maxDrainFailures = 10
-	drainFailures := 0
+	// Bound a persistently failing drain by how long it has been failing, on
+	// the volume. A single success clears it, so transient backend slowness
+	// does not accumulate toward the deadline.
+	budget := vb.backpressureStallTimeout()
 
 	for vb.PendingBytes() > low {
 		if err := ctx.Err(); err != nil {
 			return err
+		}
+
+		// Checked by every blocked writer, not only the one driving the drain:
+		// that is what makes the bound independent of how many are waiting.
+		if stalled, lastErr := vb.drainStall.elapsed(); stalled > budget {
+			return stalledDrainErr(stalled, lastErr)
 		}
 
 		if vb.drainInFlight.CompareAndSwap(false, true) {
@@ -2022,13 +2048,14 @@ func (vb *VB) awaitBackpressure(ctx context.Context) error {
 				if errors.Is(err, ErrNoSpace) {
 					return err
 				}
-				drainFailures++
-				vb.logger().Warn("write backpressure: drain failed, retrying", "err", err, "consecutiveFailures", drainFailures)
-				if drainFailures >= maxDrainFailures {
-					return fmt.Errorf("write backpressure: %d consecutive drains failed, aborting: %w", drainFailures, err)
+				stalled := vb.drainStall.fail(err)
+				vb.logger().Warn("write backpressure: drain failed, retrying",
+					"err", err, "stalled_ms", stalled.Milliseconds())
+				if stalled > budget {
+					return stalledDrainErr(stalled, err)
 				}
 			} else {
-				drainFailures = 0
+				vb.drainStall.clear()
 			}
 			if vb.PendingBytes() <= low {
 				break
@@ -2046,6 +2073,62 @@ func (vb *VB) awaitBackpressure(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// drainStall records how long the backend has been failing to drain and what
+// the last failure was. Volume-scoped, so every writer blocked in
+// awaitBackpressure shares one deadline instead of holding its own count.
+type drainStall struct {
+	mu    sync.Mutex
+	since time.Time
+	err   error
+}
+
+// fail records a drain failure and returns how long the current run of them has
+// lasted. The first failure of a run returns zero, so one failure never trips a
+// deadline on its own.
+func (s *drainStall) fail(err error) time.Duration {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.err = err
+	if s.since.IsZero() {
+		s.since = time.Now()
+		return 0
+	}
+	return time.Since(s.since)
+}
+
+// clear ends the current run of failures. A drain that succeeds means the
+// backend is answering, whatever it did before.
+func (s *drainStall) clear() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.since, s.err = time.Time{}, nil
+}
+
+// elapsed reports the current run's duration and its last error, or zero when
+// the backend last drained cleanly.
+func (s *drainStall) elapsed() (time.Duration, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.since.IsZero() {
+		return 0, nil
+	}
+	return time.Since(s.since), s.err
+}
+
+func stalledDrainErr(stalled time.Duration, cause error) error {
+	return fmt.Errorf("write backpressure: backend has not drained for %s, aborting: %w",
+		stalled.Round(time.Millisecond), cause)
+}
+
+// backpressureStallTimeout is how long this volume tolerates a backend that
+// will not drain.
+func (vb *VB) backpressureStallTimeout() time.Duration {
+	if vb.BackpressureStallTimeout > 0 {
+		return vb.BackpressureStallTimeout
+	}
+	return DefaultBackpressureStallTimeout
 }
 
 // backendNearFuller lets a backend report pre-full backpressure out-of-band

--- a/viperblock/viperblock.go
+++ b/viperblock/viperblock.go
@@ -748,6 +748,20 @@ func (b *BlocksToObject) resolveBlockLookup(block uint64) (BlockLookup, int, boo
 	return bl, safecast.Uint64ToInt(block - bl.StartBlock), true
 }
 
+// supersedesLocked reports whether candidate is strictly newer than whatever
+// the block map already holds for that block, so it may repoint it.
+//
+// The comparison is against the covering entry's SeqNum for THAT block, via
+// seqNumAt. A coalesced extent's own SeqNum is its first block's, and the rest
+// of the run carries values that can be higher or lower, so comparing against
+// the extent gets the answer wrong in both directions.
+//
+// Caller must hold BlocksToObject.mu.
+func (vb *VB) supersedesLocked(candidate Block) bool {
+	existing, index, found := vb.BlocksToObject.resolveBlockLookup(candidate.Block)
+	return !found || existing.seqNumAt(index) < candidate.SeqNum
+}
+
 // insertCoalescedLocked inserts newEntry into BlockLookup, fracturing any
 // overlapping existing entries into their surviving head/tail; stride
 // recomputes the tail's ObjectOffset. Caller must hold BlocksToObject.mu.
@@ -3732,64 +3746,75 @@ func (vb *VB) createChunkFile(ctx context.Context, currentWALNum uint64, chunkBu
 		for runEnd < len(*matchedBlocks) && (*matchedBlocks)[runEnd].Block == (*matchedBlocks)[runEnd-1].Block+1 {
 			runEnd++
 		}
-		numBlocks := runEnd - runStart
-		first := (*matchedBlocks)[runStart]
-
-		seqNums := make([]uint64, numBlocks)
-		for i := runStart; i < runEnd; i++ {
-			seqNums[i-runStart] = (*matchedBlocks)[i].SeqNum
-		}
-
-		newBlock := BlockLookup{
-			StartBlock:   first.Block,
-			NumBlocks:    safecast.IntToUint16(numBlocks),
-			ObjectID:     chunkIndex,
-			ObjectOffset: safecast.IntToUint32(headerLen + (runStart * stride)),
-			SeqNum:       first.SeqNum,
-			SeqNums:      seqNums,
-		}
-
-		// resolveBlockLookup finds the covering entry even when this run
-		// starts inside an existing coalesced extent, not just an exact key.
-		oldBlock, _, hadOld := vb.BlocksToObject.resolveBlockLookup(first.Block)
-
 		// Reject a stale drain: an older WAL segment landing here last would
 		// otherwise overwrite the newer, live chunk and drop its refcount to
 		// zero, letting the next sweep delete a still-referenced chunk. Only
 		// advance on a strictly newer SeqNum. The stale chunk we already
 		// uploaded is recorded at refcount zero (if not already tracked) so
 		// it becomes a GC candidate instead of leaking silently.
-		if hadOld && oldBlock.SeqNum >= newBlock.SeqNum {
-			if vb.GCEnabled {
-				if _, tracked := vb.gcRefcount[newBlock.ObjectID]; !tracked {
-					vb.gcRefcount[newBlock.ObjectID] = 0
+		//
+		// Decided per block, not per run: the covering entry may be a coalesced
+		// extent whose own SeqNum belongs to its first block, and a run replayed
+		// from the WAL routinely straddles blocks with opposite verdicts. One
+		// verdict for the whole run drops newer writes or installs superseded
+		// ones, and the wrong bytes then persist into the checkpoint.
+		for segStart := runStart; segStart < runEnd; {
+			if !vb.supersedesLocked((*matchedBlocks)[segStart]) {
+				if vb.GCEnabled {
+					if _, tracked := vb.gcRefcount[chunkIndex]; !tracked {
+						vb.gcRefcount[chunkIndex] = 0
+					}
 				}
+				segStart++
+				continue
 			}
-			runStart = runEnd
-			continue
-		}
 
-		// Fracture any existing entry this run overwrites (e.g. a prior
-		// persisted extent partially rewritten) into its surviving
-		// head/tail before inserting the new run. gcRefcount is passed
-		// through so surviving fragments keep their share of the old
-		// chunk's refcount, rather than always dropping it by exactly one.
-		var gcRefcount map[uint64]uint64
-		if vb.GCEnabled {
-			gcRefcount = vb.gcRefcount
-		}
-		vb.BlocksToObject.insertCoalescedLocked(newBlock, strideU32, gcRefcount)
-
-		// Transition from Pending to Persisted, one range op per run.
-		// Per-block SeqNums keep the location/seqNum binding atomic per
-		// block; a stale block is rejected per-block inside
-		// MarkPersistedRange, same as the single-block MarkPersisted guard.
-		if vb.UseBlockStore && vb.BlockStore != nil {
-			blocks := make([]uint64, numBlocks)
-			for i := range blocks {
-				blocks[i] = first.Block + uint64(i)
+			segEnd := segStart + 1
+			for segEnd < runEnd && vb.supersedesLocked((*matchedBlocks)[segEnd]) {
+				segEnd++
 			}
-			vb.BlockStore.MarkPersistedRange(blocks, chunkIndex, newBlock.ObjectOffset, strideU32, seqNums)
+
+			numBlocks := segEnd - segStart
+			first := (*matchedBlocks)[segStart]
+
+			seqNums := make([]uint64, numBlocks)
+			for i := segStart; i < segEnd; i++ {
+				seqNums[i-segStart] = (*matchedBlocks)[i].SeqNum
+			}
+
+			newBlock := BlockLookup{
+				StartBlock:   first.Block,
+				NumBlocks:    safecast.IntToUint16(numBlocks),
+				ObjectID:     chunkIndex,
+				ObjectOffset: safecast.IntToUint32(headerLen + (segStart * stride)),
+				SeqNum:       first.SeqNum,
+				SeqNums:      seqNums,
+			}
+
+			// Fracture any existing entry this run overwrites (e.g. a prior
+			// persisted extent partially rewritten) into its surviving
+			// head/tail before inserting the new run. gcRefcount is passed
+			// through so surviving fragments keep their share of the old
+			// chunk's refcount, rather than always dropping it by exactly one.
+			var gcRefcount map[uint64]uint64
+			if vb.GCEnabled {
+				gcRefcount = vb.gcRefcount
+			}
+			vb.BlocksToObject.insertCoalescedLocked(newBlock, strideU32, gcRefcount)
+
+			// Transition from Pending to Persisted, one range op per run.
+			// Per-block SeqNums keep the location/seqNum binding atomic per
+			// block; a stale block is rejected per-block inside
+			// MarkPersistedRange, same as the single-block MarkPersisted guard.
+			if vb.UseBlockStore && vb.BlockStore != nil {
+				blocks := make([]uint64, numBlocks)
+				for i := range blocks {
+					blocks[i] = first.Block + uint64(i)
+				}
+				vb.BlockStore.MarkPersistedRange(blocks, chunkIndex, newBlock.ObjectOffset, strideU32, seqNums)
+			}
+
+			segStart = segEnd
 		}
 
 		runStart = runEnd

--- a/viperblock/viperblock.go
+++ b/viperblock/viperblock.go
@@ -2062,6 +2062,12 @@ func (vb *VB) awaitBackpressure(ctx context.Context) error {
 				if errors.Is(err, ErrNoSpace) {
 					return err
 				}
+				// A caller that gave up is not the backend failing, and the
+				// stall deadline is shared by every writer on this volume: one
+				// cancelled request must not push the others toward it.
+				if ctxErr := ctx.Err(); ctxErr != nil {
+					return ctxErr
+				}
 				stalled := vb.drainStall.fail(err)
 				vb.logger().Warn("write backpressure: drain failed, retrying",
 					"err", err, "stalled_ms", stalled.Milliseconds())

--- a/viperblock/viperblock.go
+++ b/viperblock/viperblock.go
@@ -252,6 +252,13 @@ type VB struct {
 	// the number of writers and never bounds anything.
 	drainStall drainStall
 
+	// chunkRunsFastPath and chunkRunsClassified count how createChunkFile
+	// resolved each consecutive run: accepted whole on one range query, or
+	// classified block by block. Tests and benchmarks read them to confirm
+	// which path a workload takes; nothing in production does.
+	chunkRunsFastPath   atomic.Uint64
+	chunkRunsClassified atomic.Uint64
+
 	// Last sampled free space on the WAL device, and when it was taken, so
 	// maxPendingBytes can clamp without a statfs per call.
 	walFreeBytes     atomic.Uint64
@@ -760,6 +767,33 @@ func (b *BlocksToObject) resolveBlockLookup(block uint64) (BlockLookup, int, boo
 func (vb *VB) supersedesLocked(candidate Block) bool {
 	existing, index, found := vb.BlocksToObject.resolveBlockLookup(candidate.Block)
 	return !found || existing.seqNumAt(index) < candidate.SeqNum
+}
+
+// classifyRun gives the same verdict as supersedesLocked for each candidate in
+// run, reached by merging two ordered sequences rather than descending the tree
+// once per block. Verdicts are appended to dst.
+//
+// run must be consecutive and ascending, and overlaps must be exactly the
+// extents intersecting it, in ascending start order -- which is what
+// collectOverlaps returns. Extents are disjoint but need not be contiguous: a
+// candidate falling in a gap between two of them is mapped by neither.
+func classifyRun(overlaps []BlockLookup, run []Block, dst []bool) []bool {
+	ext := 0
+	for _, candidate := range run {
+		// Both inputs ascend, so the cursor only ever moves forward: the whole
+		// run costs one pass over the overlaps rather than a descent per block.
+		for ext < len(overlaps) && overlaps[ext].end() <= candidate.Block {
+			ext++
+		}
+		if ext == len(overlaps) || overlaps[ext].StartBlock > candidate.Block {
+			dst = append(dst, true) // nothing maps this block
+			continue
+		}
+		existing := overlaps[ext]
+		mapped := existing.seqNumAt(safecast.Uint64ToInt(candidate.Block - existing.StartBlock))
+		dst = append(dst, mapped < candidate.SeqNum)
+	}
+	return dst
 }
 
 // insertCoalescedLocked inserts newEntry into BlockLookup, fracturing any
@@ -3741,17 +3775,84 @@ func (vb *VB) createChunkFile(ctx context.Context, currentWALNum uint64, chunkBu
 	stride := int(strideU32)
 
 	vb.BlocksToObject.mu.Lock()
+	// installSegment maps [segStart, segEnd) of matchedBlocks -- which the
+	// caller guarantees is one consecutive, superseding run -- onto this chunk.
+	installSegment := func(segStart, segEnd int) {
+		numBlocks := segEnd - segStart
+		first := (*matchedBlocks)[segStart]
+
+		seqNums := make([]uint64, numBlocks)
+		for i := segStart; i < segEnd; i++ {
+			seqNums[i-segStart] = (*matchedBlocks)[i].SeqNum
+		}
+
+		newBlock := BlockLookup{
+			StartBlock:   first.Block,
+			NumBlocks:    safecast.IntToUint16(numBlocks),
+			ObjectID:     chunkIndex,
+			ObjectOffset: safecast.IntToUint32(headerLen + (segStart * stride)),
+			SeqNum:       first.SeqNum,
+			SeqNums:      seqNums,
+		}
+
+		// Fracture any existing entry this run overwrites (e.g. a prior
+		// persisted extent partially rewritten) into its surviving head/tail
+		// before inserting the new run. gcRefcount is passed through so
+		// surviving fragments keep their share of the old chunk's refcount,
+		// rather than always dropping it by exactly one.
+		var gcRefcount map[uint64]uint64
+		if vb.GCEnabled {
+			gcRefcount = vb.gcRefcount
+		}
+		vb.BlocksToObject.insertCoalescedLocked(newBlock, strideU32, gcRefcount)
+
+		// Transition from Pending to Persisted, one range op per run. Per-block
+		// SeqNums keep the location/seqNum binding atomic per block; a stale
+		// block is rejected per-block inside MarkPersistedRange, same as the
+		// single-block MarkPersisted guard.
+		if vb.UseBlockStore && vb.BlockStore != nil {
+			blocks := make([]uint64, numBlocks)
+			for i := range blocks {
+				blocks[i] = first.Block + uint64(i)
+			}
+			vb.BlockStore.MarkPersistedRange(blocks, chunkIndex, newBlock.ObjectOffset, strideU32, seqNums)
+		}
+	}
+
 	// matchedBlocks is sorted by Block ascending (see caller). Coalesce each
 	// maximal consecutive run into a single BlockLookup entry instead of one
 	// entry per block: an uncoalesced map grows unboundedly with total bytes
 	// ever written, not with live data, which is what drove nbdkit RSS up on
 	// long-running volumes.
+	// Reused across this chunk's runs. Locals rather than scratch on vb: chunk
+	// uploads run on parallel workers, and only the map lock is shared.
+	var (
+		runOverlaps []BlockLookup
+		supersedes  []bool
+	)
+
 	runStart := 0
 	for runStart < len(*matchedBlocks) {
 		runEnd := runStart + 1
 		for runEnd < len(*matchedBlocks) && (*matchedBlocks)[runEnd].Block == (*matchedBlocks)[runEnd-1].Block+1 {
 			runEnd++
 		}
+
+		run := (*matchedBlocks)[runStart:runEnd]
+		runOverlaps = vb.BlocksToObject.lookup.collectOverlaps(runOverlaps[:0], run[0].Block, run[len(run)-1].Block+1)
+
+		// A run the map does not cover at all is necessarily all-new, so the one
+		// range query above settles every block in it. Reaching that verdict a
+		// block at a time costs a tree descent each -- 1,024 per 4 MiB chunk --
+		// and a fresh or sparse volume takes this path throughout.
+		if len(runOverlaps) == 0 {
+			vb.chunkRunsFastPath.Add(1)
+			installSegment(runStart, runEnd)
+			runStart = runEnd
+			continue
+		}
+		vb.chunkRunsClassified.Add(1)
+
 		// Reject a stale drain: an older WAL segment landing here last would
 		// otherwise overwrite the newer, live chunk and drop its refcount to
 		// zero, letting the next sweep delete a still-referenced chunk. Only
@@ -3764,8 +3865,15 @@ func (vb *VB) createChunkFile(ctx context.Context, currentWALNum uint64, chunkBu
 		// from the WAL routinely straddles blocks with opposite verdicts. One
 		// verdict for the whole run drops newer writes or installs superseded
 		// ones, and the wrong bytes then persist into the checkpoint.
+		//
+		// Classified up front against the overlaps collected above, which stay
+		// valid as segments are installed below: insertCoalescedLocked touches
+		// only the segment's own blocks, and the head/tail it leaves behind
+		// carry the same per-block SeqNums the snapshot holds.
+		supersedes = classifyRun(runOverlaps, run, supersedes[:0])
+
 		for segStart := runStart; segStart < runEnd; {
-			if !vb.supersedesLocked((*matchedBlocks)[segStart]) {
+			if !supersedes[segStart-runStart] {
 				if vb.GCEnabled {
 					if _, tracked := vb.gcRefcount[chunkIndex]; !tracked {
 						vb.gcRefcount[chunkIndex] = 0
@@ -3776,49 +3884,11 @@ func (vb *VB) createChunkFile(ctx context.Context, currentWALNum uint64, chunkBu
 			}
 
 			segEnd := segStart + 1
-			for segEnd < runEnd && vb.supersedesLocked((*matchedBlocks)[segEnd]) {
+			for segEnd < runEnd && supersedes[segEnd-runStart] {
 				segEnd++
 			}
 
-			numBlocks := segEnd - segStart
-			first := (*matchedBlocks)[segStart]
-
-			seqNums := make([]uint64, numBlocks)
-			for i := segStart; i < segEnd; i++ {
-				seqNums[i-segStart] = (*matchedBlocks)[i].SeqNum
-			}
-
-			newBlock := BlockLookup{
-				StartBlock:   first.Block,
-				NumBlocks:    safecast.IntToUint16(numBlocks),
-				ObjectID:     chunkIndex,
-				ObjectOffset: safecast.IntToUint32(headerLen + (segStart * stride)),
-				SeqNum:       first.SeqNum,
-				SeqNums:      seqNums,
-			}
-
-			// Fracture any existing entry this run overwrites (e.g. a prior
-			// persisted extent partially rewritten) into its surviving
-			// head/tail before inserting the new run. gcRefcount is passed
-			// through so surviving fragments keep their share of the old
-			// chunk's refcount, rather than always dropping it by exactly one.
-			var gcRefcount map[uint64]uint64
-			if vb.GCEnabled {
-				gcRefcount = vb.gcRefcount
-			}
-			vb.BlocksToObject.insertCoalescedLocked(newBlock, strideU32, gcRefcount)
-
-			// Transition from Pending to Persisted, one range op per run.
-			// Per-block SeqNums keep the location/seqNum binding atomic per
-			// block; a stale block is rejected per-block inside
-			// MarkPersistedRange, same as the single-block MarkPersisted guard.
-			if vb.UseBlockStore && vb.BlockStore != nil {
-				blocks := make([]uint64, numBlocks)
-				for i := range blocks {
-					blocks[i] = first.Block + uint64(i)
-				}
-				vb.BlockStore.MarkPersistedRange(blocks, chunkIndex, newBlock.ObjectOffset, strideU32, seqNums)
-			}
+			installSegment(segStart, segEnd)
 
 			segStart = segEnd
 		}


### PR DESCRIPTION
## Summary

Two fixes found by running the spinifex storage-fault e2e suite against dev-prod
(3 nodes, RS(2,1)). Both are on the path a volume takes when its backend has
been failing, which is exactly the path a guest depends on to come back.

Companion PR: mulgadc/spinifex#977.

## A stale-drain check compared the wrong SeqNum

`createChunkFile` resolved the covering `BlockLookup` and compared its `SeqNum`
against the run it was about to install. `BlockLookup` is a coalesced extent
whose `SeqNum` belongs to its **first** block, so for every other block in the
run the comparison was against an unrelated sequence number. Where the extent
started newer an acknowledged write was dropped; where it started older a
superseded chunk was installed over a current one. The verdict was also computed
once per contiguous run and applied to all of it, up to 1024 blocks, and a run
replayed from the WAL routinely spans blocks with opposite verdicts.

This is only reachable after a **failed seal**: a clean `Close` removes the local
WAL, so `RecoverLocalWALs` is the one path that replays long overlapping runs
over a populated map. That made the recovery path the one that corrupted guests
— ext4 directory-block checksum errors in one run, lost file data in the next.

Each block is now decided against `seqNumAt`, and each run is split into the
maximal spans that win.

## Backpressure was bounded by a counter that could not be reached

`maxDrainFailures` was a local in `awaitBackpressure`, so every writer blocked in
backpressure held its own count. Only one writer at a time wins the
`drainInFlight` CAS, so the losers slept without ever incrementing and the bound
was reached at a rate divided by the number of writers — in practice not at all.
Over a 420s outage the counter was observed running 4, 6, 5, 4, 3, 6, 4, 6, 5
and never reaching 10.

An attempt budget is the wrong shape regardless: ten fast failures and ten slow
ones mean different things. It is replaced by a stall deadline held on the
volume, so the tolerance is one bound shared by every writer. A successful drain
ends the run, as the counter reset did.

## Verification

`make preflight` passes. Both fixes carry unit tests
(`coalesced_seqnum_test.go`, `backpressure_stall_test.go`). End to end, the
spinifex storage-fault suite is green on dev-prod with this branch deployed:

```
--- PASS: TestGuestSurvivesBackendOutage (1073.87s)
--- PASS: TestGuestSurvivesNbdkitLoss (1386.61s)
--- PASS: TestStopStartPreservesWritesOnSameNode (605.87s)
--- PASS: TestCrossNodeStartAfterFailedSealTakesOverLoudly (617.77s)
ok  github.com/mulgadc/spinifex/tests/e2e/storagefault 3767.792s
```


## Review round (2026-09-04)

Two more commits, both from the codex analysis in `docs/development/improvements/viperblock-bench.md`.

### `5f359f7` — a cancelled caller was recorded as a backend failure

`awaitBackpressure` drives `DrainToBackendCtx(ctx)` on the **caller's** context, so a caller that goes away comes back as a drain error. That error went to `vb.drainStall.fail(err)`.

Since `b1ae71a` made `drainStall` volume-scoped, that is not a cosmetic misattribution: one abandoned request starts a deadline every other writer on the volume checks, and the next writer to block aborts with `stalledDrainErr` against a backend that never failed. The existing `ErrNoSpace` special case shows the shape was already understood — some drain errors are not evidence of a stalled backend.

`ctx.Err()` now returns before the failure is recorded, after the `ErrNoSpace` check so a real out-of-space condition still surfaces in preference to the cancellation. Both tests verified red against the unpatched code: `TestCancelledWriteDoesNotRecordADrainStall` (53 µs of stall recorded) and `TestCancelledWriteDoesNotStallLaterWriters` (the later healthy write aborted).

### `e659bfa` — classify a drain run with one ordered merge

`createChunkFile` descended the extent B-tree once per candidate block — 1,024 times per 4 MiB chunk — to decide whether each superseded what the map held. Both sides are already ordered: candidates ascend, and `collectOverlaps` returns extents in ascending start order. So collect once per consecutive run and merge with a forward-only cursor: `O(log E + B + K)` instead of `O(B log E)`, same strictly-per-block verdict.

No overlaps at all means every candidate is new, so the run installs as one segment without classifying anything — codex's item 1 falls out of item 2 for free.

Classifying the whole run up front is safe against the segments installed underneath it: `insertCoalescedLocked` never merges with neighbours, and the head and tail it leaves behind carry the same per-block `SeqNums` the snapshot holds, so no later verdict in the run can change.

The invariant is unchanged:

> A candidate may replace a block only when that candidate block's sequence number is strictly greater than the sequence number currently mapped for that same block.

`TestClassifyRunMatchesPerBlockLookup` is the guard: 500 random runs against a randomly fragmented map, asserting `classifyRun` agrees with `supersedesLocked` block for block. `TestChunkDrainTakesTheFastPathOnlyWhenNothingOverlaps` proves which branch fires via the two counters, including the partial-overlap case that must **not** take the shortcut, plus a cold-reopen readback.

### Measured — volume size is not the variable

`BenchmarkRunClassify` isolates the map work for one 4 MiB chunk landing on mapped blocks:

| Map | per-block lookup | ordered merge | speedup |
| --- | --- | --- | --- |
| 8 GiB, 32 KiB extents | 173 µs | 17.9 µs | 9.7x |
| 8 GiB, 512 KiB extents | 150 µs | 12.9 µs | 11.6x |
| 250 GiB, 32 KiB extents | 164 µs | 15.1 µs | 10.9x |
| 250 GiB, 512 KiB extents | 163 µs | 13.1 µs | 12.4x |

A 32x bigger map costs the per-block path nothing measurable. The cost is `B` descents, not `log E`: the tree gains a level or two over that range and a 1,024-block run keeps hitting the same leaf nodes, so they stay cached. Fragmentation moves it more than size does.

End to end it does not show. `BenchmarkChunkDrain`, 300 chunks x 6, real WAL and file backend: FreshSequential 13.03 -> 13.01 ms/op, FullOverwrite 13.27 -> 12.88 ms/op. 145 µs against a 13 ms chunk write is inside the run-to-run spread, and a bigger volume does not change that ratio because the chunk is still 4 MiB. Expect fio on dev-prod to come back flat for the same reason.

Where it should pay is where the backend write is not the denominator: `BlocksToObject.mu` is global and every parallel upload worker queues on it, and recovery replay classifies with no backend write in the loop at all. Neither is what the fio harness measures, so I am not claiming either without a measurement of it.

Items 3-9 of the codex brainstorm are deferred. Item 3 is now partly redundant — the snapshot it asks for is the one `classifyRun` already takes.
