### PR TITLE
feat: measure NBD request latency at the guest boundary

### DIFF
--- a/nbd/viperblock.go
+++ b/nbd/viperblock.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/mulgadc/bluebottle/pkg/masterkey"
 	"github.com/mulgadc/bluebottle/pkg/otelsetup"
+	"github.com/mulgadc/viperblock/telemetry"
 	"github.com/mulgadc/viperblock/types"
 	"github.com/mulgadc/viperblock/viperblock"
 	"github.com/mulgadc/viperblock/viperblock/backends/s3"
@@ -502,11 +503,25 @@ func (c *ViperBlockConnection) CanMultiConn() (bool, error) {
 
 }
 
-func (c *ViperBlockConnection) PRead(buf []byte, offset uint64, flags uint32) error {
+// recordGuest reports one served NBD request. Deferred by each handler so the
+// timing covers the whole call including any error return, and so a handler
+// that grows an early return cannot silently stop being measured.
+func (c *ViperBlockConnection) recordGuest(op string, bytes int, start time.Time, err *error) {
+	outcome := "success"
+	if *err != nil {
+		outcome = "error"
+	}
+	telemetry.RecordGuestIO(context.Background(), op, c.vb.VolumeName, outcome, bytes, time.Since(start))
+}
+
+func (c *ViperBlockConnection) PRead(buf []byte, offset uint64, flags uint32) (err error) {
+	defer c.recordGuest("read", len(buf), time.Now(), &err)
+
 	slog.Debug("PREAD:", "offset", offset, "len", len(buf))
-	data, err := c.vb.ReadAt(offset, uint64(len(buf)))
-	if err != nil && err != viperblock.ErrZeroBlock {
-		return nbdkit.PluginError{Errmsg: fmt.Sprintf("Could not read data: %v", err)}
+	data, readErr := c.vb.ReadAt(offset, uint64(len(buf)))
+	if readErr != nil && readErr != viperblock.ErrZeroBlock {
+		err = nbdkit.PluginError{Errmsg: fmt.Sprintf("Could not read data: %v", readErr)}
+		return err
 	}
 
 	copy(buf, data)
@@ -520,21 +535,23 @@ func (c *ViperBlockConnection) CanWrite() (bool, error) {
 }
 
 func (c *ViperBlockConnection) PWrite(buf []byte, offset uint64,
-	flags uint32) error {
+	flags uint32) (err error) {
+	defer c.recordGuest("write", len(buf), time.Now(), &err)
 
 	//slog.Info("PWRITE:", "len", len(buf), "offset", offset)
 
 	if c.readonly {
-		return nbdkit.PluginError{Errmsg: "write to a read-only export", Errno: syscall.EROFS}
+		err = nbdkit.PluginError{Errmsg: "write to a read-only export", Errno: syscall.EROFS}
+		return err
 	}
 
 	data := make([]byte, len(buf))
 
 	copy(data, buf)
-	err := c.vb.WriteAt(offset, data)
 
-	if err != nil {
-		return backendErrToPluginError("Could not write data", err)
+	if writeErr := c.vb.WriteAt(offset, data); writeErr != nil {
+		err = backendErrToPluginError("Could not write data", writeErr)
+		return err
 	}
 
 	return nil
@@ -593,9 +610,12 @@ func (c *ViperBlockConnection) CanFlush() (bool, error) {
 // fsynced to the local WAL and survives host crash or power loss. It does not
 // wait for the data to reach predastore, so it does not survive loss of the
 // node itself.
-func (c *ViperBlockConnection) Flush(flags uint32) error {
-	if err := c.vb.Flush(); err != nil {
-		return backendErrToPluginError("Flush failed", err)
+func (c *ViperBlockConnection) Flush(flags uint32) (err error) {
+	defer c.recordGuest("flush", 0, time.Now(), &err)
+
+	if flushErr := c.vb.Flush(); flushErr != nil {
+		err = backendErrToPluginError("Flush failed", flushErr)
+		return err
 	}
 	return nil
 }

--- a/telemetry/guest_io_test.go
+++ b/telemetry/guest_io_test.go
@@ -1,0 +1,98 @@
+package telemetry
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+func TestRecordGuestIOEmitsCounterBytesAndDuration(t *testing.T) {
+	reader := withManualReader(t)
+
+	RecordGuestIO(context.Background(), "write", "vol-1", "success", 4096, 7*time.Millisecond)
+
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &rm); err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	metrics := collectMetrics(t, rm)
+
+	sum, ok := metrics["viperblock.guest.io.ops"].(metricdata.Sum[int64])
+	if !ok || len(sum.DataPoints) != 1 || sum.DataPoints[0].Value != 1 {
+		t.Fatalf("viperblock.guest.io.ops = %#v, want one point of 1", metrics["viperblock.guest.io.ops"])
+	}
+
+	bytesSum, ok := metrics["viperblock.guest.io.bytes"].(metricdata.Sum[int64])
+	if !ok || len(bytesSum.DataPoints) != 1 || bytesSum.DataPoints[0].Value != 4096 {
+		t.Fatalf("viperblock.guest.io.bytes = %#v, want 4096", metrics["viperblock.guest.io.bytes"])
+	}
+
+	durSum, ok := metrics["viperblock.guest.io.duration.sum"].(metricdata.Sum[float64])
+	if !ok || len(durSum.DataPoints) != 1 {
+		t.Fatalf("viperblock.guest.io.duration.sum = %#v, want one point", metrics["viperblock.guest.io.duration.sum"])
+	}
+	if got := durSum.DataPoints[0].Value; got != 0.007 {
+		t.Errorf("duration sum = %v seconds, want 0.007", got)
+	}
+
+	attrs := sum.DataPoints[0].Attributes
+	wantAttr(t, attrs, "op", "write")
+	wantAttr(t, attrs, "outcome", "success")
+	wantAttr(t, attrs, "volume.name", "vol-1")
+}
+
+// A flush moves no bytes but is the op whose latency matters most, so it must
+// still record an op and a duration. Suppressing the whole record on zero bytes
+// would erase exactly the measurement this instrument exists for.
+func TestRecordGuestIOFlushCarriesNoBytesButIsStillTimed(t *testing.T) {
+	reader := withManualReader(t)
+
+	RecordGuestIO(context.Background(), "flush", "vol-1", "success", 0, 11*time.Millisecond)
+
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &rm); err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	metrics := collectMetrics(t, rm)
+
+	if bytesSum, ok := metrics["viperblock.guest.io.bytes"].(metricdata.Sum[int64]); ok && len(bytesSum.DataPoints) != 0 {
+		t.Errorf("flush recorded %d bytes data points, want none", len(bytesSum.DataPoints))
+	}
+
+	sum, ok := metrics["viperblock.guest.io.ops"].(metricdata.Sum[int64])
+	if !ok || len(sum.DataPoints) != 1 || sum.DataPoints[0].Value != 1 {
+		t.Fatalf("flush was not counted: %#v", metrics["viperblock.guest.io.ops"])
+	}
+	durSum, ok := metrics["viperblock.guest.io.duration.sum"].(metricdata.Sum[float64])
+	if !ok || len(durSum.DataPoints) != 1 || durSum.DataPoints[0].Value != 0.011 {
+		t.Fatalf("flush duration = %#v, want 0.011s", metrics["viperblock.guest.io.duration.sum"])
+	}
+	wantAttr(t, sum.DataPoints[0].Attributes, "op", "flush")
+}
+
+// A failed request still consumed the guest's time. Recording only successes
+// would make a volume that errors quickly look faster than one that works.
+func TestRecordGuestIOSeparatesFailuresByOutcome(t *testing.T) {
+	reader := withManualReader(t)
+
+	RecordGuestIO(context.Background(), "flush", "vol-1", "success", 0, 2*time.Millisecond)
+	RecordGuestIO(context.Background(), "flush", "vol-1", "error", 0, 90*time.Millisecond)
+
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &rm); err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	metrics := collectMetrics(t, rm)
+
+	sum, ok := metrics["viperblock.guest.io.ops"].(metricdata.Sum[int64])
+	if !ok || len(sum.DataPoints) != 2 {
+		t.Fatalf("want two series split by outcome, got %#v", metrics["viperblock.guest.io.ops"])
+	}
+	for _, dp := range sum.DataPoints {
+		if dp.Value != 1 {
+			t.Errorf("outcome series counted %d, want 1", dp.Value)
+		}
+	}
+}

--- a/telemetry/metrics.go
+++ b/telemetry/metrics.go
@@ -29,6 +29,10 @@ var (
 	walOpCount       metric.Int64Counter
 	walOpDurationSum metric.Float64Counter
 
+	guestIOOps         metric.Int64Counter
+	guestIOBytes       metric.Int64Counter
+	guestIODurationSum metric.Float64Counter
+
 	cacheLookups metric.Int64Counter
 
 	rmwConflicts  metric.Int64Counter
@@ -83,6 +87,29 @@ func instruments() {
 		}
 		walOpDurationSum, err = m.Float64Counter("viperblock.wal.operation.duration.sum",
 			metric.WithDescription("Cumulative seconds spent in WAL flush/replay/consolidate operations."),
+			metric.WithUnit("s"))
+		if err != nil {
+			otel.Handle(err)
+		}
+
+		// The guest boundary, as distinct from the WAL and backend instruments
+		// below and above it. A guest fsync is a write followed by a flush, two
+		// separate NBD requests, and only the flush reaches the WAL timer — so
+		// without these the cost the guest actually waits on is unattributable.
+		guestIOOps, err = m.Int64Counter("viperblock.guest.io.ops",
+			metric.WithDescription("Count of NBD requests served to the guest, by op."),
+			metric.WithUnit("{operation}"))
+		if err != nil {
+			otel.Handle(err)
+		}
+		guestIOBytes, err = m.Int64Counter("viperblock.guest.io.bytes",
+			metric.WithDescription("Bytes transferred by NBD requests served to the guest."),
+			metric.WithUnit("By"))
+		if err != nil {
+			otel.Handle(err)
+		}
+		guestIODurationSum, err = m.Float64Counter("viperblock.guest.io.duration.sum",
+			metric.WithDescription("Cumulative seconds the guest spent waiting on NBD requests. Divided by ops this is the latency the guest observes, which for a flush is what a datastore's commit latency is made of."),
 			metric.WithUnit("s"))
 		if err != nil {
 			otel.Handle(err)
@@ -245,6 +272,35 @@ func RecordWALOp(ctx context.Context, phase, volume, outcome string, elapsed tim
 	}
 	if walOpDurationSum != nil {
 		walOpDurationSum.Add(ctx, elapsed.Seconds(), opt)
+	}
+}
+
+// RecordGuestIO records one NBD request served to the guest: op count, bytes
+// and the wall time the guest waited. op is "read"/"write"/"flush"/"zero"/
+// "trim", outcome is "success"/"error". bytesTransferred is 0 for a flush.
+//
+// This is the only measurement taken where the guest feels it. Everything else
+// times an internal stage, and a stage that looks fast can still leave the
+// guest waiting on queueing or lock contention in front of it.
+func RecordGuestIO(ctx context.Context, op, volume, outcome string, bytesTransferred int, elapsed time.Duration) {
+	instruments()
+	attrs := []attribute.KeyValue{
+		attribute.String("op", op),
+		attribute.String("outcome", outcome),
+	}
+	if volume != "" {
+		attrs = append(attrs, attribute.String("volume.name", volume))
+	}
+	opt := metric.WithAttributeSet(attribute.NewSet(attrs...))
+
+	if guestIOOps != nil {
+		guestIOOps.Add(ctx, 1, opt)
+	}
+	if guestIOBytes != nil && bytesTransferred > 0 {
+		guestIOBytes.Add(ctx, int64(bytesTransferred), opt)
+	}
+	if guestIODurationSum != nil {
+		guestIODurationSum.Add(ctx, elapsed.Seconds(), opt)
 	}
 }
 


### PR DESCRIPTION
## Why

An EKS control plane's etcd was measured committing its WAL at a **10.9ms mean
fsync** on a run where the cell passed. etcd's own guidance is a p99 under 10ms,
so a mean above it is outside what the datastore is specified to run on.

Breaking that down against the instruments we already had:

| Term | Measured |
| --- | --- |
| etcd fsync, in the guest | 10.9 ms |
| `viperblock.wal.operation.duration.sum` (flush) | 4.9 ms |
| unaccounted | ~6 ms |

Roughly 6ms of the guest's wait is not attributable to anything viperblock
currently reports. That is the larger of the two terms and the one with no
evidence either way.

The gap is structural, not incidental. Every instrument in `telemetry` times an
internal stage — the WAL flush, the backend object write, the cache lookup —
and none of them times what the guest waits on. A guest fsync is a write
followed by a flush, two separate NBD requests, and only the flush reaches the
WAL timer. The write half has never been measured.

## What this adds

`viperblock.guest.io.{ops,bytes,duration.sum}`, recorded in `PRead`, `PWrite`
and `Flush`, attributed by `op`, `outcome` and `volume.name`. Same sum-counter
shape as the existing instruments, so mean latency is `duration.sum / ops` in
ES|QL.

Each handler defers the record rather than calling it before returning, so the
timing covers the whole call including error paths, and a handler that later
grows an early return cannot silently stop being measured.

## What this does not do

It does not fix anything. It makes the missing 6ms attributable so that a fix
targets something measured. Two earlier hypotheses for the latency — the
16-way sharded WAL fsync loop, and the absence of WAL preallocation — were both
tested and disproven, the first because CI runs `shardwal: false` and the second
by an A/B on the same disk showing preallocation buys nothing on ext4.

The leading remaining hypothesis, still unverified, is `flushMu`: `Flush` holds
it across the whole WAL write while nbdkit serves 16 threads, so on a control
plane where etcd shares a volume with kubelet and containerd, every etcd commit
can queue behind another thread's flush. These metrics are what would show it.

Nothing here is EKS-specific. etcd is simply the only workload in the stack
doing synchronous small commits at queue depth 1, so it is where the latency
shows, not where it originates.

## Verification

`make preflight` passes. `make go_build_nbd` builds the cgo plugin, which
preflight does not cover — `nbd/` is outside the workspace modules, so
`go test ./nbd/...` cannot load it. Three telemetry tests cover the emission,
the zero-byte flush case (a flush moves no bytes but is the op whose latency
matters most, so suppressing its record on zero bytes would erase the point of
the instrument) and outcome separation.