### PR TITLE
feat: measure time guest writes spend blocked on backpressure

### DIFF
--- a/telemetry/backpressure_test.go
+++ b/telemetry/backpressure_test.go
@@ -1,0 +1,55 @@
+package telemetry
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+func TestRecordWriteBackpressureCountsWaitAndDuration(t *testing.T) {
+	reader := withManualReader(t)
+
+	RecordWriteBackpressure(context.Background(), "vol-1", 30*time.Millisecond)
+
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &rm); err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	metrics := collectMetrics(t, rm)
+
+	waits, ok := metrics["viperblock.write.backpressure.waits"].(metricdata.Sum[int64])
+	if !ok || len(waits.DataPoints) != 1 || waits.DataPoints[0].Value != 1 {
+		t.Fatalf("waits = %#v, want one point of 1", metrics["viperblock.write.backpressure.waits"])
+	}
+	durSum, ok := metrics["viperblock.write.backpressure.duration.sum"].(metricdata.Sum[float64])
+	if !ok || len(durSum.DataPoints) != 1 || durSum.DataPoints[0].Value != 0.03 {
+		t.Fatalf("duration = %#v, want 0.03s", metrics["viperblock.write.backpressure.duration.sum"])
+	}
+	wantAttr(t, waits.DataPoints[0].Attributes, "volume.name", "vol-1")
+}
+
+// The counters are what make backpressure separable from the write itself, so
+// they must accumulate across waits rather than report only the latest.
+func TestRecordWriteBackpressureAccumulates(t *testing.T) {
+	reader := withManualReader(t)
+
+	RecordWriteBackpressure(context.Background(), "vol-1", 10*time.Millisecond)
+	RecordWriteBackpressure(context.Background(), "vol-1", 40*time.Millisecond)
+
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &rm); err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	metrics := collectMetrics(t, rm)
+
+	waits := metrics["viperblock.write.backpressure.waits"].(metricdata.Sum[int64])
+	if waits.DataPoints[0].Value != 2 {
+		t.Errorf("waits = %d, want 2", waits.DataPoints[0].Value)
+	}
+	durSum := metrics["viperblock.write.backpressure.duration.sum"].(metricdata.Sum[float64])
+	if got := durSum.DataPoints[0].Value; got != 0.05 {
+		t.Errorf("duration sum = %v, want 0.05", got)
+	}
+}

--- a/telemetry/metrics.go
+++ b/telemetry/metrics.go
@@ -35,6 +35,9 @@ var (
 
 	cacheLookups metric.Int64Counter
 
+	backpressureWaits       metric.Int64Counter
+	backpressureDurationSum metric.Float64Counter
+
 	rmwConflicts  metric.Int64Counter
 	volumeOpens   metric.Int64Counter
 	volumeEngines metric.Int64UpDownCounter
@@ -127,6 +130,23 @@ func instruments() {
 		}
 		cacheMissOpts = []metric.AddOption{
 			metric.WithAttributeSet(attribute.NewSet(attribute.String("result", "miss"))),
+		}
+
+		// Counted only when a write actually blocked, so waits/guest-write-ops
+		// is the fraction of writes that stalled and duration.sum against the
+		// guest write duration is how much of guest write latency is this and
+		// not the write itself.
+		backpressureWaits, err = m.Int64Counter("viperblock.write.backpressure.waits",
+			metric.WithDescription("Guest writes that blocked because buffered bytes crossed the high-watermark. Zero means the backend kept up."),
+			metric.WithUnit("{wait}"))
+		if err != nil {
+			otel.Handle(err)
+		}
+		backpressureDurationSum, err = m.Float64Counter("viperblock.write.backpressure.duration.sum",
+			metric.WithDescription("Cumulative seconds guest writes spent blocked on backpressure, waiting for the backend to drain."),
+			metric.WithUnit("s"))
+		if err != nil {
+			otel.Handle(err)
 		}
 
 		rmwConflicts, err = m.Int64Counter("viperblock.write.rmw_conflicts",
@@ -272,6 +292,26 @@ func RecordWALOp(ctx context.Context, phase, volume, outcome string, elapsed tim
 	}
 	if walOpDurationSum != nil {
 		walOpDurationSum.Add(ctx, elapsed.Seconds(), opt)
+	}
+}
+
+// RecordWriteBackpressure records one guest write that blocked waiting for the
+// backend to drain, and how long it waited. Only blocked writes are recorded:
+// the unblocked path is the common case, and counting it would bury the stalls
+// this exists to surface in a mean dominated by zeros.
+func RecordWriteBackpressure(ctx context.Context, volume string, elapsed time.Duration) {
+	instruments()
+	var attrs []attribute.KeyValue
+	if volume != "" {
+		attrs = append(attrs, attribute.String("volume.name", volume))
+	}
+	opt := metric.WithAttributeSet(attribute.NewSet(attrs...))
+
+	if backpressureWaits != nil {
+		backpressureWaits.Add(ctx, 1, opt)
+	}
+	if backpressureDurationSum != nil {
+		backpressureDurationSum.Add(ctx, elapsed.Seconds(), opt)
 	}
 }
 

--- a/viperblock/chunk_fastpath_test.go
+++ b/viperblock/chunk_fastpath_test.go
@@ -37,7 +37,7 @@ func assertBlocks(t *testing.T, vb *VB, base uint64, count int, fill byte) {
 	blockSize := uint64(vb.BlockSize)
 	want := bytes.Repeat([]byte{fill}, int(blockSize))
 	for i := range count {
-		got, err := vb.ReadAt((base+uint64(i))*blockSize, uint64(blockSize))
+		got, err := vb.ReadAt((base+uint64(i))*blockSize, blockSize)
 		require.NoError(t, err, "block %d", base+uint64(i))
 		assert.Equal(t, want, got, "block %d", base+uint64(i))
 	}

--- a/viperblock/classify_run_test.go
+++ b/viperblock/classify_run_test.go
@@ -1,7 +1,7 @@
 package viperblock
 
 import (
-	"math/rand"
+	"math/rand/v2"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -97,17 +97,17 @@ func TestClassifyRun(t *testing.T) {
 // merge: against a randomly fragmented index it must give the identical verdict
 // to supersedesLocked, which reaches it with one tree descent per block.
 func TestClassifyRunMatchesPerBlockLookup(t *testing.T) {
-	rng := rand.New(rand.NewSource(20260904))
+	rng := rand.New(rand.NewPCG(20260904, 0))
 	vb := &VB{}
 
 	// A fragmented map: extents of random length with random gaps between
 	// them, and per-block sequence numbers that rise and fall within each.
 	for block := uint64(0); block < 4096; {
-		block += uint64(rng.Intn(4)) // gap, sometimes zero
-		n := 1 + rng.Intn(12)
+		block += uint64(rng.IntN(4)) // gap, sometimes zero
+		n := 1 + rng.IntN(12)
 		seqNums := make([]uint64, n)
 		for i := range seqNums {
-			seqNums[i] = uint64(rng.Intn(2000))
+			seqNums[i] = uint64(rng.IntN(2000))
 		}
 		vb.BlocksToObject.lookup.set(BlockLookup{
 			StartBlock: block,
@@ -119,10 +119,10 @@ func TestClassifyRunMatchesPerBlockLookup(t *testing.T) {
 	require.NotZero(t, vb.BlocksToObject.lookup.len())
 
 	for range 500 {
-		start := uint64(rng.Intn(4096))
-		run := make([]Block, 1+rng.Intn(64))
+		start := uint64(rng.IntN(4096))
+		run := make([]Block, 1+rng.IntN(64))
 		for i := range run {
-			run[i] = Block{Block: start + uint64(i), SeqNum: uint64(rng.Intn(2000))}
+			run[i] = Block{Block: start + uint64(i), SeqNum: uint64(rng.IntN(2000))}
 		}
 
 		overlaps := vb.BlocksToObject.lookup.collectOverlaps(nil, run[0].Block, run[len(run)-1].Block+1)

--- a/viperblock/viperblock.go
+++ b/viperblock/viperblock.go
@@ -2081,6 +2081,14 @@ func (vb *VB) awaitBackpressure(ctx context.Context) error {
 		return nil
 	}
 
+	// Past the fast path the guest write is stalled, so time from here rather
+	// than function entry: recording the unblocked case would leave a mean
+	// dominated by zeros and hide the stall it exists to show.
+	stalledSince := time.Now()
+	defer func() {
+		telemetry.RecordWriteBackpressure(context.Background(), vb.VolumeName, time.Since(stalledSince))
+	}()
+
 	low := high - high/backpressureLowFraction
 	backoff := 10 * time.Millisecond
 	// The loop re-checks pendingBytes on every wake, so a long backoff only


### PR DESCRIPTION
Follows #90, which made the guest boundary measurable and closed the gap in
etcd's commit latency:

```
guest write   6.214 ms  x17704
guest flush   5.931 ms  x 8581
              --------
              12.145 ms
etcd fsync    12.1 ms    (logged baseline, same run)
```

An EKS control plane's etcd commit is one NBD write plus one NBD flush, and
both are inside viperblock. Nothing above it accounts for meaningful time, so
viperblock owns essentially all of that latency. etcd's guidance is a p99 under
10ms and this is a mean above it.

## Why another metric and not a fix

Four explanations have been tested and eliminated:

| Hypothesis | Eliminated by |
| --- | --- |
| 16-way sharded WAL fsync loop | the deployment runs `shardwal: false` |
| Missing WAL preallocation | A/B on one disk: 3.80ms grown vs 3.92ms preallocated |
| `flushMu` queueing ahead of the WAL write | guest flush 5.93ms sits *below* WAL flush 7.01ms |
| Read-modify-write backend fetches | 97.5% cache hits; 721 backend reads against 17704 writes |

What survives is `awaitBackpressure`. It stalls the guest write and drives a
synchronous `DrainToBackendCtx` with a 10-50ms backoff once buffered bytes
cross the high-watermark, and backend writes on that run averaged **356ms** —
which is the condition that trips it. Mean write latency also rises
monotonically with write count across the four volumes in the run.

That is suggestive, not conclusive. A 6.2ms mean is equally consistent with
every write costing 6ms and with 80% costing 0.1ms while 20% block for 30ms,
and those have different fixes. Sum-counters cannot separate them, so this
adds the one measurement that can.

`viperblock.write.backpressure.{waits,duration.sum}`, recorded only when a
write actually blocked. Against the guest write counters from #90 this gives
both the fraction of writes that stalled and how much of guest write latency
is the stall rather than the write. If it carries nearly all of it, the answer
is backpressure and the fix belongs in the drain path; if it is near zero, the
cost is in `writeOneBlockLocked` and that is where to look next.

Recording the unblocked path as a zero was deliberately avoided — it is the
common case and would leave a mean dominated by zeros, hiding the stalls the
instrument exists to surface.

## Also here

A separate first commit restores lint on `dev`. Two violations landed with the
ordered-merge drain classifier (`math/rand` where the linter requires
`math/rand/v2`, and an unnecessary conversion) and fail `golangci-lint` on a
clean `dev` checkout, so every branch cut from it is blocked before it starts.
Kept as its own commit since it is not part of this change.

## Verification

`make preflight` passes, which it does not on `dev` without the first commit.
`make go_build_nbd` builds the cgo plugin, which preflight does not cover.
Telemetry tests cover emission and accumulation across waits.