### PR TITLE
fix: reclaim WAL generations once a checkpoint names their blocks

### DIFF
--- a/viperblock/viperblock.go
+++ b/viperblock/viperblock.go
@@ -273,6 +273,11 @@ type VB struct {
 	// chunk upload failed. Retried at the head of the next consolidation so
 	// the data is not stranded in-process until the next restart.
 	pendingWALChunks []uint64
+
+	// consolidatedWALs holds generations whose blocks are durable as backend
+	// chunks but are not yet named by a persisted checkpoint. Until one lands
+	// the local WAL is the only record that maps them, so they stay on disk.
+	consolidatedWALs []uint64
 	pendingWALMu     sync.Mutex
 
 	// drainMu serializes DrainToBackendCtx across all its triggers. Two
@@ -2646,6 +2651,12 @@ func (vb *VB) DrainToBackendCtx(ctx context.Context) (err error) {
 	if err = vb.SaveLiveCheckpointCtx(ctx); err != nil {
 		return fmt.Errorf("drain live checkpoint: %w", err)
 	}
+
+	// The checkpoint naming these generations' blocks is now durable, so their
+	// local WAL files are redundant. A no-op checkpoint (nothing dirty) still
+	// means the persisted one is current, so it releases them too.
+	vb.reclaimConsolidatedWALs()
+
 	return nil
 }
 
@@ -3284,6 +3295,7 @@ func (vb *VB) WriteShardedWALToChunkCtx(ctx context.Context, force bool) error {
 		vb.pendingWALMu.Unlock()
 		return err
 	}
+	vb.markWALConsolidated(currentWALNum)
 
 	return nil
 }
@@ -3452,6 +3464,7 @@ func (vb *VB) retryPendingWALChunks(ctx context.Context, consolidate func(contex
 		if err := consolidate(ctx, walNum); err != nil {
 			return err
 		}
+		vb.markWALConsolidated(walNum)
 
 		// Drop the entry only after a successful consolidation. Re-check the
 		// head in case a concurrent caller already removed it.
@@ -3460,6 +3473,51 @@ func (vb *VB) retryPendingWALChunks(ctx context.Context, consolidate func(contex
 			vb.pendingWALChunks = vb.pendingWALChunks[1:]
 		}
 		vb.pendingWALMu.Unlock()
+	}
+}
+
+// markWALConsolidated records a generation whose blocks are now durable as
+// backend chunks. It becomes reclaimable once a checkpoint naming them lands.
+func (vb *VB) markWALConsolidated(walNum uint64) {
+	vb.pendingWALMu.Lock()
+	vb.consolidatedWALs = append(vb.consolidatedWALs, walNum)
+	vb.pendingWALMu.Unlock()
+}
+
+// walGenerationFiles returns the local files holding generation walNum: one on
+// the single-file WAL, one per shard on the sharded WAL.
+func (vb *VB) walGenerationFiles(walNum uint64) []string {
+	if vb.UseShardedWAL && vb.ShardedWAL != nil {
+		paths := make([]string, 0, NumShards)
+		for shardID := range NumShards {
+			paths = append(paths, filepath.Join(vb.ShardedWAL.BaseDir,
+				types.GetShardedWALPath(vb.GetVolume(), walNum, shardID)))
+		}
+		return paths
+	}
+	return []string{filepath.Join(vb.WAL.BaseDir,
+		types.GetFilePath(types.FileTypeWALChunk, walNum, vb.GetVolume()))}
+}
+
+// reclaimConsolidatedWALs deletes the local WAL files of every generation
+// consolidated since the last checkpoint. Call only once SaveLiveCheckpointCtx
+// has succeeded: before that the WAL is the only record mapping those blocks.
+//
+// A failed unlink is logged, not returned. RecoverLocalWALs replays a leftover
+// harmlessly on the next open, so it costs space rather than correctness, and
+// failing an otherwise clean drain over it would be the worse trade.
+func (vb *VB) reclaimConsolidatedWALs() {
+	vb.pendingWALMu.Lock()
+	reclaim := vb.consolidatedWALs
+	vb.consolidatedWALs = nil
+	vb.pendingWALMu.Unlock()
+
+	for _, walNum := range reclaim {
+		for _, path := range vb.walGenerationFiles(walNum) {
+			if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+				vb.logger().Warn("failed to reclaim consolidated WAL file", "file", path, "error", err)
+			}
+		}
 	}
 }
 
@@ -3536,6 +3594,7 @@ func (vb *VB) WriteWALToChunkCtx(ctx context.Context, force bool) (err error) {
 		vb.pendingWALMu.Unlock()
 		return err
 	}
+	vb.markWALConsolidated(currentWALNum)
 
 	return nil
 }

--- a/viperblock/wal_reclaim_test.go
+++ b/viperblock/wal_reclaim_test.go
@@ -1,0 +1,203 @@
+package viperblock
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/mulgadc/viperblock/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// walDirBytes returns the file count and total size of a volume's local WAL
+// directory, the space that grew 1:1 with guest writes before reclaim existed.
+func walDirBytes(t *testing.T, vb *VB) (int, int64) {
+	t.Helper()
+	baseDir := vb.WAL.BaseDir
+	if vb.UseShardedWAL && vb.ShardedWAL != nil {
+		baseDir = vb.ShardedWAL.BaseDir
+	}
+	dir := filepath.Join(baseDir, vb.GetVolume(), "wal", "chunks")
+
+	entries, err := os.ReadDir(dir)
+	if os.IsNotExist(err) {
+		return 0, 0
+	}
+	require.NoError(t, err)
+
+	var total int64
+	for _, e := range entries {
+		info, err := e.Info()
+		require.NoError(t, err)
+		total += info.Size()
+	}
+	return len(entries), total
+}
+
+// TestWALReclaimBoundsLocalGrowth is the regression gate. A consolidated WAL
+// generation whose blocks are named by a durable checkpoint is redundant, but
+// nothing deleted it: 128 MiB of guest writes left 128.9 MiB of WAL on disk
+// across 9 files. That filled the WAL device, which collapsed the
+// maxPendingBytes window onto its floor and multiplied drain frequency.
+func TestWALReclaimBoundsLocalGrowth(t *testing.T) {
+	runWithBackends(t, "wal_reclaim_growth", func(t *testing.T, vb *VB) {
+		data := make([]byte, vb.BlockSize)
+		block := 0
+
+		// One generation per round: DrainToBackendCtx consolidates with
+		// force=true, so every round rotates whatever it wrote.
+		const rounds = 6
+		const blocksPerRound = 64
+
+		var firstFiles int
+		var firstBytes int64
+
+		for round := range rounds {
+			for range blocksPerRound {
+				require.NoError(t, vb.WriteAt(uint64(block)*uint64(vb.BlockSize), data))
+				block++
+			}
+			require.NoError(t, vb.DrainToBackendCtx(context.Background()))
+
+			files, bytes := walDirBytes(t, vb)
+			if round == 0 {
+				firstFiles, firstBytes = files, bytes
+				continue
+			}
+			// Only the current open generation may remain, so the directory
+			// must not grow with the number of rounds.
+			assert.LessOrEqual(t, files, firstFiles,
+				"round %d: WAL file count grew, consolidated generations are not being reclaimed", round)
+			assert.LessOrEqual(t, bytes, firstBytes,
+				"round %d: WAL bytes grew, consolidated generations are not being reclaimed", round)
+		}
+	})
+}
+
+// TestWALReclaimSkipsStrandedGeneration gates the ordering that makes reclaim
+// safe. A generation whose chunk upload failed holds the only copy of its
+// blocks, so it must stay on disk for retryPendingWALChunks even though a
+// later drain succeeds and reclaims its own generation.
+func TestWALReclaimSkipsStrandedGeneration(t *testing.T) {
+	dir := t.TempDir()
+	vb := openEncryptedVBInDir(t, dir, "reclaim-stranded", nil)
+	vb.StopChunkUploader()
+	t.Cleanup(func() { vb.StopWALSyncer() })
+
+	eb := &errBackend{Backend: vb.Backend, failType: types.FileTypeChunk, failN: 1}
+	vb.Backend = eb
+
+	data := make([]byte, vb.BlockSize)
+	require.NoError(t, vb.WriteAt(0, data))
+
+	// The chunk upload fails, so the generation is stranded, not consolidated.
+	require.Error(t, vb.DrainToBackendCtx(context.Background()),
+		"a failed chunk upload must fail the drain")
+
+	vb.pendingWALMu.Lock()
+	strandedCount := len(vb.pendingWALChunks)
+	consolidatedCount := len(vb.consolidatedWALs)
+	vb.pendingWALMu.Unlock()
+
+	assert.Equal(t, 1, strandedCount, "the failed generation must be queued for retry")
+	assert.Equal(t, 0, consolidatedCount, "a stranded generation must never be marked consolidated")
+
+	files, _ := walDirBytes(t, vb)
+	assert.GreaterOrEqual(t, files, 2, "the stranded generation must stay on disk alongside the open one")
+}
+
+// TestWALReclaimDeferredUntilCheckpointLands gates the other half of the
+// ordering. Until the checkpoint naming a generation's blocks is durable the
+// local WAL is the only record that maps them, so a failed checkpoint must
+// leave the file alone and the next successful one must release it.
+func TestWALReclaimDeferredUntilCheckpointLands(t *testing.T) {
+	dir := t.TempDir()
+	vb := openEncryptedVBInDir(t, dir, "reclaim-deferred", nil)
+	vb.StopChunkUploader()
+	vb.checkpointRetryBackoff = time.Microsecond
+	t.Cleanup(func() { vb.StopWALSyncer() })
+
+	// SaveLiveCheckpointCtx retries three times internally, so exhaust them.
+	eb := &errBackend{Backend: vb.Backend, failType: types.FileTypeBlockCheckpointLive, failN: 3}
+	vb.Backend = eb
+
+	data := make([]byte, vb.BlockSize)
+	require.NoError(t, vb.WriteAt(0, data))
+
+	require.Error(t, vb.DrainToBackendCtx(context.Background()),
+		"a checkpoint that exhausts its retries must fail the drain")
+
+	vb.pendingWALMu.Lock()
+	held := len(vb.consolidatedWALs)
+	vb.pendingWALMu.Unlock()
+	assert.Equal(t, 1, held, "the consolidated generation must be held until a checkpoint lands")
+
+	filesBefore, _ := walDirBytes(t, vb)
+	assert.GreaterOrEqual(t, filesBefore, 2,
+		"the consolidated generation must stay on disk while the checkpoint is stale")
+
+	// The injected failures are spent; this drain checkpoints cleanly.
+	require.NoError(t, vb.WriteAt(uint64(vb.BlockSize), data))
+	require.NoError(t, vb.DrainToBackendCtx(context.Background()))
+
+	vb.pendingWALMu.Lock()
+	remaining := len(vb.consolidatedWALs)
+	vb.pendingWALMu.Unlock()
+	assert.Equal(t, 0, remaining, "a durable checkpoint must release every held generation")
+
+	filesAfter, _ := walDirBytes(t, vb)
+	assert.Less(t, filesAfter, filesBefore,
+		"the held generations must be reclaimed once the checkpoint is durable")
+}
+
+// TestReclaimedWALStillReadsFromCheckpoint is the durability half: reclaim is
+// only correct if the checkpoint that released a generation can rebuild its
+// block map without it. A reader with no WAL of its own must see the data.
+func TestReclaimedWALStillReadsFromCheckpoint(t *testing.T) {
+	dir := t.TempDir()
+	vb := openEncryptedVBInDir(t, dir, "reclaim-durable", nil)
+	vb.StopChunkUploader()
+	t.Cleanup(func() { vb.StopWALSyncer() })
+
+	blocks := 32
+	written := make([][]byte, blocks)
+	for i := range blocks {
+		buf := make([]byte, vb.BlockSize)
+		for j := range buf {
+			buf[j] = byte(i + 1)
+		}
+		written[i] = buf
+		require.NoError(t, vb.WriteAt(uint64(i)*uint64(vb.BlockSize), buf))
+	}
+
+	require.NoError(t, vb.DrainToBackendCtx(context.Background()))
+
+	vb.pendingWALMu.Lock()
+	remaining := len(vb.consolidatedWALs)
+	vb.pendingWALMu.Unlock()
+	require.Equal(t, 0, remaining, "the drain must have reclaimed its generation")
+
+	reader := &VB{
+		VolumeName:   vb.VolumeName,
+		VolumeSize:   vb.VolumeSize,
+		BlockSize:    vb.BlockSize,
+		ObjBlockSize: vb.ObjBlockSize,
+		Version:      vb.Version,
+		BaseDir:      vb.BaseDir,
+		Backend:      vb.Backend,
+		BlockToObjectWAL: WAL{
+			WALMagic: vb.BlockToObjectWAL.WALMagic,
+		},
+		BlocksToObject: BlocksToObject{},
+	}
+	require.NoError(t, reader.LoadLiveCheckpoint())
+
+	for i := range blocks {
+		got, err := reader.ReadAt(uint64(i)*uint64(vb.BlockSize), uint64(vb.BlockSize))
+		require.NoError(t, err, "block %d must still be readable after its WAL was reclaimed", i)
+		assert.Equal(t, written[i], got, "block %d must be byte-identical after reclaim", i)
+	}
+}


### PR DESCRIPTION
## Problem

`consolidateWALGeneration` uploads a rotated generation's blocks as backend chunks and returns without removing the file. The only `os.Remove` of a WAL file in the package is in `RecoverLocalWALs`, which runs at open. The local WAL therefore retains 100% of guest bytes for the life of the process — measured, 128 MiB of guest writes left 128.9 MiB across 9 files.

This is a gap rather than a decision. `DESIGN.md`'s WAL lifecycle lists Open, Write, Sync, Consolidate, Rotate with no delete step, and the recovery section then says `RecoverLocalWALs` "scans for **unconsolidated** WAL files" — an invariant nothing maintained. Retention does have one designed purpose, cleanup at detach via `RemoveLocalFiles`, but that has no runtime bound.

## Why it matters

Unbounded local growth, and eventually a full WAL device. `maxPendingBytes` clamps the backpressure window to free space on that device:

```
high = min(256MB, max(free/2, 16MB))
```

so a WAL that grows 1:1 with guest writes ends by collapsing the window onto its 16 MiB floor and tripping backpressure up to 16x more often.

**Scope note.** An earlier version of this description claimed that collapse was the cause of the `mulga-fxz6z` etcd stalls. It is not, and the claim is withdrawn. Cell-25 run `34089435511` shipped this change with no improvement (29 waits / 99.6 s to 36 / 124.5 s), and the WAL device on that host had 26.1 GiB free, so the clamp never bound. Those stalls are the 64 MiB watermark gap divided by a 15-22 MB/s drain rate, and are addressed by `mulga-c7v0o` plus drain-throughput work. This PR fixes a real unbounded-growth defect on its own terms and remains the safety precondition for that work.

## Change

Track generations whose chunks are durable in `consolidatedWALs`, and release them once `SaveLiveCheckpointCtx` succeeds. Until the checkpoint naming those blocks is persisted the local WAL is the only record mapping them, so the ordering is what makes reclaim safe.

- A generation stranded by a failed upload goes to `pendingWALChunks` and is never marked consolidated, so it stays on disk for retry.
- A crash between checkpoint and unlink leaves the file, which `RecoverLocalWALs` replays harmlessly; blocks re-upload under new ObjectIDs and the superseded chunks become GC candidates.
- A no-op checkpoint (nothing dirty) still means the persisted one is current, so it releases held generations too.
- A failed unlink is logged, not returned: a leftover costs space, not correctness, and failing an otherwise clean drain over it would be worse.
- `RemoveLocalFiles` at detach and the `#58` retain-on-Close-failure path are untouched.

Covers both the single-file and sharded WAL paths, and the retry path.

## Tests

`TestWALReclaimBoundsLocalGrowth` runs through `runWithBackends`, so it covers the sharded, legacy and s3 configurations. Verified it fails without the fix — WAL file count and bytes grow every round.

The other three gate the ordering and the durability that depends on it: a stranded generation is not reclaimed, a failed checkpoint defers reclaim until a later one lands, and a reader with no WAL of its own reads back byte-identical data from the checkpoint alone.

Cell-25 (`34089435511`) exercised this end to end against a live EKS cluster and passed every subtest except a pre-existing IRSA failure (`mulga-9bh6f`).

## Follow-ups

Stage 2 (`mulga-c7v0o`) takes the full-map checkpoint and the GC sweep off the guest stall path — this PR is its precondition, because it is what guarantees the WAL still holds any mapping the deferred checkpoint has not yet persisted.

Plan: `docs/development/bugs/viperblock-wal-reclaim-and-checkpoint-pacing.md`
Analysis: `docs/development/bugs/eks-etcd-commit-latency-through-viperblock.md`
Bead: `mulga-tsehv`
