### PR TITLE
fix: take the live checkpoint off the guest stall path

### DIFF
--- a/telemetry/metrics.go
+++ b/telemetry/metrics.go
@@ -40,6 +40,12 @@ var (
 	backpressureDurationSum metric.Float64Counter
 	backpressurePending     metric.Int64Gauge
 	backpressureHigh        metric.Int64Gauge
+	backpressureWaiters     metric.Int64UpDownCounter
+	backpressureSlowWaits   metric.Int64Counter
+
+	backpressurePhaseOps         metric.Int64Counter
+	backpressurePhaseDurationSum metric.Float64Counter
+	backpressureDrainedBytes     metric.Int64Counter
 
 	rmwConflicts  metric.Int64Counter
 	volumeOpens   metric.Int64Counter
@@ -163,6 +169,49 @@ func instruments() {
 		}
 		backpressureHigh, err = m.Int64Gauge("viperblock.write.backpressure.high_watermark_bytes",
 			metric.WithDescription("Runtime high-watermark the gate blocks at, after the WAL-device free-space clamp. Not the 256MB default unless the device has room, so it must be read rather than assumed."),
+			metric.WithUnit("By"))
+		if err != nil {
+			otel.Handle(err)
+		}
+
+		// Waits are recorded per blocked writer, so duration.sum counts one
+		// stall once per writer that sat through it. Without this, N writers
+		// blocked on a single event are indistinguishable from N events.
+		backpressureWaiters, err = m.Int64UpDownCounter("viperblock.write.backpressure.waiters",
+			metric.WithDescription("Guest writes currently blocked on backpressure for this volume. A value above 1 means duration.sum is counting one stall several times over."),
+			metric.WithUnit("{writer}"))
+		if err != nil {
+			otel.Handle(err)
+		}
+
+		// A mean cannot show a tail, and the tail is the failure: etcd loses
+		// its leader on one stall over the election timeout, however good the
+		// average was.
+		backpressureSlowWaits, err = m.Int64Counter("viperblock.write.backpressure.slow_waits",
+			metric.WithDescription("Guest writes that blocked for longer than the bucket's lower bound, by threshold. The 1s bucket is the one that costs a datastore its leader."),
+			metric.WithUnit("{wait}"))
+		if err != nil {
+			otel.Handle(err)
+		}
+
+		// Splits a wait into the part this writer spent driving a drain and
+		// the part it spent polling while another writer drove one. Phase sums
+		// on the drain itself cannot do this: the guest flush path calls the
+		// same Flush(), so those counters mix both callers.
+		backpressurePhaseOps, err = m.Int64Counter("viperblock.write.backpressure.phase.ops",
+			metric.WithDescription("Occurrences of each phase within a backpressure wait: drain (this writer drove one) or poll (it waited on another writer's)."),
+			metric.WithUnit("{operation}"))
+		if err != nil {
+			otel.Handle(err)
+		}
+		backpressurePhaseDurationSum, err = m.Float64Counter("viperblock.write.backpressure.phase.duration.sum",
+			metric.WithDescription("Cumulative seconds spent in each phase within a backpressure wait. Against waits.duration.sum this is where a stall actually goes."),
+			metric.WithUnit("s"))
+		if err != nil {
+			otel.Handle(err)
+		}
+		backpressureDrainedBytes, err = m.Int64Counter("viperblock.write.backpressure.drained_bytes",
+			metric.WithDescription("Bytes pendingBytes fell by during drains driven from the stall path. Divided by the drain phase duration this is the net drain rate under guest load, which is what the watermark gap is actually divided by."),
 			metric.WithUnit("By"))
 		if err != nil {
 			otel.Handle(err)
@@ -332,6 +381,79 @@ func RecordWriteBackpressure(ctx context.Context, volume string, elapsed time.Du
 	if backpressureDurationSum != nil {
 		backpressureDurationSum.Add(ctx, elapsed.Seconds(), opt)
 	}
+}
+
+// backpressureSlowThresholds are the tail buckets a wait is counted into. A
+// wait longer than several of them is counted in each, so a bucket reads as
+// "waits at least this long".
+var backpressureSlowThresholds = []struct {
+	label string
+	limit time.Duration
+}{
+	{"100ms", 100 * time.Millisecond},
+	{"1s", time.Second},
+	{"5s", 5 * time.Second},
+}
+
+// BackpressureWaiterScope marks a writer as blocked for as long as the
+// returned function is uncalled, so concurrent waiters are countable. Call the
+// returned function once, on the way out of the wait.
+func BackpressureWaiterScope(ctx context.Context, volume string) func() {
+	instruments()
+	if backpressureWaiters == nil {
+		return func() {}
+	}
+	opt := metric.WithAttributeSet(attribute.NewSet(volumeAttrs(volume)...))
+	backpressureWaiters.Add(ctx, 1, opt)
+	return func() { backpressureWaiters.Add(ctx, -1, opt) }
+}
+
+// RecordBackpressurePhase records one phase within a backpressure wait: phase
+// is "drain" when this writer drove one itself, "poll" when it slept while
+// another writer's drain ran. drainedBytes is how far pendingBytes fell, and
+// is meaningful for the drain phase only.
+func RecordBackpressurePhase(ctx context.Context, volume, phase string, elapsed time.Duration, drainedBytes int64) {
+	instruments()
+	attrs := volumeAttrs(volume)
+	attrs = append(attrs, attribute.String("phase", phase))
+	opt := metric.WithAttributeSet(attribute.NewSet(attrs...))
+
+	if backpressurePhaseOps != nil {
+		backpressurePhaseOps.Add(ctx, 1, opt)
+	}
+	if backpressurePhaseDurationSum != nil {
+		backpressurePhaseDurationSum.Add(ctx, elapsed.Seconds(), opt)
+	}
+	if backpressureDrainedBytes != nil && drainedBytes > 0 {
+		backpressureDrainedBytes.Add(ctx, drainedBytes, opt)
+	}
+}
+
+// RecordBackpressureTail counts one completed wait into every tail bucket it
+// exceeds, so the shape of the tail is readable without percentiles, which
+// counter sums cannot express.
+func RecordBackpressureTail(ctx context.Context, volume string, elapsed time.Duration) {
+	instruments()
+	if backpressureSlowWaits == nil {
+		return
+	}
+	for _, t := range backpressureSlowThresholds {
+		if elapsed < t.limit {
+			continue
+		}
+		attrs := volumeAttrs(volume)
+		attrs = append(attrs, attribute.String("threshold", t.label))
+		backpressureSlowWaits.Add(ctx, 1, metric.WithAttributeSet(attribute.NewSet(attrs...)))
+	}
+}
+
+// volumeAttrs builds the common per-volume attribute slice, omitting the
+// attribute entirely when the volume is unnamed.
+func volumeAttrs(volume string) []attribute.KeyValue {
+	if volume == "" {
+		return nil
+	}
+	return []attribute.KeyValue{attribute.String("volume.name", volume)}
 }
 
 // RecordBackpressureLevels samples the two levels the gate compares: the

--- a/telemetry/metrics.go
+++ b/telemetry/metrics.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/mulgadc/bluebottle/pkg/safecast"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
@@ -37,6 +38,8 @@ var (
 
 	backpressureWaits       metric.Int64Counter
 	backpressureDurationSum metric.Float64Counter
+	backpressurePending     metric.Int64Gauge
+	backpressureHigh        metric.Int64Gauge
 
 	rmwConflicts  metric.Int64Counter
 	volumeOpens   metric.Int64Counter
@@ -145,6 +148,22 @@ func instruments() {
 		backpressureDurationSum, err = m.Float64Counter("viperblock.write.backpressure.duration.sum",
 			metric.WithDescription("Cumulative seconds guest writes spent blocked on backpressure, waiting for the backend to drain."),
 			metric.WithUnit("s"))
+		if err != nil {
+			otel.Handle(err)
+		}
+
+		// The two levels the gate compares. Both were previously inferable only
+		// from a wait count, which is how a wrong watermark went unnoticed
+		// across three runs; the gap between them is what a stalled write pays.
+		backpressurePending, err = m.Int64Gauge("viperblock.write.backpressure.pending_bytes",
+			metric.WithDescription("Buffered bytes not yet durable in a backend chunk, as the backpressure gate sees them. Approaching the high-watermark means the background uploader is not keeping up with the guest."),
+			metric.WithUnit("By"))
+		if err != nil {
+			otel.Handle(err)
+		}
+		backpressureHigh, err = m.Int64Gauge("viperblock.write.backpressure.high_watermark_bytes",
+			metric.WithDescription("Runtime high-watermark the gate blocks at, after the WAL-device free-space clamp. Not the 256MB default unless the device has room, so it must be read rather than assumed."),
+			metric.WithUnit("By"))
 		if err != nil {
 			otel.Handle(err)
 		}
@@ -312,6 +331,26 @@ func RecordWriteBackpressure(ctx context.Context, volume string, elapsed time.Du
 	}
 	if backpressureDurationSum != nil {
 		backpressureDurationSum.Add(ctx, elapsed.Seconds(), opt)
+	}
+}
+
+// RecordBackpressureLevels samples the two levels the gate compares: the
+// buffered bytes it watches and the runtime high-watermark it blocks at.
+// Sampled on the write path whether or not the write blocked, so a volume
+// tracking just under the watermark is visible before it starts stalling.
+func RecordBackpressureLevels(ctx context.Context, volume string, pending, high uint64) {
+	instruments()
+	var attrs []attribute.KeyValue
+	if volume != "" {
+		attrs = append(attrs, attribute.String("volume.name", volume))
+	}
+	opt := metric.WithAttributeSet(attribute.NewSet(attrs...))
+
+	if backpressurePending != nil {
+		backpressurePending.Record(ctx, safecast.Uint64ToInt64(pending), opt)
+	}
+	if backpressureHigh != nil {
+		backpressureHigh.Record(ctx, safecast.Uint64ToInt64(high), opt)
 	}
 }
 

--- a/viperblock/backpressure_stall_test.go
+++ b/viperblock/backpressure_stall_test.go
@@ -85,12 +85,13 @@ func TestAwaitBackpressureDeadlineHoldsWithConcurrentWriters(t *testing.T) {
 	vb.BackpressureStallTimeout = 500 * time.Millisecond
 	require.NoError(t, vb.WriteAt(0, make([]byte, blockSize)))
 
-	// Every checkpoint write fails from here on, and pendingBytes is pinned
-	// back above the low-watermark so no writer can escape by the gate
-	// releasing rather than by the deadline.
-	backend.genericFail.Store(true)
+	// Every chunk write fails from here on, and pendingBytes is pinned back
+	// above the low-watermark so no writer can escape by the gate releasing
+	// rather than by the deadline. The chunk write is what the guest stall
+	// path drives, now that the checkpoint has moved off it.
+	backend.chunkFail.Store(true)
 	backend.afterWrite = func(fileType types.FileType, _ error) {
-		if fileType == types.FileTypeBlockCheckpointLive {
+		if fileType == types.FileTypeChunk {
 			vb.pendingBytes.Store(int64(vb.maxPendingBytes()) * 4)
 		}
 	}

--- a/viperblock/checkpoint_off_guest_path_test.go
+++ b/viperblock/checkpoint_off_guest_path_test.go
@@ -1,0 +1,139 @@
+package viperblock
+
+import (
+	"context"
+	"testing"
+
+	"github.com/mulgadc/viperblock/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// countingVB opens a file-backed VB with the background uploader stopped and a
+// counting backend installed, so a test can attribute every backend write to
+// the call that made it.
+func countingVB(t *testing.T, name string) (*VB, *countingBackend) {
+	t.Helper()
+	vb := openEncryptedVBInDir(t, t.TempDir(), name, nil)
+	vb.StopChunkUploader()
+	t.Cleanup(func() { vb.StopWALSyncer() })
+
+	cb := &countingBackend{Backend: vb.Backend, counts: map[types.FileType]int{}}
+	vb.Backend = cb
+	return vb, cb
+}
+
+// TestDrainChunksWritesNoCheckpoint is the point of the split. The guest stall
+// path needs pendingBytes to fall, and rebuilding the whole block map does not
+// lower it, so a chunk drain must not touch the live checkpoint at all.
+func TestDrainChunksWritesNoCheckpoint(t *testing.T) {
+	vb, cb := countingVB(t, "drain-chunks-only")
+
+	data := make([]byte, vb.BlockSize)
+	for i := range 16 {
+		require.NoError(t, vb.WriteAt(uint64(i)*uint64(vb.BlockSize), data))
+	}
+
+	require.NoError(t, vb.DrainChunksCtx(context.Background()))
+
+	assert.Positive(t, cb.count(types.FileTypeChunk),
+		"a chunk drain must still upload the blocks it is draining")
+	assert.Equal(t, 0, cb.count(types.FileTypeBlockCheckpointLive),
+		"a chunk drain must not write the live checkpoint")
+}
+
+// TestDrainChunksLowersPendingBytes gates that the cheap half is the half that
+// actually releases a blocked writer. If this stopped being true, the guest
+// would spin in awaitBackpressure instead of stalling on the checkpoint.
+func TestDrainChunksLowersPendingBytes(t *testing.T) {
+	vb, _ := countingVB(t, "drain-chunks-pending")
+
+	data := make([]byte, vb.BlockSize)
+	for i := range 32 {
+		require.NoError(t, vb.WriteAt(uint64(i)*uint64(vb.BlockSize), data))
+	}
+	before := vb.PendingBytes()
+	require.Positive(t, before, "the writes must have registered as pending")
+
+	require.NoError(t, vb.DrainChunksCtx(context.Background()))
+
+	assert.Zero(t, vb.PendingBytes(),
+		"a chunk drain must release every byte it made durable, from %d", before)
+}
+
+// TestDrainChunksDefersWALReclaim is the durability half. Reclaim is gated on
+// the checkpoint, so a drain that skips the checkpoint must leave the WAL
+// generation on disk: it is the only record mapping those blocks until a
+// checkpoint names them.
+func TestDrainChunksDefersWALReclaim(t *testing.T) {
+	vb, _ := countingVB(t, "drain-chunks-reclaim")
+
+	data := make([]byte, vb.BlockSize)
+	for i := range 8 {
+		require.NoError(t, vb.WriteAt(uint64(i)*uint64(vb.BlockSize), data))
+	}
+
+	require.NoError(t, vb.DrainChunksCtx(context.Background()))
+
+	vb.pendingWALMu.Lock()
+	held := len(vb.consolidatedWALs)
+	vb.pendingWALMu.Unlock()
+	assert.Equal(t, 1, held, "a chunk drain must hold its generation, not reclaim it")
+
+	files, _ := walDirBytes(t, vb)
+	assert.GreaterOrEqual(t, files, 2,
+		"the consolidated generation must stay on disk alongside the open one")
+
+	// The full drain checkpoints, which is what makes the held generation
+	// redundant and releases it.
+	require.NoError(t, vb.DrainToBackendCtx(context.Background()))
+
+	vb.pendingWALMu.Lock()
+	remaining := len(vb.consolidatedWALs)
+	vb.pendingWALMu.Unlock()
+	assert.Zero(t, remaining, "the full drain must reclaim what the chunk drain held")
+}
+
+// TestFullDrainStillCheckpoints guards the callers that were deliberately left
+// on the full drain -- the background uploader, Close, snapshots and the nbd
+// entrypoints. Their semantics must be unchanged by the split.
+func TestFullDrainStillCheckpoints(t *testing.T) {
+	vb, cb := countingVB(t, "full-drain-checkpoint")
+
+	data := make([]byte, vb.BlockSize)
+	for i := range 8 {
+		require.NoError(t, vb.WriteAt(uint64(i)*uint64(vb.BlockSize), data))
+	}
+
+	require.NoError(t, vb.DrainToBackendCtx(context.Background()))
+
+	assert.Positive(t, cb.count(types.FileTypeChunk), "the full drain must upload chunks")
+	assert.Positive(t, cb.count(types.FileTypeBlockCheckpointLive),
+		"the full drain must still write the live checkpoint")
+}
+
+// TestReadsSurviveChunkOnlyDrain is the correctness gate on deferring the
+// checkpoint: blocks made durable by a chunk drain must still read back
+// through the WAL the drain deliberately did not reclaim.
+func TestReadsSurviveChunkOnlyDrain(t *testing.T) {
+	vb, _ := countingVB(t, "drain-chunks-readback")
+
+	blocks := 24
+	written := make([][]byte, blocks)
+	for i := range blocks {
+		buf := make([]byte, vb.BlockSize)
+		for j := range buf {
+			buf[j] = byte(i + 1)
+		}
+		written[i] = buf
+		require.NoError(t, vb.WriteAt(uint64(i)*uint64(vb.BlockSize), buf))
+	}
+
+	require.NoError(t, vb.DrainChunksCtx(context.Background()))
+
+	for i := range blocks {
+		got, err := vb.ReadAt(uint64(i)*uint64(vb.BlockSize), uint64(vb.BlockSize))
+		require.NoError(t, err, "block %d must be readable after a chunk-only drain", i)
+		assert.Equal(t, written[i], got, "block %d must be byte-identical", i)
+	}
+}

--- a/viperblock/enospc_test.go
+++ b/viperblock/enospc_test.go
@@ -40,6 +40,11 @@ type enospcBackend struct {
 	// being retried every drain round.
 	genericFail atomic.Bool
 
+	// chunkFail is the same idea scoped to FileTypeChunk. The guest stall
+	// path drains chunks only, so this is what makes a drain it drives fail
+	// persistently.
+	chunkFail atomic.Bool
+
 	// mu guards checkpointScript/checkpointScriptIdx below.
 	mu sync.Mutex
 
@@ -49,6 +54,11 @@ type enospcBackend struct {
 	// exhausted, checkpoint writes fall back to the genericFail toggle.
 	checkpointScript    []error
 	checkpointScriptIdx int
+
+	// chunkScript is the same mechanism for FileTypeChunk writes, which is
+	// what the guest stall path drives.
+	chunkScript    []error
+	chunkScriptIdx int
 
 	// afterWrite, if set, runs after every Write/WriteCtx call returns.
 	// Tests use it to pin vb.pendingBytes above the low-watermark so an
@@ -99,6 +109,27 @@ func (b *enospcBackend) dispatch(fileType types.FileType, doWrite func() error) 
 			return doWrite()
 		}
 		if b.genericFail.Load() {
+			return genericBackendErr()
+		}
+	}
+
+	if fileType == types.FileTypeChunk {
+		b.mu.Lock()
+		var scriptedErr error
+		scripted := b.chunkScriptIdx < len(b.chunkScript)
+		if scripted {
+			scriptedErr = b.chunkScript[b.chunkScriptIdx]
+			b.chunkScriptIdx++
+		}
+		b.mu.Unlock()
+
+		if scripted {
+			if scriptedErr != nil {
+				return scriptedErr
+			}
+			return doWrite()
+		}
+		if b.chunkFail.Load() {
 			return genericBackendErr()
 		}
 	}
@@ -585,9 +616,10 @@ func TestWriteAtRecoveryProbeDoesNotHangAgainstUnresponsiveBackend(t *testing.T)
 }
 
 // TestAwaitBackpressureBoundsConsecutiveNonNoSpaceFailures pins that a
-// backend persistently rejecting the checkpoint write with a non-ErrNoSpace
-// error does not keep awaitBackpressure spinning indefinitely: the volume's
-// stall deadline bounds it.
+// backend persistently rejecting the chunk write with a non-ErrNoSpace error
+// does not keep awaitBackpressure spinning indefinitely: the volume's stall
+// deadline bounds it. The chunk write is the backend write the guest stall
+// path drives, now that the checkpoint has moved off it.
 func TestAwaitBackpressureBoundsConsecutiveNonNoSpaceFailures(t *testing.T) {
 	vb, backend := newEnospcTestVB(t)
 	blockSize := uint64(vb.BlockSize)
@@ -597,13 +629,12 @@ func TestAwaitBackpressureBoundsConsecutiveNonNoSpaceFailures(t *testing.T) {
 	vb.BackpressureStallTimeout = 500 * time.Millisecond
 	require.NoError(t, vb.WriteAt(0, make([]byte, blockSize)))
 
-	// Every checkpoint write fails from here on. Pin pendingBytes back
-	// above the low-watermark after each attempt so it can't fall under it
-	// and let awaitBackpressure return nil, silently swallowing the
-	// checkpoint failure.
-	backend.genericFail.Store(true)
+	// Every chunk write fails from here on. Pin pendingBytes back above the
+	// low-watermark after each attempt so it can't fall under it and let
+	// awaitBackpressure return nil, silently swallowing the drain failure.
+	backend.chunkFail.Store(true)
 	backend.afterWrite = func(fileType types.FileType, err error) {
-		if fileType == types.FileTypeBlockCheckpointLive {
+		if fileType == types.FileTypeChunk {
 			vb.pendingBytes.Store(int64(vb.maxPendingBytes()) * 4)
 		}
 	}
@@ -640,31 +671,53 @@ func TestAwaitBackpressureFailureCounterResetsAfterInterleavedSuccess(t *testing
 	for range 27 {
 		script = append(script, genericBackendErr())
 	}
-	backend.checkpointScript = script
+	// Scripted on the chunk write: that is the backend write the guest stall
+	// path drives, so it is what decides whether a drain the blocked writer
+	// runs succeeds or fails.
+	backend.chunkScript = script
 
-	// Drive dirty/pendingBytes from an independent goroutine rather than the
-	// backend's afterWrite hook: SaveLiveCheckpointCtx clears
-	// BlocksToObject.dirty right after a successful write returns, which
-	// would clobber a redirty attempted from inside that same call. Ticking
-	// out-of-band mimics a concurrent guest write instead.
+	// Drive the volume from an independent goroutine rather than the backend's
+	// afterWrite hook, so it mimics concurrent guest writes rather than
+	// mutations made from inside the drain they are meant to outlive.
+	//
+	// Buffering a real block each tick is what keeps the script advancing: a
+	// chunk write only happens when a drain has something to consolidate, so
+	// pinning pendingBytes alone would leave the drain a no-op and the run of
+	// failures would never resume after the scripted success.
 	stop := make(chan struct{})
 	driverDone := make(chan struct{})
 	go func() {
 		defer close(driverDone)
 		ticker := time.NewTicker(20 * time.Millisecond)
 		defer ticker.Stop()
+		var block uint64 = 1024
 		for {
 			select {
 			case <-stop:
 				return
 			case <-ticker.C:
 				backend.mu.Lock()
-				exhausted := backend.checkpointScriptIdx >= len(backend.checkpointScript)
+				exhausted := backend.chunkScriptIdx >= len(backend.chunkScript)
 				backend.mu.Unlock()
 				if exhausted {
 					vb.pendingBytes.Store(0)
 					return
 				}
+
+				block++
+				seq, err := vb.reserveSeqNum(context.Background(), 1)
+				if err != nil {
+					return
+				}
+				vb.Writes.mu.Lock()
+				vb.Writes.Blocks = append(vb.Writes.Blocks, Block{
+					SeqNum: seq + 1,
+					Block:  block,
+					Len:    uint64(vb.BlockSize),
+					Data:   make([]byte, vb.BlockSize),
+				})
+				vb.Writes.mu.Unlock()
+
 				vb.BlocksToObject.dirty.Store(true)
 				vb.pendingBytes.Store(int64(vb.maxPendingBytes()) * 4)
 			}

--- a/viperblock/viperblock.go
+++ b/viperblock/viperblock.go
@@ -273,6 +273,11 @@ type VB struct {
 	// chunk upload failed. Retried at the head of the next consolidation so
 	// the data is not stranded in-process until the next restart.
 	pendingWALChunks []uint64
+
+	// consolidatedWALs holds generations whose blocks are durable as backend
+	// chunks but are not yet named by a persisted checkpoint. Until one lands
+	// the local WAL is the only record that maps them, so they stay on disk.
+	consolidatedWALs []uint64
 	pendingWALMu     sync.Mutex
 
 	// drainMu serializes DrainToBackendCtx across all its triggers. Two
@@ -2646,6 +2651,12 @@ func (vb *VB) DrainToBackendCtx(ctx context.Context) (err error) {
 	if err = vb.SaveLiveCheckpointCtx(ctx); err != nil {
 		return fmt.Errorf("drain live checkpoint: %w", err)
 	}
+
+	// The checkpoint naming these generations' blocks is now durable, so their
+	// local WAL files are redundant. A no-op checkpoint (nothing dirty) still
+	// means the persisted one is current, so it releases them too.
+	vb.reclaimConsolidatedWALs()
+
 	return nil
 }
 
@@ -3284,6 +3295,7 @@ func (vb *VB) WriteShardedWALToChunkCtx(ctx context.Context, force bool) error {
 		vb.pendingWALMu.Unlock()
 		return err
 	}
+	vb.markWALConsolidated(currentWALNum)
 
 	return nil
 }
@@ -3452,6 +3464,7 @@ func (vb *VB) retryPendingWALChunks(ctx context.Context, consolidate func(contex
 		if err := consolidate(ctx, walNum); err != nil {
 			return err
 		}
+		vb.markWALConsolidated(walNum)
 
 		// Drop the entry only after a successful consolidation. Re-check the
 		// head in case a concurrent caller already removed it.
@@ -3460,6 +3473,51 @@ func (vb *VB) retryPendingWALChunks(ctx context.Context, consolidate func(contex
 			vb.pendingWALChunks = vb.pendingWALChunks[1:]
 		}
 		vb.pendingWALMu.Unlock()
+	}
+}
+
+// markWALConsolidated records a generation whose blocks are now durable as
+// backend chunks. It becomes reclaimable once a checkpoint naming them lands.
+func (vb *VB) markWALConsolidated(walNum uint64) {
+	vb.pendingWALMu.Lock()
+	vb.consolidatedWALs = append(vb.consolidatedWALs, walNum)
+	vb.pendingWALMu.Unlock()
+}
+
+// walGenerationFiles returns the local files holding generation walNum: one on
+// the single-file WAL, one per shard on the sharded WAL.
+func (vb *VB) walGenerationFiles(walNum uint64) []string {
+	if vb.UseShardedWAL && vb.ShardedWAL != nil {
+		paths := make([]string, 0, NumShards)
+		for shardID := range NumShards {
+			paths = append(paths, filepath.Join(vb.ShardedWAL.BaseDir,
+				types.GetShardedWALPath(vb.GetVolume(), walNum, shardID)))
+		}
+		return paths
+	}
+	return []string{filepath.Join(vb.WAL.BaseDir,
+		types.GetFilePath(types.FileTypeWALChunk, walNum, vb.GetVolume()))}
+}
+
+// reclaimConsolidatedWALs deletes the local WAL files of every generation
+// consolidated since the last checkpoint. Call only once SaveLiveCheckpointCtx
+// has succeeded: before that the WAL is the only record mapping those blocks.
+//
+// A failed unlink is logged, not returned. RecoverLocalWALs replays a leftover
+// harmlessly on the next open, so it costs space rather than correctness, and
+// failing an otherwise clean drain over it would be the worse trade.
+func (vb *VB) reclaimConsolidatedWALs() {
+	vb.pendingWALMu.Lock()
+	reclaim := vb.consolidatedWALs
+	vb.consolidatedWALs = nil
+	vb.pendingWALMu.Unlock()
+
+	for _, walNum := range reclaim {
+		for _, path := range vb.walGenerationFiles(walNum) {
+			if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+				vb.logger().Warn("failed to reclaim consolidated WAL file", "file", path, "error", err)
+			}
+		}
 	}
 }
 
@@ -3536,6 +3594,7 @@ func (vb *VB) WriteWALToChunkCtx(ctx context.Context, force bool) (err error) {
 		vb.pendingWALMu.Unlock()
 		return err
 	}
+	vb.markWALConsolidated(currentWALNum)
 
 	return nil
 }

--- a/viperblock/viperblock.go
+++ b/viperblock/viperblock.go
@@ -2101,8 +2101,12 @@ func (vb *VB) awaitBackpressure(ctx context.Context) error {
 	// than function entry: recording the unblocked case would leave a mean
 	// dominated by zeros and hide the stall it exists to show.
 	stalledSince := time.Now()
+	releaseWaiter := telemetry.BackpressureWaiterScope(ctx, vb.VolumeName)
 	defer func() {
-		telemetry.RecordWriteBackpressure(context.Background(), vb.VolumeName, time.Since(stalledSince))
+		releaseWaiter()
+		waited := time.Since(stalledSince)
+		telemetry.RecordWriteBackpressure(context.Background(), vb.VolumeName, waited)
+		telemetry.RecordBackpressureTail(context.Background(), vb.VolumeName, waited)
 	}()
 
 	low := high - high/backpressureLowFraction
@@ -2131,8 +2135,21 @@ func (vb *VB) awaitBackpressure(ctx context.Context) error {
 			// Chunks only: the checkpoint and the sweep do not lower
 			// pendingBytes, so charging them to a stalled guest write buys
 			// nothing and costs most of the wait.
+			drainStarted := time.Now()
+			pendingBefore := vb.PendingBytes()
 			err := vb.DrainChunksCtx(ctx)
+			pendingAfter := vb.PendingBytes()
 			vb.drainInFlight.Store(false)
+
+			// Guest writes keep arriving during the drain, so this is the NET
+			// fall in pendingBytes, not the bytes uploaded. That is the rate
+			// the watermark gap is really divided by.
+			var freed int64
+			if pendingAfter < pendingBefore {
+				freed = safecast.Uint64ToInt64(pendingBefore - pendingAfter)
+			}
+			telemetry.RecordBackpressurePhase(ctx, vb.VolumeName, "drain",
+				time.Since(drainStarted), freed)
 			if err != nil {
 				if errors.Is(err, ErrNoSpace) {
 					return err
@@ -2157,11 +2174,14 @@ func (vb *VB) awaitBackpressure(ctx context.Context) error {
 			}
 		}
 
+		pollStarted := time.Now()
 		select {
 		case <-time.After(backoff):
 		case <-ctx.Done():
 			return ctx.Err()
 		}
+		telemetry.RecordBackpressurePhase(ctx, vb.VolumeName, "poll", time.Since(pollStarted), 0)
+
 		if backoff < maxBackoff {
 			backoff *= 2
 		}

--- a/viperblock/viperblock.go
+++ b/viperblock/viperblock.go
@@ -269,6 +269,11 @@ type VB struct {
 	// DrainToBackendCtx's deferred handler for where it is set and cleared.
 	backendFull atomic.Bool
 
+	// bpWaiters counts guest writes currently blocked in awaitBackpressure.
+	// Non-zero closes the gate's fast path, which is what stops an arriving
+	// write from overtaking one already queued. See awaitBackpressure.
+	bpWaiters atomic.Int64
+
 	// pendingWALChunks holds WAL generations that were rotated out but whose
 	// chunk upload failed. Retried at the head of the next consolidation so
 	// the data is not stranded in-process until the next restart.
@@ -2093,9 +2098,20 @@ func (vb *VB) awaitBackpressure(ctx context.Context) error {
 	high := vb.maxPendingBytes()
 	pending := vb.PendingBytes()
 	telemetry.RecordBackpressureLevels(ctx, vb.VolumeName, pending, high)
-	if pending <= high {
+
+	// The fast path is closed while anyone is queued. WriteAtCtx buffers
+	// before it gets here, so an arriving write has already pushed
+	// pendingBytes back up; letting it through would refill what a waiter is
+	// waiting to see fall, and the waiter loses its place to a later arrival.
+	// That starvation, not backend throughput, is what makes the tail: at a
+	// fixed drain rate, going from 1 to 16 writers left throughput unchanged
+	// and multiplied p99 stall by ten.
+	if pending <= high && vb.bpWaiters.Load() == 0 {
 		return nil
 	}
+
+	vb.bpWaiters.Add(1)
+	defer vb.bpWaiters.Add(-1)
 
 	// Past the fast path the guest write is stalled, so time from here rather
 	// than function entry: recording the unblocked case would leave a mean
@@ -2110,10 +2126,12 @@ func (vb *VB) awaitBackpressure(ctx context.Context) error {
 	}()
 
 	low := high - high/backpressureLowFraction
-	backoff := 10 * time.Millisecond
-	// The loop re-checks pendingBytes on every wake, so a long backoff only
-	// adds latency after the drain that unblocked the writer has finished.
-	const maxBackoff = 50 * time.Millisecond
+	backoff := time.Millisecond
+	// Capped low and reset after every drain. The old 10-50ms doubling was
+	// pure latency added after the drain that released the writer had already
+	// finished, and it never reset within a wait, so a writer that lost one
+	// race waited longer on each subsequent one.
+	const maxBackoff = 5 * time.Millisecond
 
 	// Bound a persistently failing drain by how long it has been failing, on
 	// the volume. A single success clears it, so transient backend slowness
@@ -2172,6 +2190,9 @@ func (vb *VB) awaitBackpressure(ctx context.Context) error {
 			if vb.PendingBytes() <= low {
 				break
 			}
+			// A drain just ran, so the next re-check is worth making promptly
+			// rather than at whatever the backoff had grown to.
+			backoff = time.Millisecond
 		}
 
 		pollStarted := time.Now()

--- a/viperblock/viperblock.go
+++ b/viperblock/viperblock.go
@@ -285,7 +285,16 @@ type VB struct {
 	// createChunkFile, where an older segment landing last can clobber a
 	// newer chunk's live pointer and let GC delete a still-referenced chunk.
 	// createChunkFile's SeqNum guard is a secondary defense, not a substitute.
+	//
+	// It covers WAL rotation and chunk upload only. The checkpoint is under
+	// checkpointMu instead, so a guest write blocked on backpressure never
+	// queues behind one.
 	drainMu sync.Mutex
+
+	// checkpointMu serializes the live checkpoint and the WAL reclaim gated on
+	// it. Held for the whole map serialization and backend write, which is
+	// long, so it deliberately does not overlap drainMu.
+	checkpointMu sync.Mutex
 
 	// flushMu serialises flushWrites. Writes.mu used to do this implicitly by
 	// being held across the whole WAL write, which also blocked every guest
@@ -2082,7 +2091,9 @@ func (vb *VB) signalSizeTrigger() {
 // triggered this wait.
 func (vb *VB) awaitBackpressure(ctx context.Context) error {
 	high := vb.maxPendingBytes()
-	if vb.PendingBytes() <= high {
+	pending := vb.PendingBytes()
+	telemetry.RecordBackpressureLevels(ctx, vb.VolumeName, pending, high)
+	if pending <= high {
 		return nil
 	}
 
@@ -2117,7 +2128,10 @@ func (vb *VB) awaitBackpressure(ctx context.Context) error {
 		}
 
 		if vb.drainInFlight.CompareAndSwap(false, true) {
-			err := vb.DrainToBackendCtx(ctx)
+			// Chunks only: the checkpoint and the sweep do not lower
+			// pendingBytes, so charging them to a stalled guest write buys
+			// nothing and costs most of the wait.
+			err := vb.DrainChunksCtx(ctx)
 			vb.drainInFlight.Store(false)
 			if err != nil {
 				if errors.Is(err, ErrNoSpace) {
@@ -2231,9 +2245,9 @@ func (vb *VB) isBackendNearFull() bool {
 	return ok && nf.NearFull()
 }
 
-// probeBackendRecovery drives a real DrainToBackendCtx while backendFull is
-// latched and reports whether the latch cleared, so a retried write can
-// observe recovery immediately instead of waiting for the next drain tick.
+// probeBackendRecovery drives a real chunk drain while backendFull is latched
+// and reports whether the latch cleared, so a retried write can observe
+// recovery immediately instead of waiting for the next drain tick.
 func (vb *VB) probeBackendRecovery(ctx context.Context) bool {
 	// One write drives the probe at a time; concurrent writers fail fast
 	// rather than queuing on drainMu behind a possibly slow backend.
@@ -2248,10 +2262,11 @@ func (vb *VB) probeBackendRecovery(ctx context.Context) bool {
 	probeCtx, cancel := context.WithTimeout(ctx, vb.recoveryProbeTimeout())
 	defer cancel()
 
-	// Gated on a real upload+checkpoint round trip, not a cached threshold,
-	// so a clean result can't flap: it reports exactly what the backend just
-	// did. A timed-out or failed probe leaves the latch set.
-	if err := vb.DrainToBackendCtx(probeCtx); err != nil {
+	// Gated on a real chunk upload, not a cached threshold, so a clean result
+	// can't flap: it reports exactly what the backend just did. The checkpoint
+	// would add no signal, since ErrNoSpace latches on the chunk write either
+	// way. A timed-out or failed probe leaves the latch set.
+	if err := vb.DrainChunksCtx(probeCtx); err != nil {
 		return false
 	}
 	return !vb.backendFull.Load()
@@ -2611,35 +2626,93 @@ func (vb *VB) DrainToBackend() error {
 // DrainToBackendCtx is DrainToBackend with a caller-supplied context threaded
 // through the chunk-upload and checkpoint S3 writes.
 func (vb *VB) DrainToBackendCtx(ctx context.Context) (err error) {
+	// Every drain path funnels through here, so this is the single choke
+	// point for the backendFull latch: an out-of-space error anywhere in
+	// the drain sets it, and a clean completion clears it.
+	defer vb.latchBackendFull(&err)
+
+	// The two halves take different locks and are no longer one critical
+	// section. That is the point: a guest write blocked on backpressure needs
+	// only the first, and must not queue behind the second.
+	if err = vb.drainChunks(ctx); err != nil {
+		return err
+	}
+	if err = vb.checkpointAndReclaim(ctx); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// latchBackendFull sets or clears the out-of-space latch from a drain's
+// outcome. Deferred with a pointer to the caller's named error return.
+func (vb *VB) latchBackendFull(err *error) {
+	if *err != nil {
+		if errors.Is(*err, ErrNoSpace) {
+			// Log only the false→true edge (Swap returns the prior value) so a
+			// persistently full backend does not repeat the line on every drain
+			// attempt. This is the signal that guest writes are now failing fast.
+			if !vb.backendFull.Swap(true) {
+				vb.logger().Warn("backend out of space: latching writes off until a drain succeeds", "err", *err)
+			}
+		}
+		return
+	}
+	// A clean drain clears the latch; log only the true→false recovery edge.
+	if vb.backendFull.Swap(false) {
+		vb.logger().Info("backend space recovered: drain succeeded, writes re-enabled")
+	}
+}
+
+// drainChunks runs the chunk half under drainMu.
+func (vb *VB) drainChunks(ctx context.Context) error {
 	// Serialize every drain trigger — see drainMu's doc comment for why
 	// overlapping drains are unsafe.
 	vb.drainMu.Lock()
 	defer vb.drainMu.Unlock()
 
-	// Every drain path funnels through here, so this is the single choke
-	// point for the backendFull latch: an out-of-space error anywhere in
-	// the drain sets it, and a clean completion clears it.
-	defer func() {
-		if err != nil {
-			if errors.Is(err, ErrNoSpace) {
-				// Log only the false→true edge (Swap returns the prior value) so a
-				// persistently full backend does not repeat the line on every drain
-				// attempt. This is the signal that guest writes are now failing fast.
-				if !vb.backendFull.Swap(true) {
-					vb.logger().Warn("backend out of space: latching writes off until a drain succeeds", "err", err)
-				}
-			}
-			return
-		}
-		// A clean drain clears the latch; log only the true→false recovery edge.
-		if vb.backendFull.Swap(false) {
-			vb.logger().Info("backend space recovered: drain succeeded, writes re-enabled")
-		}
-	}()
+	return vb.drainChunksLocked(ctx)
+}
 
-	if err = vb.Flush(); err != nil {
+// checkpointAndReclaim persists the block map, then deletes the local WAL
+// generations that map is now responsible for. Under checkpointMu, not
+// drainMu, so a concurrent chunk drain is free to proceed.
+//
+// The reclaim candidates are taken before the checkpoint reads the map, so a
+// generation consolidated while the checkpoint is in flight is held back for
+// the next one rather than deleted by a checkpoint that never named it. On
+// failure they go back on the list.
+func (vb *VB) checkpointAndReclaim(ctx context.Context) error {
+	vb.checkpointMu.Lock()
+	defer vb.checkpointMu.Unlock()
+
+	reclaim := vb.takeConsolidatedWALs()
+
+	if err := vb.SaveLiveCheckpointCtx(ctx); err != nil {
+		vb.restoreConsolidatedWALs(reclaim)
+		return fmt.Errorf("drain live checkpoint: %w", err)
+	}
+
+	// The checkpoint naming these generations' blocks is now durable, so their
+	// local WAL files are redundant. A no-op checkpoint (nothing dirty) still
+	// means the persisted one is current, so it releases them too.
+	vb.reclaimWALGenerations(reclaim)
+
+	return nil
+}
+
+// drainChunksLocked is the half of the drain that lowers pendingBytes: flush
+// the write buffer into the WAL, then consolidate WAL generations into backend
+// chunks. createChunkFile is what decrements the counter, so this alone is
+// enough to release a writer blocked on backpressure.
+//
+// Caller must hold drainMu.
+func (vb *VB) drainChunksLocked(ctx context.Context) error {
+	if err := vb.Flush(); err != nil {
 		return fmt.Errorf("drain flush: %w", err)
 	}
+
+	var err error
 	if vb.UseShardedWAL {
 		err = vb.WriteShardedWALToChunkCtx(ctx, true)
 	} else {
@@ -2648,16 +2721,23 @@ func (vb *VB) DrainToBackendCtx(ctx context.Context) (err error) {
 	if err != nil {
 		return fmt.Errorf("drain chunk upload: %w", err)
 	}
-	if err = vb.SaveLiveCheckpointCtx(ctx); err != nil {
-		return fmt.Errorf("drain live checkpoint: %w", err)
-	}
-
-	// The checkpoint naming these generations' blocks is now durable, so their
-	// local WAL files are redundant. A no-op checkpoint (nothing dirty) still
-	// means the persisted one is current, so it releases them too.
-	vb.reclaimConsolidatedWALs()
-
 	return nil
+}
+
+// DrainChunksCtx is DrainToBackendCtx without the checkpoint, the GC sweep or
+// the WAL reclaim that depends on the checkpoint. It exists for the guest
+// stall path: a blocked write only needs pendingBytes to fall, and rebuilding
+// the whole block map is the most expensive phase of the drain by a wide
+// margin, so making the guest wait on it is the stall.
+//
+// Blocks stay durable throughout. Their bytes are in a backend chunk and the
+// local WAL generation naming them is still on disk, because reclaim is gated
+// on the checkpoint that has not run yet. RecoverLocalWALs replays exactly
+// those generations, so a crash here loses nothing.
+func (vb *VB) DrainChunksCtx(ctx context.Context) (err error) {
+	defer vb.latchBackendFull(&err)
+
+	return vb.drainChunks(ctx)
 }
 
 // flushSnapshot flushes a snapshot of the hot writes to the WAL. It does not
@@ -3499,19 +3579,39 @@ func (vb *VB) walGenerationFiles(walNum uint64) []string {
 		types.GetFilePath(types.FileTypeWALChunk, walNum, vb.GetVolume()))}
 }
 
-// reclaimConsolidatedWALs deletes the local WAL files of every generation
-// consolidated since the last checkpoint. Call only once SaveLiveCheckpointCtx
-// has succeeded: before that the WAL is the only record mapping those blocks.
+// takeConsolidatedWALs removes and returns the generations consolidated since
+// the last checkpoint. Called before the checkpoint reads the block map, so
+// everything it returns is already mapped in what that checkpoint will write.
+func (vb *VB) takeConsolidatedWALs() []uint64 {
+	vb.pendingWALMu.Lock()
+	defer vb.pendingWALMu.Unlock()
+
+	reclaim := vb.consolidatedWALs
+	vb.consolidatedWALs = nil
+	return reclaim
+}
+
+// restoreConsolidatedWALs puts candidates back after a failed checkpoint,
+// ahead of anything consolidated since, so generation order is preserved.
+func (vb *VB) restoreConsolidatedWALs(reclaim []uint64) {
+	if len(reclaim) == 0 {
+		return
+	}
+
+	vb.pendingWALMu.Lock()
+	defer vb.pendingWALMu.Unlock()
+
+	vb.consolidatedWALs = append(reclaim, vb.consolidatedWALs...)
+}
+
+// reclaimWALGenerations deletes the local WAL files of the given generations.
+// Call only once SaveLiveCheckpointCtx has succeeded: before that the WAL is
+// the only record mapping those blocks.
 //
 // A failed unlink is logged, not returned. RecoverLocalWALs replays a leftover
 // harmlessly on the next open, so it costs space rather than correctness, and
 // failing an otherwise clean drain over it would be the worse trade.
-func (vb *VB) reclaimConsolidatedWALs() {
-	vb.pendingWALMu.Lock()
-	reclaim := vb.consolidatedWALs
-	vb.consolidatedWALs = nil
-	vb.pendingWALMu.Unlock()
-
+func (vb *VB) reclaimWALGenerations(reclaim []uint64) {
 	for _, walNum := range reclaim {
 		for _, path := range vb.walGenerationFiles(walNum) {
 			if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
@@ -4704,10 +4804,33 @@ func (vb *VB) SaveLiveCheckpoint() error {
 }
 
 // SaveLiveCheckpointCtx is SaveLiveCheckpoint with a caller-supplied context.
-func (vb *VB) SaveLiveCheckpointCtx(ctx context.Context) error {
+func (vb *VB) SaveLiveCheckpointCtx(ctx context.Context) (err error) {
 	if !vb.BlocksToObject.dirty.Load() {
 		return nil
 	}
+
+	// Timed as a WAL phase alongside flush and consolidate. Without this the
+	// third phase of the drain is invisible, and a stall it dominates gets
+	// attributed to whichever phase happens to be measured.
+	start := time.Now()
+	defer func() {
+		outcome := "success"
+		if err != nil {
+			outcome = "error"
+		}
+		telemetry.RecordWALOp(context.Background(), "checkpoint", vb.VolumeName, outcome, time.Since(start))
+	}()
+
+	// Cleared before the snapshot, not after the write. This no longer runs
+	// under drainMu, so a chunk upload can install new mappings while the write
+	// is in flight; clearing afterwards would mark those persisted when they
+	// are not. Clearing first can only cost a redundant checkpoint next drain.
+	vb.BlocksToObject.dirty.Store(false)
+	defer func() {
+		if err != nil {
+			vb.BlocksToObject.dirty.Store(true)
+		}
+	}()
 
 	// Serialize the map under the read lock, then release before doing I/O so
 	// the lock is not held across network writes or retry sleeps.
@@ -4724,25 +4847,25 @@ func (vb *VB) SaveLiveCheckpointCtx(ctx context.Context) error {
 
 	headers := []byte{}
 	backoff := vb.checkpointBackoff()
-	var err error
 	for attempt := range 3 {
 		err = vb.Backend.WriteCtx(ctx, types.FileTypeBlockCheckpointLive, 0, &headers, &checkpoint)
 		if err == nil {
-			vb.BlocksToObject.dirty.Store(false)
 			return nil
 		}
 		if attempt < 2 {
 			slog.WarnContext(ctx, "SaveLiveCheckpoint: write failed, retrying",
-				"attempt", attempt+1, "backoff", backoff, "err", err)
+				"attempt", attempt+1, "backoff_ms", backoff.Milliseconds(), "err", err)
 			select {
 			case <-time.After(backoff):
 			case <-ctx.Done():
-				return ctx.Err()
+				err = ctx.Err()
+				return err
 			}
 			backoff *= 2
 		}
 	}
-	return fmt.Errorf("SaveLiveCheckpoint: failed after retries: %w", err)
+	err = fmt.Errorf("SaveLiveCheckpoint: failed after retries: %w", err)
+	return err
 }
 
 // LoadLiveCheckpoint reads the live checkpoint written by SaveLiveCheckpoint. If no

--- a/viperblock/wal_reclaim_test.go
+++ b/viperblock/wal_reclaim_test.go
@@ -1,0 +1,203 @@
+package viperblock
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/mulgadc/viperblock/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// walDirBytes returns the file count and total size of a volume's local WAL
+// directory, the space that grew 1:1 with guest writes before reclaim existed.
+func walDirBytes(t *testing.T, vb *VB) (int, int64) {
+	t.Helper()
+	baseDir := vb.WAL.BaseDir
+	if vb.UseShardedWAL && vb.ShardedWAL != nil {
+		baseDir = vb.ShardedWAL.BaseDir
+	}
+	dir := filepath.Join(baseDir, vb.GetVolume(), "wal", "chunks")
+
+	entries, err := os.ReadDir(dir)
+	if os.IsNotExist(err) {
+		return 0, 0
+	}
+	require.NoError(t, err)
+
+	var total int64
+	for _, e := range entries {
+		info, err := e.Info()
+		require.NoError(t, err)
+		total += info.Size()
+	}
+	return len(entries), total
+}
+
+// TestWALReclaimBoundsLocalGrowth is the regression gate. A consolidated WAL
+// generation whose blocks are named by a durable checkpoint is redundant, but
+// nothing deleted it: 128 MiB of guest writes left 128.9 MiB of WAL on disk
+// across 9 files. That filled the WAL device, which collapsed the
+// maxPendingBytes window onto its floor and multiplied drain frequency.
+func TestWALReclaimBoundsLocalGrowth(t *testing.T) {
+	runWithBackends(t, "wal_reclaim_growth", func(t *testing.T, vb *VB) {
+		data := make([]byte, vb.BlockSize)
+		block := 0
+
+		// One generation per round: DrainToBackendCtx consolidates with
+		// force=true, so every round rotates whatever it wrote.
+		const rounds = 6
+		const blocksPerRound = 64
+
+		var firstFiles int
+		var firstBytes int64
+
+		for round := range rounds {
+			for range blocksPerRound {
+				require.NoError(t, vb.WriteAt(uint64(block)*uint64(vb.BlockSize), data))
+				block++
+			}
+			require.NoError(t, vb.DrainToBackendCtx(context.Background()))
+
+			files, bytes := walDirBytes(t, vb)
+			if round == 0 {
+				firstFiles, firstBytes = files, bytes
+				continue
+			}
+			// Only the current open generation may remain, so the directory
+			// must not grow with the number of rounds.
+			assert.LessOrEqual(t, files, firstFiles,
+				"round %d: WAL file count grew, consolidated generations are not being reclaimed", round)
+			assert.LessOrEqual(t, bytes, firstBytes,
+				"round %d: WAL bytes grew, consolidated generations are not being reclaimed", round)
+		}
+	})
+}
+
+// TestWALReclaimSkipsStrandedGeneration gates the ordering that makes reclaim
+// safe. A generation whose chunk upload failed holds the only copy of its
+// blocks, so it must stay on disk for retryPendingWALChunks even though a
+// later drain succeeds and reclaims its own generation.
+func TestWALReclaimSkipsStrandedGeneration(t *testing.T) {
+	dir := t.TempDir()
+	vb := openEncryptedVBInDir(t, dir, "reclaim-stranded", nil)
+	vb.StopChunkUploader()
+	t.Cleanup(func() { vb.StopWALSyncer() })
+
+	eb := &errBackend{Backend: vb.Backend, failType: types.FileTypeChunk, failN: 1}
+	vb.Backend = eb
+
+	data := make([]byte, vb.BlockSize)
+	require.NoError(t, vb.WriteAt(0, data))
+
+	// The chunk upload fails, so the generation is stranded, not consolidated.
+	require.Error(t, vb.DrainToBackendCtx(context.Background()),
+		"a failed chunk upload must fail the drain")
+
+	vb.pendingWALMu.Lock()
+	strandedCount := len(vb.pendingWALChunks)
+	consolidatedCount := len(vb.consolidatedWALs)
+	vb.pendingWALMu.Unlock()
+
+	assert.Equal(t, 1, strandedCount, "the failed generation must be queued for retry")
+	assert.Equal(t, 0, consolidatedCount, "a stranded generation must never be marked consolidated")
+
+	files, _ := walDirBytes(t, vb)
+	assert.GreaterOrEqual(t, files, 2, "the stranded generation must stay on disk alongside the open one")
+}
+
+// TestWALReclaimDeferredUntilCheckpointLands gates the other half of the
+// ordering. Until the checkpoint naming a generation's blocks is durable the
+// local WAL is the only record that maps them, so a failed checkpoint must
+// leave the file alone and the next successful one must release it.
+func TestWALReclaimDeferredUntilCheckpointLands(t *testing.T) {
+	dir := t.TempDir()
+	vb := openEncryptedVBInDir(t, dir, "reclaim-deferred", nil)
+	vb.StopChunkUploader()
+	vb.checkpointRetryBackoff = time.Microsecond
+	t.Cleanup(func() { vb.StopWALSyncer() })
+
+	// SaveLiveCheckpointCtx retries three times internally, so exhaust them.
+	eb := &errBackend{Backend: vb.Backend, failType: types.FileTypeBlockCheckpointLive, failN: 3}
+	vb.Backend = eb
+
+	data := make([]byte, vb.BlockSize)
+	require.NoError(t, vb.WriteAt(0, data))
+
+	require.Error(t, vb.DrainToBackendCtx(context.Background()),
+		"a checkpoint that exhausts its retries must fail the drain")
+
+	vb.pendingWALMu.Lock()
+	held := len(vb.consolidatedWALs)
+	vb.pendingWALMu.Unlock()
+	assert.Equal(t, 1, held, "the consolidated generation must be held until a checkpoint lands")
+
+	filesBefore, _ := walDirBytes(t, vb)
+	assert.GreaterOrEqual(t, filesBefore, 2,
+		"the consolidated generation must stay on disk while the checkpoint is stale")
+
+	// The injected failures are spent; this drain checkpoints cleanly.
+	require.NoError(t, vb.WriteAt(uint64(vb.BlockSize), data))
+	require.NoError(t, vb.DrainToBackendCtx(context.Background()))
+
+	vb.pendingWALMu.Lock()
+	remaining := len(vb.consolidatedWALs)
+	vb.pendingWALMu.Unlock()
+	assert.Equal(t, 0, remaining, "a durable checkpoint must release every held generation")
+
+	filesAfter, _ := walDirBytes(t, vb)
+	assert.Less(t, filesAfter, filesBefore,
+		"the held generations must be reclaimed once the checkpoint is durable")
+}
+
+// TestReclaimedWALStillReadsFromCheckpoint is the durability half: reclaim is
+// only correct if the checkpoint that released a generation can rebuild its
+// block map without it. A reader with no WAL of its own must see the data.
+func TestReclaimedWALStillReadsFromCheckpoint(t *testing.T) {
+	dir := t.TempDir()
+	vb := openEncryptedVBInDir(t, dir, "reclaim-durable", nil)
+	vb.StopChunkUploader()
+	t.Cleanup(func() { vb.StopWALSyncer() })
+
+	blocks := 32
+	written := make([][]byte, blocks)
+	for i := range blocks {
+		buf := make([]byte, vb.BlockSize)
+		for j := range buf {
+			buf[j] = byte(i + 1)
+		}
+		written[i] = buf
+		require.NoError(t, vb.WriteAt(uint64(i)*uint64(vb.BlockSize), buf))
+	}
+
+	require.NoError(t, vb.DrainToBackendCtx(context.Background()))
+
+	vb.pendingWALMu.Lock()
+	remaining := len(vb.consolidatedWALs)
+	vb.pendingWALMu.Unlock()
+	require.Equal(t, 0, remaining, "the drain must have reclaimed its generation")
+
+	reader := &VB{
+		VolumeName:   vb.VolumeName,
+		VolumeSize:   vb.VolumeSize,
+		BlockSize:    vb.BlockSize,
+		ObjBlockSize: vb.ObjBlockSize,
+		Version:      vb.Version,
+		BaseDir:      vb.BaseDir,
+		Backend:      vb.Backend,
+		BlockToObjectWAL: WAL{
+			WALMagic: vb.BlockToObjectWAL.WALMagic,
+		},
+		BlocksToObject: BlocksToObject{},
+	}
+	require.NoError(t, reader.LoadLiveCheckpoint())
+
+	for i := range blocks {
+		got, err := reader.ReadAt(uint64(i)*uint64(vb.BlockSize), uint64(vb.BlockSize))
+		require.NoError(t, err, "block %d must still be readable after its WAL was reclaimed", i)
+		assert.Equal(t, written[i], got, "block %d must be byte-identical after reclaim", i)
+	}
+}


### PR DESCRIPTION
Stacked on #92 (`feat/wal-generation-reclaim`). Review that one first; this branch contains its commit.

## Problem

A guest write blocked on backpressure only needs `pendingBytes` to fall, and `createChunkFile` is what lowers it. `SaveLiveCheckpointCtx` does not lower it at all — yet the blocked writer drove a full `DrainToBackendCtx` and paid for the checkpoint too.

`RecordWALOp` already timed the `flush` and `consolidate` phases. The checkpoint, the third phase, was not timed at all. Cell-25 run `34089435511`, env3:

| volume | flush | consolidate | stall recorded |
|---|---|---|---|
| `vol-09c1f073` (control plane) | 31.17 s / 9122 ops = 3.4 ms | 8.24 s / 36 ops = 229 ms | 14 waits / 40.25 s |
| `vol-188f912f` | 26.53 s / 2830 ops = 9.4 ms | 16.55 s / 54 ops = 306 ms | 13 waits |

`Flush` also runs on the 200 ms WAL syncer tick, which is why its op count is in the thousands; the drain's own share is 36 flushes at 3.4 ms, about 0.12 s. So flush plus consolidate account for **8.4 s of the 40.25 s** that volume spent stalled, and `awaitBackpressure`'s poll backoff caps at 50 ms. The checkpoint is the rest.

It is not a bytes problem: 7 MiB of checkpoint against 229 ms of chunk upload for ~64 MiB is not throughput-bound. It is `expandBlockLookup` building a 34-byte record per block for every block the volume has ever written, under `BlocksToObject`'s RLock, on every drain.

## Change

Split the drain:

- `drainChunks` — flush plus WAL-to-chunk upload, under `drainMu`.
- `checkpointAndReclaim` — `SaveLiveCheckpointCtx` then the WAL reclaim gated on it, under a new `checkpointMu`.
- `DrainToBackendCtx` — both halves in order, semantics unchanged for every current caller.

`awaitBackpressure` and `probeBackendRecovery` take `DrainChunksCtx`. The background uploader, `Close`, the snapshot path and the three `nbd/viperblock.go` callers keep the full drain.

The checkpoint moves out of `drainMu` entirely, not merely off the guest call path. Leaving it there would only relocate the stall: a guest write would still queue on `drainMu` behind a background drain holding it across the checkpoint. `drainMu`'s own doc comment scopes it to WAL rotation and `createChunkFile` ordering, neither of which the checkpoint touches.

## Why it is safe

Blocks stay durable throughout a chunk-only drain. Their bytes are in a backend chunk and the WAL generation naming them is still on disk, because reclaim is gated on the checkpoint that has not run yet — `RecoverLocalWALs` replays exactly those generations.

Two ordering details the concurrency depends on:

- **`dirty` is cleared before the map snapshot, not after the write.** A chunk upload can now install mappings while the checkpoint write is in flight. Clearing afterwards would mark those persisted when they are not, and reclaim keys off that flag, so the WAL naming them would be deleted. Clearing first can only cost a redundant checkpoint on the next drain. Restored on failure.
- **Reclaim candidates are taken before the checkpoint reads the map.** A generation consolidated mid-checkpoint is held for the next one rather than released by a checkpoint that never named it. On failure they go back on the list, ahead of anything consolidated since.

## Instrumentation

The gaps that let a wrong root cause survive three runs:

- `viperblock.wal.operation` gains a `checkpoint` phase.
- `viperblock.write.backpressure.pending_bytes` and `.high_watermark_bytes` gauges, so the two levels the gate compares are read rather than inferred from a wait count.

## Tests

`checkpoint_off_guest_path_test.go`: a chunk drain uploads chunks but writes no checkpoint; it zeroes `pendingBytes`; it holds its WAL generation and the next full drain releases it; the full drain still checkpoints; blocks read back byte-identical after a chunk-only drain.

Three existing stall tests drove their failure injection through the checkpoint write, which the guest path no longer performs — so they hung or passed vacuously. They now drive it through the chunk write, the backend write that path does perform, with every assertion unchanged. `TestAwaitBackpressureFailureCounterResetsAfterInterleavedSuccess` also needed its driver to buffer a real block per tick, because a chunk write only happens when a drain has something to consolidate.

Full suite green, race detector clean on the drain/checkpoint/backpressure set, `make preflight` passes.

## Verification

Cell-25 on spinifex `feat/checkpoint-off-guest-path`, run `34094219863`. The merge gate is etcd's p99 fsync under 10 ms.

Plan: `docs/development/bugs/viperblock-wal-reclaim-and-checkpoint-pacing.md`
Analysis: `docs/development/bugs/eks-etcd-commit-latency-through-viperblock.md`
Bead: `mulga-c7v0o`
