### PR TITLE
feat: allow viperblock WAL to live on a separate base directory

### DIFF
--- a/nbd/viperblock.go
+++ b/nbd/viperblock.go
@@ -91,6 +91,11 @@ var access_key string
 var secret_key string
 var host string
 var base_dir string
+
+// wal_base_dir mirrors viperblock.VB.WALBaseDir. Optional: empty routes the
+// WAL back onto base_dir, the same as before this parameter existed.
+var wal_base_dir string
+
 var cache_size int = viperblock.DefaultCacheBlocks
 var max_pending_bytes uint64 = 0
 var upload_workers int = 16
@@ -168,6 +173,9 @@ func (p *ViperBlockPlugin) Config(key string, value string) error {
 		return nil
 	} else if key == "base_dir" {
 		base_dir = value
+		return nil
+	} else if key == "wal_base_dir" {
+		wal_base_dir = value
 		return nil
 	} else if key == "cache_size" {
 		var err error
@@ -317,6 +325,7 @@ func (p *ViperBlockPlugin) Open(readonly bool) (nbdkit.ConnectionInterface, erro
 		VolumeName: volume,
 		VolumeSize: size,
 		BaseDir:    base_dir,
+		WALBaseDir: wal_base_dir,
 		// Data-path engine. Recorded on the volume-open metric so a volume
 		// simultaneously held by a control-plane import is visible.
 		Role: "nbdkit",

--- a/nbd/viperblock_test.go
+++ b/nbd/viperblock_test.go
@@ -23,8 +23,34 @@ func resetPluginConfigState() {
 	secret_key = ""
 	host = ""
 	base_dir = ""
+	wal_base_dir = ""
 	encryption_key_file = ""
 	loadedMasterKey = nil
+}
+
+// TestConfig_WalBaseDirRoundTrips pins that the "wal_base_dir" nbdkit param
+// sets the package var Open() reads into viperblock.VB.WALBaseDir, and that
+// leaving it unset does not trip ConfigComplete's required-param checks.
+func TestConfig_WalBaseDirRoundTrips(t *testing.T) {
+	resetPluginConfigState()
+	defer resetPluginConfigState()
+
+	p := &ViperBlockPlugin{}
+	err := p.Config("wal_base_dir", "/mnt/wal-device")
+	assert.NoError(t, err)
+	assert.Equal(t, "/mnt/wal-device", wal_base_dir)
+
+	size = 1
+	volume = "vol-1"
+	bucket = "bucket-1"
+	region = "region-1"
+	access_key = "argv-access-key"
+	secret_key = "argv-secret-key"
+	base_dir = "/data"
+	host = "localhost:9000"
+
+	err = p.ConfigComplete()
+	assert.NoError(t, err, "wal_base_dir must stay optional")
 }
 
 // TestCredentialFromArgOrEnv_ArgvTakesPriority pins that a non-empty argv

--- a/telemetry/guest_io_latency_test.go
+++ b/telemetry/guest_io_latency_test.go
@@ -1,0 +1,79 @@
+package telemetry
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+// TestGuestIOLatencyHistogramCapturesTheTail is the whole reason the histogram
+// exists alongside the sum: two fast flushes and one slow one have a mean well
+// under the 10 ms an etcd-class guest is specified against, while the sample
+// that misses it stays visible in the distribution.
+func TestGuestIOLatencyHistogramCapturesTheTail(t *testing.T) {
+	reader := withManualReader(t)
+
+	ctx := context.Background()
+	RecordGuestIO(ctx, "flush", "vol-1", "success", 0, 2*time.Millisecond)
+	RecordGuestIO(ctx, "flush", "vol-1", "success", 0, 3*time.Millisecond)
+	RecordGuestIO(ctx, "flush", "vol-1", "success", 0, 400*time.Millisecond)
+
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(ctx, &rm); err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	metrics := collectMetrics(t, rm)
+
+	h, ok := metrics["viperblock.guest.io.latency"].(metricdata.Histogram[float64])
+	if !ok {
+		t.Fatalf("viperblock.guest.io.latency = %#v, want a float64 histogram", metrics["viperblock.guest.io.latency"])
+	}
+	if len(h.DataPoints) != 1 {
+		t.Fatalf("got %d data points, want 1", len(h.DataPoints))
+	}
+	dp := h.DataPoints[0]
+
+	if dp.Count != 3 {
+		t.Errorf("count = %d, want 3", dp.Count)
+	}
+	if got, set := dp.Max.Value(); !set || got < 0.4 {
+		t.Errorf("max = %v (set=%v), want the 400ms sample", got, set)
+	}
+	if mean := dp.Sum / float64(dp.Count); mean >= 0.4 {
+		t.Fatalf("mean = %v, expected it to sit well under the slow sample", mean)
+	}
+
+	wantAttr(t, dp.Attributes, "op", "flush")
+	wantAttr(t, dp.Attributes, "volume.name", "vol-1")
+}
+
+// TestGuestIOLatencyAccompaniesItsSum pins that the histogram is additive
+// rather than a replacement: ES|QL reads the sum for means and cannot read a
+// histogram field at all.
+func TestGuestIOLatencyAccompaniesItsSum(t *testing.T) {
+	reader := withManualReader(t)
+
+	ctx := context.Background()
+	RecordGuestIO(ctx, "flush", "vol-1", "success", 0, 5*time.Millisecond)
+
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(ctx, &rm); err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	metrics := collectMetrics(t, rm)
+
+	if _, ok := metrics["viperblock.guest.io.latency"].(metricdata.Histogram[float64]); !ok {
+		t.Errorf("histogram missing: %#v", metrics["viperblock.guest.io.latency"])
+	}
+	if _, ok := metrics["viperblock.guest.io.duration.sum"].(metricdata.Sum[float64]); !ok {
+		t.Errorf("sum counter must be kept alongside the histogram: %#v", metrics["viperblock.guest.io.duration.sum"])
+	}
+
+	// "duration" must stay an object with "duration.sum" beneath it. A
+	// histogram of that name would collide on the Elasticsearch mapping.
+	if _, exists := metrics["viperblock.guest.io.duration"]; exists {
+		t.Error("viperblock.guest.io.duration collides with duration.sum; the histogram is named .latency")
+	}
+}

--- a/telemetry/metrics.go
+++ b/telemetry/metrics.go
@@ -32,6 +32,7 @@ var (
 	guestIOOps         metric.Int64Counter
 	guestIOBytes       metric.Int64Counter
 	guestIODurationSum metric.Float64Counter
+	guestIOLatency     metric.Float64Histogram
 
 	cacheLookups metric.Int64Counter
 
@@ -113,6 +114,15 @@ func instruments() {
 		}
 		guestIODurationSum, err = m.Float64Counter("viperblock.guest.io.duration.sum",
 			metric.WithDescription("Cumulative seconds the guest spent waiting on NBD requests. Divided by ops this is the latency the guest observes, which for a flush is what a datastore's commit latency is made of."),
+			metric.WithUnit("s"))
+		if err != nil {
+			otel.Handle(err)
+		}
+		// A sum yields a mean and nothing else, and a datastore specifies its
+		// disk as a p99. Named ".latency" because "duration" is already an
+		// object in Elasticsearch, with "duration.sum" a leaf under it.
+		guestIOLatency, err = m.Float64Histogram("viperblock.guest.io.latency",
+			metric.WithDescription("Distribution of the wall time the guest waited on each NBD request. The flush percentiles are what an etcd-class guest is specified against."),
 			metric.WithUnit("s"))
 		if err != nil {
 			otel.Handle(err)
@@ -341,6 +351,9 @@ func RecordGuestIO(ctx context.Context, op, volume, outcome string, bytesTransfe
 	}
 	if guestIODurationSum != nil {
 		guestIODurationSum.Add(ctx, elapsed.Seconds(), opt)
+	}
+	if guestIOLatency != nil {
+		guestIOLatency.Record(ctx, elapsed.Seconds(), opt)
 	}
 }
 

--- a/viperblock/viperblock.go
+++ b/viperblock/viperblock.go
@@ -358,6 +358,11 @@ type VB struct {
 
 	BaseDir string
 
+	// WALBaseDir, when set, is where WAL, BlockToObjectWAL, and ShardedWAL
+	// files live instead of BaseDir. A node-local deployment choice (e.g. a
+	// separate fsync-friendly device), never persisted to config.json.
+	WALBaseDir string
+
 	VolumeConfig VolumeConfig
 
 	// Logger, if set, is used for this instance's log lines instead of
@@ -1266,6 +1271,13 @@ func newVB(config *VB, btype string, backendConfig any) (vb *VB, err error) {
 		config.BaseDir = "/tmp/viperblock"
 	}
 
+	// walBaseDir defaults to BaseDir so an unset WALBaseDir is a no-op: WAL,
+	// BlockToObjectWAL, and ShardedWAL land under BaseDir exactly as before.
+	walBaseDir := config.BaseDir
+	if config.WALBaseDir != "" {
+		walBaseDir = config.WALBaseDir
+	}
+
 	if config.FlushInterval == 0 {
 		config.FlushInterval = DefaultFlushInterval
 	}
@@ -1345,8 +1357,8 @@ func newVB(config *VB, btype string, backendConfig any) (vb *VB, err error) {
 		GCEnabled:           config.GCEnabled,
 		GCInterval:          config.GCInterval,
 		Writes:              Blocks{},
-		WAL:                 WAL{BaseDir: config.BaseDir, WALMagic: walMagic},
-		BlockToObjectWAL:    WAL{BaseDir: config.BaseDir, WALMagic: blockToObjectWALMagic},
+		WAL:                 WAL{BaseDir: walBaseDir, WALMagic: walMagic},
+		BlockToObjectWAL:    WAL{BaseDir: walBaseDir, WALMagic: blockToObjectWALMagic},
 		Cache: Cache{
 			lru: lruCache,
 			Config: CacheConfig{
@@ -1370,7 +1382,7 @@ func newVB(config *VB, btype string, backendConfig any) (vb *VB, err error) {
 		Role: config.Role,
 
 		UseShardedWAL: false,
-		ShardedWAL:    NewShardedWAL(config.BaseDir, [4]byte{'V', 'B', 'W', 'L'}),
+		ShardedWAL:    NewShardedWAL(walBaseDir, [4]byte{'V', 'B', 'W', 'L'}),
 
 		chunkUploadTrigger: make(chan struct{}, 1),
 
@@ -1412,6 +1424,15 @@ func newVB(config *VB, btype string, backendConfig any) (vb *VB, err error) {
 	// Create the checkpoint directory if it doesn't exist
 	if err := os.MkdirAll(filepath.Join(vb.BaseDir, vb.GetVolume(), "checkpoints"), 0750); err != nil {
 		return nil, fmt.Errorf("failed to create checkpoint directory: %w", err)
+	}
+
+	// When WALBaseDir puts the WAL on a separate device, its volume
+	// directory needs to exist before any WAL open, not just the ones that
+	// already MkdirAll their own target file.
+	if walBaseDir != vb.BaseDir {
+		if err := os.MkdirAll(filepath.Join(walBaseDir, vb.GetVolume()), 0750); err != nil {
+			return nil, fmt.Errorf("failed to create WAL base directory: %w", err)
+		}
 	}
 
 	vb.readAhead.nextBlock = noStreamPosition
@@ -4846,7 +4867,7 @@ func (vb *VB) RecoverLocalWALs() (err error) {
 		telemetry.RecordWALOp(context.Background(), "replay", vb.VolumeName, outcome, time.Since(start))
 	}()
 
-	walDir := filepath.Join(vb.BaseDir, vb.GetVolume(), "wal", "chunks")
+	walDir := filepath.Join(vb.WAL.BaseDir, vb.GetVolume(), "wal", "chunks")
 
 	entries, err := os.ReadDir(walDir)
 	if err != nil {
@@ -5709,7 +5730,7 @@ func (vb *VB) LoadStateCtx(ctx context.Context) error {
 	if state.ShardedWAL {
 		vb.UseShardedWAL = true
 		if vb.ShardedWAL == nil {
-			vb.ShardedWAL = NewShardedWAL(vb.BaseDir, vb.WAL.WALMagic)
+			vb.ShardedWAL = NewShardedWAL(vb.WAL.BaseDir, vb.WAL.WALMagic)
 		}
 		vb.ShardedWAL.WallNum.Store(state.WALNum)
 	}
@@ -6370,6 +6391,16 @@ func (vb *VB) RemoveLocalFiles() (err error) {
 	vb.WAL.mu.Lock()
 	err = os.RemoveAll(localPath)
 	vb.WAL.mu.Unlock()
+
+	// WAL, BlockToObjectWAL, and ShardedWAL all resolve to the same base dir
+	// (see New), which may live on a device separate from BaseDir. Its
+	// volume tree is otherwise never cleaned up.
+	if vb.WAL.BaseDir != "" && vb.WAL.BaseDir != vb.BaseDir {
+		walPath := filepath.Join(vb.WAL.BaseDir, vb.GetVolume())
+		if rmErr := os.RemoveAll(walPath); rmErr != nil && err == nil {
+			err = rmErr
+		}
+	}
 
 	return err
 }

--- a/viperblock/wal_base_dir_test.go
+++ b/viperblock/wal_base_dir_test.go
@@ -1,0 +1,226 @@
+package viperblock
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/mulgadc/viperblock/types"
+	"github.com/mulgadc/viperblock/viperblock/backends/file"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newWALBaseDirTestVB builds a file-backend VB the same way newEnospcTestVB
+// does, except BaseDir and the WAL base dir are two distinct roots under the
+// test's tmpDir when separateWALDir is true. When false, WALBaseDir is left
+// unset so the WAL/BlockToObjectWAL/ShardedWAL fall back to BaseDir exactly
+// as before this field existed.
+func newWALBaseDirTestVB(t *testing.T, sharded bool, separateWALDir bool) (vb *VB, baseDir, walBaseDir string) {
+	t.Helper()
+
+	tmpDir := t.TempDir()
+	testVol := fmt.Sprintf("test_wal_base_dir_%d", time.Now().UnixNano())
+
+	baseDir = filepath.Join(tmpDir, "viperblock")
+	walBaseDir = baseDir
+	if separateWALDir {
+		walBaseDir = filepath.Join(tmpDir, "wal-device")
+	}
+
+	backendConfig := file.FileConfig{
+		VolumeName: testVol,
+		VolumeSize: 64 * 1024 * 1024,
+		BaseDir:    tmpDir,
+	}
+
+	vbconfig := VB{
+		VolumeName: testVol,
+		VolumeSize: 64 * 1024 * 1024,
+		BaseDir:    baseDir,
+		// Deterministic: no background WAL fsync or ticker-driven chunk
+		// upload racing the test; drains are driven explicitly.
+		WALSyncInterval:     -1,
+		ChunkUploadInterval: -1,
+		Cache: Cache{
+			Config: CacheConfig{Size: 0},
+		},
+	}
+	if separateWALDir {
+		vbconfig.WALBaseDir = walBaseDir
+	}
+
+	var err error
+	vb, err = New(&vbconfig, FileBackend, backendConfig)
+	require.NoError(t, err)
+	require.NotNil(t, vb)
+
+	t.Cleanup(func() {
+		assert.NoError(t, vb.RemoveLocalFiles())
+	})
+
+	vb.UseShardedWAL = sharded
+	if !sharded {
+		vb.ShardedWAL = nil
+	}
+
+	require.NoError(t, vb.Backend.Init())
+
+	if sharded {
+		require.NoError(t, vb.OpenShardedWAL())
+	} else {
+		require.NoError(t, vb.OpenWAL(&vb.WAL, fmt.Sprintf("%s/%s", vb.WAL.BaseDir, types.GetFilePath(types.FileTypeWALChunk, vb.WAL.WallNum.Load(), vb.GetVolume()))))
+	}
+	require.NoError(t, vb.OpenWAL(&vb.BlockToObjectWAL, fmt.Sprintf("%s/%s", vb.BlockToObjectWAL.BaseDir, types.GetFilePath(types.FileTypeWALBlock, vb.BlockToObjectWAL.WallNum.Load(), vb.GetVolume()))))
+
+	return vb, baseDir, walBaseDir
+}
+
+// walTreeExists reports whether <root>/<volume>/wal exists and, if it does,
+// contains at least one regular file somewhere underneath it.
+func walTreeExists(t *testing.T, root, volume string) bool {
+	t.Helper()
+
+	walDir := filepath.Join(root, volume, "wal")
+	info, err := os.Stat(walDir)
+	if os.IsNotExist(err) {
+		return false
+	}
+	require.NoError(t, err)
+	require.True(t, info.IsDir(), "%s exists but is not a directory", walDir)
+
+	found := false
+	err = filepath.WalkDir(walDir, func(path string, d os.DirEntry, err error) error {
+		require.NoError(t, err)
+		if !d.IsDir() {
+			found = true
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	return found
+}
+
+// TestWALBaseDirSeparatesWALFilesFromBaseDir pins the actual point of
+// WALBaseDir: once set, every WAL-shaped file (legacy WAL segments, sharded
+// WAL shard files, and the block-to-object WAL) lands only under WALBaseDir,
+// never under BaseDir, and data written before a forced rotation and
+// consolidation is still readable afterward.
+func TestWALBaseDirSeparatesWALFilesFromBaseDir(t *testing.T) {
+	for _, sharded := range []bool{false, true} {
+		t.Run(fmt.Sprintf("sharded=%v", sharded), func(t *testing.T) {
+			vb, baseDir, walBaseDir := newWALBaseDirTestVB(t, sharded, true)
+
+			require.NotEqual(t, baseDir, walBaseDir)
+			require.Equal(t, walBaseDir, vb.WAL.BaseDir)
+			require.Equal(t, walBaseDir, vb.BlockToObjectWAL.BaseDir)
+			if sharded {
+				require.Equal(t, walBaseDir, vb.ShardedWAL.BaseDir)
+			}
+
+			blockSize := uint64(vb.BlockSize)
+			data := make([]byte, blockSize)
+			copy(data, []byte("wal-base-dir-test"))
+			require.NoError(t, vb.WriteAt(0, data))
+
+			// Force a rotation and consolidation of the current WAL
+			// generation into a chunk upload, exactly what a real
+			// checkpoint/drain cycle does.
+			require.NoError(t, vb.DrainToBackendCtx(context.Background()))
+
+			got, err := vb.ReadAt(0, blockSize)
+			require.NoError(t, err)
+			assert.Equal(t, data, got, "data must survive a forced WAL rotation and consolidation")
+
+			assert.False(t, walTreeExists(t, baseDir, vb.GetVolume()),
+				"no WAL-shaped file must appear under BaseDir when WALBaseDir is set")
+			assert.True(t, walTreeExists(t, walBaseDir, vb.GetVolume()),
+				"WAL files must appear under WALBaseDir")
+
+			// RemoveLocalFiles must clean up both trees, not just BaseDir's.
+			require.NoError(t, vb.RemoveLocalFiles())
+			_, err = os.Stat(filepath.Join(baseDir, vb.GetVolume()))
+			assert.True(t, os.IsNotExist(err), "BaseDir volume tree must be removed")
+			_, err = os.Stat(filepath.Join(walBaseDir, vb.GetVolume()))
+			assert.True(t, os.IsNotExist(err), "WALBaseDir volume tree must be removed")
+		})
+	}
+}
+
+// TestWALBaseDirEmptyIsNoOp pins that an unset WALBaseDir behaves exactly as
+// it did before the field existed: WAL, BlockToObjectWAL, and ShardedWAL all
+// resolve to BaseDir, and WAL files land under BaseDir as before.
+func TestWALBaseDirEmptyIsNoOp(t *testing.T) {
+	for _, sharded := range []bool{false, true} {
+		t.Run(fmt.Sprintf("sharded=%v", sharded), func(t *testing.T) {
+			vb, baseDir, walBaseDir := newWALBaseDirTestVB(t, sharded, false)
+
+			require.Equal(t, baseDir, walBaseDir)
+			assert.Equal(t, baseDir, vb.WAL.BaseDir)
+			assert.Equal(t, baseDir, vb.BlockToObjectWAL.BaseDir)
+			if sharded {
+				assert.Equal(t, baseDir, vb.ShardedWAL.BaseDir)
+			}
+
+			blockSize := uint64(vb.BlockSize)
+			data := make([]byte, blockSize)
+			copy(data, []byte("wal-base-dir-empty-test"))
+			require.NoError(t, vb.WriteAt(0, data))
+			require.NoError(t, vb.DrainToBackendCtx(context.Background()))
+
+			got, err := vb.ReadAt(0, blockSize)
+			require.NoError(t, err)
+			assert.Equal(t, data, got)
+
+			assert.True(t, walTreeExists(t, baseDir, vb.GetVolume()),
+				"WAL files must land under BaseDir when WALBaseDir is unset, same as before")
+		})
+	}
+}
+
+// TestWALBaseDirCrashRecovery pins that RecoverLocalWALs looks for orphaned
+// WAL files under WALBaseDir, not BaseDir, when the two differ. Before this
+// fix, RecoverLocalWALs scanned vb.BaseDir directly: with a separate
+// WALBaseDir it would find no wal/chunks directory there, silently treat
+// crash recovery as a no-op, and lose every block still sitting only in the
+// WAL.
+func TestWALBaseDirCrashRecovery(t *testing.T) {
+	vb, baseDir, walBaseDir := newWALBaseDirTestVB(t, false, true)
+	require.NotEqual(t, baseDir, walBaseDir)
+
+	blockSize := uint64(vb.BlockSize)
+	testData := make([][]byte, 3)
+	for i := range 3 {
+		testData[i] = make([]byte, blockSize)
+		msg := fmt.Sprintf("recover_block_%d", i)
+		copy(testData[i], []byte(msg))
+		require.NoError(t, vb.WriteAt(uint64(i)*blockSize, testData[i]))
+	}
+	require.NoError(t, vb.Flush())
+
+	// Blocks are now only in the WAL file under walBaseDir, not chunked to
+	// the backend. Simulate a crash: reset in-memory state without going
+	// through WriteWALToChunk/Close.
+	vb.BlocksToObject.mu.Lock()
+	vb.BlocksToObject.lookup.clear()
+	vb.BlocksToObject.mu.Unlock()
+
+	vb.PendingBackendWrites.mu.Lock()
+	vb.PendingBackendWrites.Blocks = nil
+	vb.PendingBackendWrites.mu.Unlock()
+
+	if vb.UseBlockStore && vb.BlockStore != nil {
+		vb.BlockStore = NewUnifiedBlockStore(vb.BlockSize)
+	}
+
+	require.NoError(t, vb.RecoverLocalWALs())
+
+	for i := range 3 {
+		data, err := vb.ReadAt(uint64(i)*blockSize, blockSize)
+		require.NoError(t, err, "block %d should be recovered from the WAL under WALBaseDir", i)
+		assert.Equal(t, testData[i], data, "block %d data mismatch after recovery", i)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `VB.WALBaseDir`: when set, `WAL`, `BlockToObjectWAL`, and `ShardedWAL` resolve their files under it instead of `VB.BaseDir`, so the fsync-heavy WAL can live on its own device separate from the block cache, checkpoints, and predastore. An empty `WALBaseDir` is a no-op — behavior is byte-for-byte identical to before this field existed.
- Fixes `RecoverLocalWALs`, which read `vb.BaseDir` directly instead of `vb.WAL.BaseDir`: with a separate WAL device, crash recovery would silently scan the wrong directory, find nothing, and lose blocks that only ever made it to the WAL.
- Fixes `RemoveLocalFiles`, which only removed `vb.BaseDir`'s volume tree: with a separate WAL device, `Close` would leave the WAL device's volume directory behind forever.
- Fixes a defensive `LoadStateCtx` path that lazily reconstructs `ShardedWAL` using `vb.BaseDir` instead of `vb.WAL.BaseDir` (normally dead code since `New` always sets `ShardedWAL` non-nil, but inconsistent with how `nbd/viperblock.go` does the same reconstruction).
- Adds a `wal_base_dir` nbdkit plugin parameter, wired through to `WALBaseDir` on the `viperblock.VB` the plugin opens. The plugin backs every mounted volume, so without this the guest write path — the one that actually needs the separate device — would still write its WAL beside everything else.
- Adds `viperblock.guest.io.latency`, a histogram of NBD request wall time. The existing `guestIODurationSum` only yields a mean; validating the WAL-device fix needs a p99 (a datastore's disk is specified against p99, not mean).

## Test plan
- [x] `GOWORK=off go build ./...`
- [x] `GOWORK=off go test ./...` (full repo, including new `wal_base_dir_test.go` and the nbdkit plugin's `TestConfig_WalBaseDirRoundTrips`)
- [x] `make preflight` (lint + govulncheck + coverage) passes
- [x] Manually reverted the `RecoverLocalWALs` fix and confirmed `TestWALBaseDirCrashRecovery` fails, then restored it, to prove the new test actually catches the regression
