### PR TITLE
fix: do not report a WAL flush durable while the fsync covering it is in flight

### DIFF
--- a/viperblock/viperblock.go
+++ b/viperblock/viperblock.go
@@ -939,6 +939,11 @@ type WAL struct {
 	// Uses atomic for lock-free access from write path and sync goroutine
 	dirty atomic.Bool
 
+	// syncMu serialises the fsync. A caller arriving while one is in flight
+	// must wait for it rather than read the cleared dirty flag and conclude
+	// its own record is already durable.
+	syncMu sync.Mutex
+
 	mu sync.RWMutex
 }
 
@@ -946,8 +951,11 @@ type WAL struct {
 // Each shard has its own file and mutex, so writes to different shards
 // have zero lock contention.
 type WALShard struct {
-	DB      *os.File
-	dirty   atomic.Bool
+	DB    *os.File
+	dirty atomic.Bool
+
+	// syncMu serialises this shard's fsync, for the same reason as WAL.syncMu.
+	syncMu  sync.Mutex
 	mu      sync.RWMutex
 	shardID int
 }
@@ -1759,12 +1767,18 @@ func (vb *VB) syncWALIfDirty() {
 // Note: Only the last file in vb.WAL.DB is the active WAL being written to.
 // Previous files are closed after WriteWALToChunk processes them.
 func (vb *VB) syncWAL() error {
-	// Fast path: check dirty flag without lock
+	// Held across the check and the fsync. Without it a caller that appended
+	// before this fsync began would see the cleared flag mid-flight and report
+	// its write durable while the only fsync covering it was still running.
+	vb.WAL.syncMu.Lock()
+	defer vb.WAL.syncMu.Unlock()
+
 	if !vb.WAL.dirty.Load() {
 		return nil
 	}
 
-	// Clear dirty flag before sync (writes during sync will re-set it)
+	// Cleared before the fsync so a write arriving during it re-marks the WAL
+	// and the next caller syncs again rather than trusting this one.
 	vb.WAL.dirty.Store(false)
 
 	vb.WAL.mu.RLock()
@@ -1781,6 +1795,34 @@ func (vb *VB) syncWAL() error {
 				return fmt.Errorf("WAL sync: %w", err)
 			}
 		}
+	}
+	return nil
+}
+
+// sync fsyncs this shard if it has unflushed writes, serialised so a caller
+// arriving mid-fsync waits for it instead of reading the cleared dirty flag
+// and reporting its own record durable.
+func (s *WALShard) sync() error {
+	s.syncMu.Lock()
+	defer s.syncMu.Unlock()
+
+	if !s.dirty.Load() {
+		return nil
+	}
+
+	// Cleared before the fsync so a write arriving during it re-marks the
+	// shard and the next caller syncs again rather than trusting this one.
+	s.dirty.Store(false)
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.DB == nil {
+		return nil
+	}
+	if err := s.DB.Sync(); err != nil {
+		s.dirty.Store(true)
+		return err
 	}
 	return nil
 }
@@ -1806,23 +1848,9 @@ func (vb *VB) syncShardedWAL() error {
 	for i := range NumShards {
 		shard := sw.Shards[i]
 
-		// Fast path: skip clean shards
-		if !shard.dirty.Load() {
-			continue
+		if err := shard.sync(); err != nil && firstErr == nil {
+			firstErr = fmt.Errorf("sharded WAL sync, shard %d: %w", i, err)
 		}
-
-		shard.dirty.Store(false)
-
-		shard.mu.RLock()
-		if shard.DB != nil {
-			if err := shard.DB.Sync(); err != nil {
-				shard.dirty.Store(true)
-				if firstErr == nil {
-					firstErr = fmt.Errorf("sharded WAL sync, shard %d: %w", i, err)
-				}
-			}
-		}
-		shard.mu.RUnlock()
 	}
 	return firstErr
 }

--- a/viperblock/wal_sync_lost_write_test.go
+++ b/viperblock/wal_sync_lost_write_test.go
@@ -1,0 +1,104 @@
+package viperblock
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSyncWALDoesNotReportDurableDuringAnInFlightFsync pins the lost-write
+// window. The dirty flag is cleared before the fsync, so a caller whose record
+// was appended beforehand could read the cleared flag mid-flight and return --
+// reporting the guest's write durable while the only fsync covering it was
+// still running.
+func TestSyncWALDoesNotReportDurableDuringAnInFlightFsync(t *testing.T) {
+	vb, _ := newEnospcTestVB(t)
+
+	// Both callers' records are in the WAL before either sync starts, so one
+	// fsync covers both and the second is entitled to return once it ends --
+	// but not before.
+	require.NoError(t, vb.WriteAt(0, make([]byte, vb.BlockSize)))
+	require.NoError(t, vb.flushWrites())
+	require.True(t, vb.WAL.dirty.Load(), "the append must mark the WAL dirty")
+
+	leaderOut := make(chan struct{})
+	go func() {
+		assert.NoError(t, vb.syncWAL())
+		close(leaderOut)
+	}()
+
+	// Start the follower only once the leader has cleared the flag, which is
+	// the exact window under test. Bounded so a leader that never runs fails
+	// as a timeout rather than hanging.
+	deadline := time.Now().Add(2 * time.Second)
+	for vb.WAL.dirty.Load() {
+		if time.Now().After(deadline) {
+			t.Fatal("leader never entered its fsync")
+		}
+	}
+
+	followerOut := make(chan struct{})
+	go func() {
+		assert.NoError(t, vb.syncWAL())
+		close(followerOut)
+	}()
+
+	select {
+	case <-followerOut:
+		select {
+		case <-leaderOut:
+			// Leader finished first, so the follower's return is covered.
+		default:
+			t.Fatal("syncWAL returned while the fsync covering its record was still in flight")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("syncWAL deadlocked")
+	}
+
+	<-leaderOut
+	assert.False(t, vb.WAL.dirty.Load(), "a completed sync must leave the WAL clean")
+}
+
+// TestSyncWALResyncsForAWriteThatArrivedDuringAnFsync pins the other half. The
+// flag is cleared before the fsync, so a write landing during it re-marks the
+// WAL and the next caller must sync again rather than trust the one that was
+// already running.
+func TestSyncWALResyncsForAWriteThatArrivedDuringAnFsync(t *testing.T) {
+	vb, _ := newEnospcTestVB(t)
+
+	require.NoError(t, vb.WriteAt(0, make([]byte, vb.BlockSize)))
+	require.NoError(t, vb.flushWrites())
+	require.NoError(t, vb.syncWAL())
+	require.False(t, vb.WAL.dirty.Load())
+
+	// A record appended after that sync must not be considered covered by it.
+	require.NoError(t, vb.WriteAt(uint64(vb.BlockSize), make([]byte, vb.BlockSize)))
+	require.NoError(t, vb.flushWrites())
+	assert.True(t, vb.WAL.dirty.Load(), "a write after a sync must leave the WAL dirty")
+
+	require.NoError(t, vb.syncWAL())
+	assert.False(t, vb.WAL.dirty.Load())
+}
+
+// TestShardedWALSyncIsSafeUnderConcurrentCallers pins the same protocol on the
+// sharded path, which carries one dirty flag per shard and had the identical
+// defect.
+func TestShardedWALSyncIsSafeUnderConcurrentCallers(t *testing.T) {
+	vb := newShardedFlushTestVB(t)
+
+	require.NoError(t, vb.WriteAt(0, make([]byte, vb.BlockSize)))
+	require.NoError(t, vb.flushWrites())
+
+	var wg sync.WaitGroup
+	for range 8 {
+		wg.Go(func() { assert.NoError(t, vb.syncShardedWAL()) })
+	}
+	wg.Wait()
+
+	for i := range NumShards {
+		assert.False(t, vb.ShardedWAL.Shards[i].dirty.Load(), "shard %d must be clean after sync", i)
+	}
+}


### PR DESCRIPTION
`syncWAL` cleared the dirty flag before calling `Sync()`:

```
A: WriteWAL   -> dirty = true
B: WriteWAL   -> dirty = true, B's record is now in the page cache
A: syncWAL    -> dirty = false, Sync() begins and will cover B
B: syncWAL    -> reads dirty == false, returns nil immediately
```

B reports the guest's write durable while the only fsync covering it is still in flight. Lose power in that window and the write is gone after an acknowledged flush.

The fix serialises the fsync so B waits for it. The flag is still cleared before the sync rather than after, so a write that lands during one re-marks the WAL and the next caller syncs again instead of trusting the one that was already running. Clearing it afterwards would have swapped this bug for the mirror-image one.

The sharded WAL carried the same defect on each shard's own flag and is fixed alongside it.

`TestSyncWALDoesNotReportDurableDuringAnInFlightFsync` fails on `dev` with "syncWAL returned while the fsync covering its record was still in flight" and passes here. Tests run clean under `-race -count=3`.

Found while investigating the etcd fsync p99. It is not that fix and does not affect that latency.